### PR TITLE
Update mc_deploy documentation

### DIFF
--- a/documentation/docs/mc_deploy.md
+++ b/documentation/docs/mc_deploy.md
@@ -15,7 +15,9 @@ Primeiro vamos instalar os pacotes necessários para o funcionamento do Mapas Cu
 root@server# apt-get update
 
 // Instale as dependências diversas
-**root@server# apt-get install git curl npm ruby
+**root@server# apt-get install git curl npm ruby2.0 ruby2.0-dev
+**root@server# sudo update-alternatives --install /usr/bin/ruby ruby /usr/bin/ruby2.0 10
+**root@server# sudo update-alternatives --install /usr/bin/gem gem /usr/bin/gem2.0 10
 
 // Instale a versão stable mais nova do nodejs
 root@server# curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
@@ -47,12 +49,13 @@ root@server# update-alternatives --install /usr/bin/node node /usr/bin/nodejs 10
 
 Instalando os minificadores de código Javascript e CSS: uglify-js, uglifycss e autoprefixer
 ```BASH
-root@server# npm install -g uglify-js uglifycss autoprefixer
+root@server# npm install -g uglify-js2 uglifycss autoprefixer
+root@server# update-alternatives --install /usr/bin/uglifyjs uglifyjs /usr/bin/uglifyjs2 10
 ```
 
 Instalando o SASS, utilizado para compilar os arquivos CSS
 ```BASH
-root@server# gem install sass
+root@server# gem install sass -v 3.4.22
 ```
 
 ## 2. Clonando o Repositório
@@ -240,7 +243,7 @@ root@server# service php5-fpm restart
 ```
 ### 6. Pós-instalação > API de CEP
 
-No arquivo de configuração da aplicação (mapasculturais/src/protected/application/conf/config.php), há possibilidade de setar um token para consulta de uma API que ajuda na geolocalização de endereço. O administrador da plataforma deve entrar no portal cep aberto (http://www.cepaberto.com), efetuar o cadastro e inserir o token no arquivo de configuração, descomentando a linha. 
+No arquivo de configuração da aplicação (mapasculturais/src/protected/application/conf/config.php), há possibilidade de setar um token para consulta de uma API que ajuda na geolocalização de endereço. O administrador da plataforma deve entrar no portal cep aberto (http://www.cepaberto.com), efetuar o cadastro e inserir o token no arquivo de configuração, descomentando a linha.
 
 ```
         // 'cep.token' => '[token]',


### PR DESCRIPTION
- Alterado a versão do sass para 3.4.22, como é definido no README do projeto, se utilizar a versão mais recente é apresentado alguns warnings quando o css é compilado.

- Alterado a versão do ruby para 2.0, a versão default ao instalar o ruby ($ sudo apt-get install ruby) é a 1.9, e o sass tem o ruby 2.0 como dependência.

- Alterado a versão do uglify-js para a 2, porque a versão instalada por default ($ npm install uglify-js) é a 3, para que o javascript seja gerado corretamente é necessário a versão 2.