### PR TITLE
Correção na referência a project e agora é opportunity no Módulo Notificações

### DIFF
--- a/src/protected/application/lib/modules/Notifications/Module.php
+++ b/src/protected/application/lib/modules/Notifications/Module.php
@@ -69,8 +69,8 @@ class Module extends \MapasCulturais\Module{
                         $message_to_requester = sprintf(i::__("Seu convite para fazer do agente %s um avaliador foi enviada."), $destination_link);
                         
                     } else if($origin->getClassName() === 'MapasCulturais\Entities\Registration'){
-                        $message = sprintf(i::__("%s quer relacionar o agente %s à inscrição %s no projeto %s."), $profile_link, $destination_link, $origin->number, "<a href=\"{$origin->project->singleUrl}\">{$origin->project->name}</a>");
-                        $message_to_requester = sprintf(i::__("Sua requisição para relacionar o agente %s à inscrição %s no projeto %s foi enviada."), $destination_link, "<a href=\"{$origin->singleUrl}\" >{$origin->number}</a>", "<a href=\"{$origin->project->singleUrl}\">{$origin->project->name}</a>");
+                        $message = sprintf(i::__("%s quer relacionar o agente %s à inscrição %s na oportunidade %s."), $profile_link, $destination_link, $origin->number, "<a href=\"{$origin->opportunity->singleUrl}\">{$origin->opportunity->name}</a>");
+                        $message_to_requester = sprintf(i::__("Sua requisição para relacionar o agente %s à inscrição %s na oportunidade %s foi enviada."), $destination_link, "<a href=\"{$origin->singleUrl}\" >{$origin->number}</a>", "<a href=\"{$origin->opportunity->singleUrl}\">{$origin->opportunity->name}</a>");
                     }else{
                         /* Translators: "{$profile_link} quer relacionar o agente {$destination_link} ao {$origin_type} {$origin_link}." */
                         $message = sprintf(i::__("%s quer relacionar o agente %s ao %s %s."), $profile_link, $destination_link, $origin_type, $origin_link);
@@ -158,7 +158,7 @@ class Module extends \MapasCulturais\Module{
             switch ($this->getClassName()) {
                 case "MapasCulturais\Entities\RequestAgentRelation":
                     if($origin->getClassName() === 'MapasCulturais\Entities\Registration'){
-                        $message = sprintf(i::__("%s aceitou o relacionamento do agente %s à inscrição %s no projeto %s."), $profile_link, $destination_link, "<a href=\"{$origin->singleUrl}\" >{$origin->number}</a>", "<a href=\"{$origin->project->singleUrl}\">{$origin->project->name}</a>");
+                        $message = sprintf(i::__("%s aceitou o relacionamento do agente %s à inscrição %s na oportunidade %s."), $profile_link, $destination_link, "<a href=\"{$origin->singleUrl}\" >{$origin->number}</a>", "<a href=\"{$origin->opportunity->singleUrl}\">{$origin->opportunity->name}</a>");
                     }else{
                         $message = sprintf(i::__("%s aceitou o relacionamento do agente %s com o %s %s."), $profile_link, $destination_link, $origin_type, $origin_link);
                     }
@@ -242,13 +242,13 @@ class Module extends \MapasCulturais\Module{
                 case "MapasCulturais\Entities\RequestAgentRelation":
                     if($origin->canUser('@control')){
                         if($origin->getClassName() === 'MapasCulturais\Entities\Registration'){
-                            $message = sprintf(i::__("%s cancelou o relacionamento do agente %s à inscrição %s no projeto %s."), $profile_link, $destination_link, "<a href=\"{$origin->singleUrl}\" >{$origin->number}</a>", "<a href=\"{$origin->project->singleUrl}\">{$origin->project->name}</a>");
+                            $message = sprintf(i::__("%s cancelou o relacionamento do agente %s à inscrição %s na oportunidade %s."), $profile_link, $destination_link, "<a href=\"{$origin->singleUrl}\" >{$origin->number}</a>", "<a href=\"{$origin->opportunity->singleUrl}\">{$origin->opportunity->name}</a>");
                         }else{
                             $message = sprintf(i::__("%s cancelou o pedido de relacionamento do agente %s com o %s %s."), $profile_link, $destination_link, $origin_type, $origin_link);
                         }
                     }else{
                         if($origin->getClassName() === 'MapasCulturais\Entities\Registration'){
-                            $message = sprintf(i::__("%s rejeitou o relacionamento do agente %s à inscrição %s no projeto %s."), $profile_link, $destination_link, "<a href=\"{$origin->singleUrl}\" >{$origin->number}</a>", "<a href=\"{$origin->project->singleUrl}\">{$origin->project->name}</a>");
+                            $message = sprintf(i::__("%s rejeitou o relacionamento do agente %s à inscrição %s na oportunidade %s."), $profile_link, $destination_link, "<a href=\"{$origin->singleUrl}\" >{$origin->number}</a>", "<a href=\"{$origin->opportunity->singleUrl}\">{$origin->opportunity->name}</a>");
                         }else{
                             $message = sprintf(i::__("%s rejeitou o relacionamento do agente %s com o %s %s."), $profile_link, $destination_link, $origin_type, $origin_link);
                         }

--- a/src/protected/db-updates.php
+++ b/src/protected/db-updates.php
@@ -686,7 +686,7 @@ return [
 
     'create opportunity tables' => function () {
         if(!__table_exists('opportunity')){
-            __exec("DELETE FROM registration_meta WHERE object_id NOT IN (SELECT id FROM registration WHERE project_id NOT IN (SELECT id FROM project))");
+            __exec("DELETE FROM registration_meta WHERE object_id IN (SELECT id FROM registration WHERE project_id NOT IN (SELECT id FROM project))");
             __exec("DELETE FROM registration WHERE project_id NOT IN (SELECT id FROM project)");
 
             // cria tabelas das oportunidades


### PR DESCRIPTION
A seguinte correção visa sanar o problema em que as notificações referente a inscrições de projetos ocasionam o erro abaixo
![erro nas notificacoes](https://user-images.githubusercontent.com/2711728/37625291-1abebb42-2baa-11e8-9c9f-c43dfa42b43f.png)
Isso aconteceu, porque as inscrições passaram a ser das oportunidades e no módulo das Notificações ainda existiam as referências

```
$origin->project->singleUrl
```
agora:
```
$origin->opportunity->singleUrl
```
