### PR TITLE
Planilha dos espaços apresentando dados privados

### DIFF
--- a/src/protected/application/lib/MapasCulturais/ApiOutputs/Html.php
+++ b/src/protected/application/lib/MapasCulturais/ApiOutputs/Html.php
@@ -83,7 +83,7 @@ class Html extends \MapasCulturais\ApiOutput{
                             <th><?php \MapasCulturais\i::_e("Ocorrências");?></th> 
                             <?php
                         }else{
-                            if(in_array($k,['singleUrl','occurrencesReadable','spaces'])){
+                            if(in_array($k,['singleUrl','occurrencesReadable','spaces','emailPrivado','telefone1','telefone2'])){
                                 continue;
                             }
                             ?>


### PR DESCRIPTION
Pedi para exportar os dados de uma consulta de espaços sem estar logado no mapas e apareceram informações sobre e-mail privado, telefone 1 e telefone 2.