### PR TITLE
Update install_vagrant.sh

### DIFF
--- a/scripts/install_vagrant.sh
+++ b/scripts/install_vagrant.sh
@@ -19,10 +19,10 @@ curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
 sudo apt-get install -y nodejs ruby
 
 # postgresql e postgis
-sudo apt-get install -y postgresql postgresql-contrib postgis postgresql-9.3-postgis-2.1 postgresql-9.3-postgis-2.1-scripts
+sudo apt-get install -y postgresql postgresql-contrib postgis postgresql-9.4-postgis-2.1 postgresql-9.4-postgis-2.1-scripts
 
 # php, php-fpm e extensoes do php utiliazdas no sistema
-sudo apt-get install -y php5 php5-gd php5-cli php5-json php5-curl php5-pgsql php-apc php5-fpm imagemagick libmagickcore-dev libmagickwand-dev php-imagick
+sudo apt-get install -y php5 php5-gd php5-cli php5-json php5-curl php5-pgsql php-apc php5-fpm imagemagick libmagickcore-dev libmagickwand-dev php5-imagick
 
 sudo update-alternatives --install /usr/bin/node node /usr/bin/nodejs 10
 


### PR DESCRIPTION
Automatização via vagrant não funcionava devido as versões de postgresql e php-imagick em sistemas baseados em linux debian