### PR TITLE
Adiciona exemplo: seleção de Ocorrências de Evento

### DIFF
--- a/documentation/docs/mc_config_api.md
+++ b/documentation/docs/mc_config_api.md
@@ -163,7 +163,7 @@ $.getJSON(
   },
   function (response){ console.log(response); });
 ```
-* **retornando o id, nome dos eventos e sua lista de ocorrências contendo id, nome do local e o objeto rule das mesmas. No objeto rules, há o campo description, que contém uma versão legível para humanos da data, horários e frequência da ocorrência. A busca filtra por eventos de id entre 100 e 200.**
+* **retornando o id, nome dos eventos e sua lista de ocorrências contendo id, nome do local e o objeto rule das mesmas. No objeto rules, há o campo description, que contém uma versão legível para humanos da data, horários e frequência da ocorrência. A busca filtra eventos de id entre 100 e 200.**
 
 ```javascript
 $.getJSON(
@@ -171,6 +171,18 @@ $.getJSON(
   {
     '@select': 'id, name,occurrences.{id,space.{name},rule}',
     'id': 'BET(100,200)'
+  },
+  function (response){ console.log(response); });
+```
+* **retornando o id, nome dos eventos e o objeto terms, que agrupa taxonomias, neste caso linguagens (cada entidade tem as suas taxonomias). A busca filtra eventos que tenham a linguagem LIKE 'Cinema' e possuam id entre 100 e 200.**
+
+```javascript
+$.getJSON(
+  'http://mapasculturais.local/api/event/find',
+  {
+    '@select': 'id, name,terms',
+    'term:linguagem': 'LIKE(Cinema)',
+    'id': 'BET(100,200)'    
   },
   function (response){ console.log(response); });
 ```

--- a/documentation/docs/mc_config_api.md
+++ b/documentation/docs/mc_config_api.md
@@ -65,7 +65,7 @@ $.getJSON(
   },
   function (response){ console.log(response); });
 ```
-* **retornando o id e nome do espaços e nomes do agentes que publicaram os espaços **
+* **retornando o id e nome do espaços e nomes do agentes que publicaram os espaços**
 
 ```javascript
 $.getJSON(
@@ -87,7 +87,6 @@ $.getJSON(
   function (response){ console.log(response); });
 ```
 * **retornando o id, nome dos agentes com com id entre 100 e 200, exceto o de id 150**
-
 
 ```javascript
 $.getJSON(
@@ -161,6 +160,17 @@ $.getJSON(
     '@select': 'id, name, location',
     '@order': 'name ASC',
     '_geoLocation': 'GEONEAR(-46.6475415229797,-23.5413271705055,700)'
+  },
+  function (response){ console.log(response); });
+```
+* **retornando o id, nome dos eventos e sua lista de ocorrências contendo id, nome do local e o objeto rule das mesmas. No objeto rules, há o campo description, que contém uma versão legível para humanos da data, horários e frequência da ocorrência. A busca filtra por eventos de id entre 100 e 200.**
+
+```javascript
+$.getJSON(
+  'http://mapasculturais.local/api/event/find',
+  {
+    '@select': 'id, name,occurrences.{id,space.{name},rule}',
+    'id': 'BET(100,200)'
   },
   function (response){ console.log(response); });
 ```


### PR DESCRIPTION
Corrige o título de um dos exemplos que não estava em negrito.
Adiciona exemplo de '@select' com query por objeto interno, neste caso das Ocorrências de um Evento e alguns parâmetros internos. Também explica brevemente o campo description do objeto rule. Não sei se aqui seria o melhor lugar para tal, mas acho que precisamos de um lugar para colocar os modelos de objetos como o EventOccurrences.