### PR TITLE
Novas opções no perfil do agente, novos gêneros e orientação sexual e campos obrigatórios nos projetos

### DIFF
--- a/src/protected/application/conf/agent-types.php
+++ b/src/protected/application/conf/agent-types.php
@@ -23,6 +23,47 @@ return array(
 //            )
         ),
 
+        'identidade' => array(
+            'private' => true,
+            'label' => \MapasCulturais\i::__('Identidade (RG)')
+        ),
+
+        'estadoCivil' => array(
+            'private' => true,
+            'label' => \MapasCulturais\i::__('Estado Civil'),
+            'type' => 'select',
+            'options' => array(
+                '' => \MapasCulturais\i::__('Não Informar'),
+                'Solteiro(a)' => \MapasCulturais\i::__('Solteiro(a)'),
+                'Casado(a)' => \MapasCulturais\i::__('Casado(a)'),
+                'Divorciado(a)' => \MapasCulturais\i::__('Divorciado(a)'),
+                'Viúvo(a)' => \MapasCulturais\i::__('Viúvo(a)'),
+                'Separado(a)' => \MapasCulturais\i::__('Separado(a)'),
+                'União Estável' => \MapasCulturais\i::__('União Estável')
+            )
+        ),
+
+        'escolaridade' => array(
+            'private' => true,
+            'label' => \MapasCulturais\i::__('Escolaridade'),
+            'type' => 'select',
+            'options' => array(
+                '' => \MapasCulturais\i::__('Não Informar'),
+                'Ensino Fundamental Completo' => \MapasCulturais\i::__('Ensino Fundamental Completo'),
+                'Ensino Fundamental Incompleto' => \MapasCulturais\i::__('Ensino Fundamental Incompleto'),
+                'Ensino Médio Completo' => \MapasCulturais\i::__('Ensino Médio Completo'),
+                'Ensino Médio Incompleto' => \MapasCulturais\i::__('Ensino Médio Incompleto'),
+                'Ensino Superior Completo' => \MapasCulturais\i::__('Ensino Superior Completo'),
+                'Ensino Superior Incompleto' => \MapasCulturais\i::__('Ensino Superior Incompleto'),
+                'Pós-graduação (Especialização) Completa' => \MapasCulturais\i::__('Pós-graduação (Especialização) Completa'),
+                'Pós-graduação (Especialização) Incompleta' => \MapasCulturais\i::__('Pós-graduação (Especialização) Incompleta'),
+                'Pós-graduação (Mestrado) Completa' => \MapasCulturais\i::__('Pós-graduação (Mestrado) Completo'),
+                'Pós-graduação (Mestrado) Incompleta' => \MapasCulturais\i::__('Pós-graduação (Mestrado) Incompleto'),
+                'Pós-graduação (Doutorado) Completa' => \MapasCulturais\i::__('Pós-graduação (Doutorado) Completo'),
+                'Pós-graduação (Doutorado) Incompleta' => \MapasCulturais\i::__('Pós-graduação (Doutorado) Incompleto')
+            )
+        ),
+
         'idade' => array(
             'private' => true,
             'label' => \MapasCulturais\i::__('Idade'),
@@ -80,13 +121,14 @@ return array(
             'type' => 'select',
             'options' => array(
                 '' => \MapasCulturais\i::__('Não Informar'),
-                'Mulher Transexual' => \MapasCulturais\i::__('Mulher Transexual'),
-                'Mulher' => \MapasCulturais\i::__('Mulher'),
-                'Homem Transexual' => \MapasCulturais\i::__('Homem Transexual'),
                 'Homem' => \MapasCulturais\i::__('Homem'),
+                'Mulher' => \MapasCulturais\i::__('Mulher'),
+                'Mulher Transexual' => \MapasCulturais\i::__('Mulher Transexual'),
+                'Homem Transexual' => \MapasCulturais\i::__('Homem Transexual'),
                 'Não Binário' => \MapasCulturais\i::__('Não Binário'),
+                'Transgênero' => \MapasCulturais\i::__('Transgênero'),
                 'Travesti' => \MapasCulturais\i::__('Travesti'),
-                'Outras' => \MapasCulturais\i::__('Outras')
+                'Outros' => \MapasCulturais\i::__('Outros')
             )
         ),
 
@@ -97,10 +139,13 @@ return array(
             'options' => array(
                 '' => \MapasCulturais\i::__('Não Informar'),
                 'Heterossexual' => \MapasCulturais\i::__('Heterossexual'),
-                'Lésbica' => \MapasCulturais\i::__('Lésbica'),
-                'Gay' => \MapasCulturais\i::__('Gay'),
-                'Bissexual' => \MapasCulturais\i::__('Bissexual'),
                 'Assexual' => \MapasCulturais\i::__('Assexual'),
+                'Intersexual' => \MapasCulturais\i::__('Intersexual'),
+                'Gay' => \MapasCulturais\i::__('Gay'),
+                'Homossexual' => \MapasCulturais\i::__('Homossexual'),
+                'Lésbica' => \MapasCulturais\i::__('Lésbica'),
+                'Transsexual' => \MapasCulturais\i::__('Transexual'),
+                'Pansexual' => \MapasCulturais\i::__('Pansexual'),
                 'Outras' => \MapasCulturais\i::__('Outras')
             )
         ),
@@ -155,7 +200,7 @@ return array(
             'label' => \MapasCulturais\i::__('Endereço'),
             'type' => 'text'
         ),
-                    
+
         'En_CEP' => [
             'label' => \MapasCulturais\i::__('CEP'),
             'private' => function(){

--- a/src/protected/application/conf/conf-base.php
+++ b/src/protected/application/conf/conf-base.php
@@ -188,18 +188,18 @@ return array(
         'required' => true,
         'label' => \MapasCulturais\i::__('Agente responsável pela inscrição'),
         'agentRelationGroupName' => 'owner',
-        'description' => \MapasCulturais\i::__('Agente individual (pessoa física) com os campos CPF, Data de Nascimento/Fundação, Email Privado e Telefone 1 obrigatoriamente preenchidos'),
+        'description' => \MapasCulturais\i::__('Agente individual (pessoa física) com os campos Nome, CPF, RG, Endereço, Data de Nascimento/Fundação, Raça, Gênero, Email Privado e Telefone 1 obrigatoriamente preenchidos'),
         'type' => 1,
-        'requiredProperties' => array('documento', 'raca', 'dataDeNascimento', 'genero', 'emailPrivado', 'telefone1')
+        'requiredProperties' => array('nomeCompleto','documento','identidade','endereco','dataDeNascimento','raca','genero','emailPrivado','telefone1')
     ),
     'registration.agentRelations' => array(
         array(
             'required' => false,
             'label' => \MapasCulturais\i::__('Instituição responsável'),
             'agentRelationGroupName' => 'instituicao',
-            'description' => \MapasCulturais\i::__('Agente coletivo (pessoa jurídica) com os campos CNPJ, Data de Nascimento/Fundação, Email Privado e Telefone 1 obrigatoriamente preenchidos'),
+            'description' => \MapasCulturais\i::__('Agente coletivo (pessoa jurídica) com os campos Nome, Endereço, CNPJ, Data de Nascimento/Fundação, Email Privado e Telefone 1 obrigatoriamente preenchidos'),
             'type' => 2,
-            'requiredProperties' => array('documento', 'dataDeNascimento', 'emailPrivado', 'telefone1')
+            'requiredProperties' => array('nomeCompleto','endereco','documento', 'dataDeNascimento', 'emailPrivado', 'telefone1')
         ),
         array(
             'required' => false,

--- a/src/protected/application/themes/BaseV1/layouts/parts/singles/history_agent.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/singles/history_agent.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 $this->bodyProperties['ng-controller'] = "EntityController";
 
 $entity = $entityRevision;
@@ -26,11 +26,11 @@ $this->includeMapAssets();
 
 <article class="main-content agent">
     <?php $this->applyTemplateHook('main-content','begin'); ?>
-    <header class="main-content-header">    
+    <header class="main-content-header">
         <?php $this->applyTemplateHook('header-image','before'); ?>
 
         <div class="header-image js-imagem-do-header"></div>
-        
+
         <?php $this->applyTemplateHook('header-image','after'); ?>
 
         <?php $this->applyTemplateHook('entity-status','before'); ?>
@@ -111,6 +111,24 @@ $this->includeMapAssets();
 
                     <?php if(isset($entity->documento) && $userCanView): ?>
                         <p class="privado"><span class="icon icon-private-info"></span><span class="label"><?php \MapasCulturais\i::_e("CPF/CNPJ");?>:</span> <span class="js-editable" data-edit="documento" data-original-title="<?php \MapasCulturais\i::esc_attr_e("CPF/CNPJ");?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Insira o CPF ou CNPJ com pontos, hífens e barras");?>"><?php echo $entity->documento; ?></span></p>
+                    <?php endif;?>
+
+                    <?php if(isset($entity->identidade) && $userCanView): ?>
+                      <p class="privado"><span class="icon icon-private-info"></span><span class="label"><?php i::_e("Número da Identidade (RG)");?>:</span> <span class="js-editable" data-edit="identidade" data-original-title="<?php i::esc_attr_e("Número da Identidade (RG)");?>" data-emptytext="<?php i::esc_attr_e("Insira o número de sua identidade (RG) se for pessoa física");?>"><?php echo $entity->identidade; ?></span></p>
+                    <?php endif;?>
+
+                    <?php if(isset($entity->estadoCivil) && $userCanView): ?>
+                    <p class="privado"><span class="icon icon-private-info"></span>
+                        <span class="label"><?php i::_e("Estado Civil");?>:</span>
+                        <span class="js-editable" data-edit="estadoCivil" data-original-title="<?php i::esc_attr_e("Estado Civil");?>" data-emptytext="<?php i::esc_attr_e("Selecione seu estado civil se for pessoa física");?>"><?php echo $entity->estadoCivil; ?></span>
+                    </p>
+                    <?php endif;?>
+
+                    <?php if(isset($entity->escolaridade) && $userCanView): ?>
+                        <p class="privado"><span class="icon icon-private-info"></span>
+                          <span class="label"><?php i::_e("Escolaridade");?>:</span>
+                          <span class="js-editable" data-edit="escolaridade" data-original-title="<?php i::esc_attr_e("Escolaridade");?>" data-emptytext="<?php i::esc_attr_e("Selecione seu nível de escolaridade se for pessoa física");?>"><?php echo $entity->escolaridade; ?></span>
+                      </p>
                     <?php endif;?>
 
                     <?php if(isset($entity->dataDeNascimento) && $userCanView): ?>
@@ -239,7 +257,7 @@ $this->includeMapAssets();
     <?php if(isset($entity->_seals)):?>
         <div class="selos-add">
             <div class="widget">
-                <h3 text-align="left" vertical-align="bottom"><?php \MapasCulturais\i::_e("Selos Aplicados");?> 
+                <h3 text-align="left" vertical-align="bottom"><?php \MapasCulturais\i::_e("Selos Aplicados");?>
                 <div class="selos clearfix">
                 <?php foreach($entity->_seals as $seal):?>
                     <div class="avatar-seal">

--- a/src/protected/application/themes/BaseV1/views/agent/single.php
+++ b/src/protected/application/themes/BaseV1/views/agent/single.php
@@ -47,7 +47,7 @@ $editEntity = $this->controller->action === 'create' || $this->controller->actio
         </div>
         <!--.header-content-->
         <?php $this->applyTemplateHook('header-content','after'); ?>
-        
+
     </header>
     <!--.main-content-header-->
     <?php $this->applyTemplateHook('header','after'); ?>
@@ -91,6 +91,9 @@ $editEntity = $this->controller->action === 'create' || $this->controller->actio
                     <?php if($this->isEditable()): ?>
                         <p class="privado"><span class="icon icon-private-info"></span><span class="label"><?php \MapasCulturais\i::_e("Nome");?>:</span> <span class="js-editable <?php echo ($entity->isPropertyRequired($entity,"nomeCompleto") && $editEntity? 'required': '');?>" data-edit="nomeCompleto" data-original-title="<?php \MapasCulturais\i::esc_attr_e("Nome Completo ou Razão Social");?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Insira seu nome completo ou razão social");?>"><?php echo $entity->nomeCompleto; ?></span></p>
                         <p class="privado"><span class="icon icon-private-info"></span><span class="label"><?php \MapasCulturais\i::_e("CPF/CNPJ");?>:</span> <span class="js-editable <?php echo ($entity->isPropertyRequired($entity,"documento") && $editEntity? 'required': '');?>" data-edit="documento" data-original-title="<?php \MapasCulturais\i::esc_attr_e("CPF/CNPJ");?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Insira o CPF ou CNPJ com pontos, hífens e barras");?>"><?php echo $entity->documento; ?></span></p>
+                        <p class="privado"><span class="icon icon-private-info"></span><span class="label"><?php \MapasCulturais\i::_e("Identidade (RG)");?>:</span> <span class="js-editable <?php echo ($entity->isPropertyRequired($entity,"identidade") && $editEntity? 'required': '');?>" data-edit="identidade" data-original-title="<?php \MapasCulturais\i::esc_attr_e("Número da Identidade (RG)");?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Insira o número de sua identidade (RG) se for pessoa física");?>"><?php echo $entity->identidade; ?></span></p>
+                        <p class="privado"><span class="icon icon-private-info"></span><span class="label"><?php \MapasCulturais\i::_e("Estado Civil");?>:</span> <span class="js-editable <?php echo ($entity->isPropertyRequired($entity,"estadoCivil") && $editEntity? 'required': '');?>" data-edit="estadoCivil" data-original-title="<?php \MapasCulturais\i::esc_attr_e("Estado Civil");?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Selecione seu estado civil se for pessoa física");?>"><?php echo $entity->estadoCivil; ?></span></p>
+                        <p class="privado"><span class="icon icon-private-info"></span><span class="label"><?php \MapasCulturais\i::_e("Escolaridade");?>:</span> <span class="js-editable <?php echo ($entity->isPropertyRequired($entity,"escolaridade") && $editEntity? 'required': '');?>" data-edit="escolaridade" data-original-title="<?php \MapasCulturais\i::esc_attr_e("Escolaridade");?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Selecione seu nível de escolaridade se for pessoa física");?>"><?php echo $entity->escolaridade; ?></span></p>
                         <p class="privado"><span class="icon icon-private-info"></span><span class="label"><?php \MapasCulturais\i::_e("Data de Nascimento/Fundação");?>:</span>
                             <span class="js-editable <?php echo ($entity->isPropertyRequired($entity,"dataDeNascimento") && $this->isEditable()? 'required': '');?>" data-type="date" data-edit="dataDeNascimento" data-viewformat="dd/mm/yyyy" data-showbuttons="false" data-original-title="<?php \MapasCulturais\i::esc_attr_e("Data de Nascimento/Fundação");?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Insira a data de nascimento ou fundação do agente");?>">
                                 <?php $dtN = (new DateTime)->createFromFormat('Y-m-d', $entity->dataDeNascimento); echo $dtN ? $dtN->format('d/m/Y') : ''; ?>
@@ -147,7 +150,7 @@ $editEntity = $this->controller->action === 'create' || $this->controller->actio
     </div>
     <!-- .tabs-content -->
     <?php $this->applyTemplateHook('tabs-content','after');?>
-    
+
     <?php $this->part('owner', array('entity' => $entity, 'owner' => $entity->owner)); ?>
 
     <?php $this->applyTemplateHook('main-content','end'); ?>


### PR DESCRIPTION
**Adicionado novas opções no cadastro do agente**
- [Identidade (RG)](https://github.com/secultce/mapasculturais/issues/1)
- [Estado Civil ](https://github.com/secultce/mapasculturais/issues/17)
> Opções de escolha listadas abaixo
> Solteiro(a)
> Casado(a)
> Divorciado(a)
> Viúvo(a)
> Separado(a)
> União Estável
- [Grau de escolaridade](https://github.com/secultce/mapasculturais/issues/16)
> Ensino Fundamental Completo
> Ensino Fundamental Incompleto
> Ensino Médio Completo
> Ensino Médio Incompleto
> Ensino Superior Completo
> Ensino Superior Incompleto
> Pós-graduação (Especialização) Completa
> Pós-graduação (Especialização) Incompleta
> Pós-graduação (Mestrado) Completa
> Pós-graduação (Mestrado) Incompleta
> Pós-graduação (Doutorado) Completa
> Pós-graduação (Doutorado) Incompleta

**Modificações realizadas**
[Orientação Sexual](https://github.com/secultce/mapasculturais/issues/20)
. Homossexual
. Bissexual
. Pansexual
. Intersexual

[Gênero](https://github.com/secultce/mapasculturais/issues/20)
. Transgênero

[Tornar obrigatório novos campos no perfil do agente para finalizar a inscrição nos projetos](https://github.com/secultce/mapasculturais/issues/11)
> 'Agente responsável pela inscrição'
> 'Agente individual (pessoa física) com os campos Nome, CPF, Endereço, Data de Nascimento/Fundação, Raça, Gênero, Email Privado e Telefone 1 obrigatoriamente preenchidos'
> 'Instituição responsável'
> 'Agente individual (pessoa física) com os campos Nome, Endereço, CPF, Raça/Cor, Data de Nascimento/Fundação, Gênero, Email Privado e Telefone 1 obrigatoriamente preenchidos'
> 'Coletivo'
> 'Agente coletivo sem CNPJ, com os campos Data de Nascimento/Fundação e Email Privado obrigatoriamente preenchidos'

**Observações:**
As mudanças no formulário do agente surgiram diante da experiência obtida nos Projetos (Editais) realizados pela Secretaria da Cultura do Estado do Ceará. Os campos adicionados normalmente se repetiam em vários Editais, assim fez se necessário incluí-los no perfil base dos agente.
Nesse contexto, adicionamos novas opções também novos campos como obrigatórios por serem solicitados em grande parte dos editais como pré-requisito básico.
Quanto a orientação sexual, foi adicionado (homossexual) que possivelmente substituiria (Gay e Lesbica) . Mantivemos todos em respeito a escolha dos agentes atuais e a diversidade.
