### PR TITLE
Correção do bug em que todos os registros informam a mesma data

### DIFF
--- a/src/protected/application/themes/BaseV1/layouts/parts/singles/history_agent.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/singles/history_agent.php
@@ -35,7 +35,7 @@ $this->includeMapAssets();
         <?php $this->applyTemplateHook('header-image','after'); ?>
 
         <?php $this->applyTemplateHook('entity-status','before'); ?>
-        <div class="alert info"><?php printf(i::__("As informações deste registro é histórico gerado em %s."), $entity->createTimestamp->format('d/m/Y á\s H:i:s'));?>
+        <div class="alert info"><?php printf(i::__("As informações deste registro é histórico gerado em %s."), $this->controller->requestedEntity->createTimestamp->format('d/m/Y á\s H:i:s'));?>
         <br>
         <?php if($entity->status === \MapasCulturais\Entity::STATUS_ENABLED): ?>
             <?php printf(i::__("Este %s está como <b>publicado</b>"), strtolower($entity->entity->entityTypeLabel));?>

--- a/src/protected/application/themes/BaseV1/layouts/parts/singles/history_event.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/singles/history_event.php
@@ -31,7 +31,7 @@ $app = MapasCulturais\App::i();
         <?php $this->applyTemplateHook('header-image','after'); ?>
 
         <?php $this->applyTemplateHook('entity-status','before'); ?>
-        <div class="alert info"><?php printf(i::__("As informações deste registro é histórico gerado em %s."), $entity->createTimestamp->format('d/m/Y á\s H:i:s'))?>
+        <div class="alert info"><?php printf(i::__("As informações deste registro é histórico gerado em %s."), $this->controller->requestedEntity->createTimestamp->format('d/m/Y á\s H:i:s'))?>
         <br>
         <?php if($entity->status === \MapasCulturais\Entity::STATUS_ENABLED): ?>
             <?php printf(i::__("Este %s está como <b>publicado</b>"), strtolower($entity->entity->entityTypeLabel));?>

--- a/src/protected/application/themes/BaseV1/layouts/parts/singles/history_space.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/singles/history_space.php
@@ -35,7 +35,7 @@ $this->includeMapAssets();
         <?php $this->applyTemplateHook('header-image','after'); ?>
 
         <?php $this->applyTemplateHook('entity-status','before'); ?>
-        <div class="alert info"><?php printf(i::__("As informações deste registro é histórico gerado em %s."), $entity->createTimestamp->format('d/m/Y á\s H:i:s'));?>
+        <div class="alert info"><?php printf(i::__("As informações deste registro é histórico gerado em %s."), $this->controller->requestedEntity->createTimestamp->format('d/m/Y á\s H:i:s'));?>
         <br>
         <?php if($entity->status === \MapasCulturais\Entity::STATUS_ENABLED): ?>
             <?php printf(i::__("Este %s está como <b>publicado</b>"), strtolower($entity->entity->entityTypeLabel));?>


### PR DESCRIPTION
O exemplo abaixo apresenta um perfil que possui vários registros de histórico. Contudo, todos os registros informam a mesma mensagem: "As informações deste registro é histórico gerado em **01/10/2016 21:41:58**

Perfil: 
http://mapa.cultura.ce.gov.br/agente/8146/

Links do histórico:
http://mapa.cultura.ce.gov.br/historico/25196/
http://mapa.cultura.ce.gov.br/historico/25046/
http://mapa.cultura.ce.gov.br/historico/19399/

issue: https://github.com/secultce/mapasculturais/issues/36

![screenshot from 2017-09-20 21-08-12](https://user-images.githubusercontent.com/2711728/30673239-01df7f84-9e48-11e7-9070-741c5dc2880b.png)