### PR TITLE
FIX - unexpected user mapasculturais

### DIFF
--- a/src/protected/db-updates.php
+++ b/src/protected/db-updates.php
@@ -94,7 +94,6 @@ return [
                                 NO MAXVALUE
                                 CACHE 1;");
 
-        $conn->executeQuery("ALTER TABLE user_meta_id_seq OWNER TO mapasculturais;");
         $conn->executeQuery("ALTER SEQUENCE user_meta_id_seq OWNED BY user_meta.id;");
         $conn->executeQuery("ALTER TABLE ONLY user_meta ALTER COLUMN id SET DEFAULT nextval('user_meta_id_seq'::regclass);");
         $conn->executeQuery("ALTER TABLE ONLY user_meta ADD CONSTRAINT user_meta_pk PRIMARY KEY (id);");


### PR DESCRIPTION
Removendo trecho que alterava para um owner não existente, na tabela user_meta_id_seq. Esse trecho acabava quebrando a iniciação de scripts de criação do banco no ambiente vagrant.