### PR TITLE
Correção "array_intersect() Argument not an array"

### DIFF
--- a/src/protected/application/lib/MapasCulturais/Repositories/Event.php
+++ b/src/protected/application/lib/MapasCulturais/Repositories/Event.php
@@ -9,7 +9,7 @@ class Event extends \MapasCulturais\Repository{
     protected function _getCurrentSubsiteSpaceIds($implode = true){
         $app = App::i();
         if($app->getCurrentSubsiteId()){
-            $space_ids = $app->repo('Space')->getCurrentSubsiteSpaceIds(true);
+            $space_ids = $app->repo('Space')->getCurrentSubsiteSpaceIds($implode);
         } else {
             $space_ids = "SELECT id FROM space WHERE status > 0";
         }


### PR DESCRIPTION
Ao consultar detalhes de um evento, retorna o erro "exception 'ErrorException' with message 'array_intersect(): Argument 2 is not an array' in /srv/mapas/mapasculturais/src/protected/application/lib/MapasCulturais/Repositories/Event.php:43"


**Causa:**
Linha 42 chama:  "$space_ids = $this->_getCurrentSubsiteSpaceIds(false);" passando o valor FALSE como argumento,
Linha 12 chama: "$space_ids = $app->repo('Space')->getCurrentSubsiteSpaceIds($implode);" sem informar o argumento recebido.