### PR TITLE
Conflitos durante o deploy da nova versão 

### DIFF
--- a/src/protected/application/lib/MapasCulturais/Entities/Registration.php
+++ b/src/protected/application/lib/MapasCulturais/Entities/Registration.php
@@ -760,6 +760,10 @@ class Registration extends \MapasCulturais\Entity
             return false;
         }
 
+        if($user->is('guest')){
+            return false;
+        }
+
         if($evaluation = $this->getUserEvaluation($user)){
             $evaluation_sent = $evaluation->status === RegistrationEvaluation::STATUS_SENT;
         }

--- a/src/protected/db-updates.php
+++ b/src/protected/db-updates.php
@@ -610,55 +610,55 @@ return [
         __try("ALTER TABLE subsite_meta ADD CONSTRAINT FK_780702F5232D562B FOREIGN KEY (object_id) REFERENCES subsite (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
         __try("ALTER TABLE subsite_meta ADD PRIMARY KEY (id);");
 
-        __try("CREATE INDEX subsite_meta_owner_key_idx ON subsite_meta (object_id, key);");
-        __try("CREATE INDEX subsite_meta_owner_idx ON subsite_meta (object_id);");
+        __try("CREATE INDEX IF NOT EXISTS subsite_meta_owner_key_idx  ON subsite_meta (object_id, key);");
+        __try("CREATE INDEX IF NOT EXISTS subsite_meta_owner_idx ON subsite_meta (object_id);");
 
         __try("ALTER TABLE agent_meta DROP CONSTRAINT agent_agent_meta_fk;");
         __try("ALTER TABLE agent_meta ALTER id DROP DEFAULT;");
         __try("ALTER TABLE agent_meta ALTER key TYPE VARCHAR(255);");
         __try("ALTER TABLE agent_meta DROP CONSTRAINT IF EXISTS FK_7A69AED6232D562B;");
         __try("ALTER TABLE agent_meta ADD CONSTRAINT FK_7A69AED6232D562B FOREIGN KEY (object_id) REFERENCES agent (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
-        __try("CREATE INDEX agent_meta_owner_key_idx ON agent_meta (object_id, key);");
-        __try("CREATE INDEX agent_meta_owner_idx ON agent_meta (object_id);");
+        __try("CREATE INDEX IF NOT EXISTS agent_meta_owner_key_idx ON agent_meta (object_id, key);");
+        __try("CREATE INDEX IF NOT EXISTS agent_meta_owner_idx ON agent_meta (object_id);");
 
         __try("ALTER TABLE user_meta ALTER key TYPE VARCHAR(255);");
         __try("ALTER TABLE user_meta DROP CONSTRAINT IF EXISTS FK_AD7358FC232D562B;");
         __try("ALTER TABLE user_meta ADD CONSTRAINT FK_AD7358FC232D562B FOREIGN KEY (object_id) REFERENCES usr (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
         __try("ALTER TABLE user_meta ADD PRIMARY KEY (id);");
 
-        __try("CREATE INDEX user_meta_owner_key_idx ON user_meta (object_id, key);");
-        __try("CREATE INDEX user_meta_owner_idx ON user_meta (object_id);");
+        __try("CREATE INDEX IF NOT EXISTS user_meta_owner_key_idx ON user_meta (object_id, key);");
+        __try("CREATE INDEX IF NOT EXISTS user_meta_owner_idx ON user_meta (object_id);");
 
         __try("ALTER TABLE event_meta DROP CONSTRAINT event_project_meta_fk;");
         __try("ALTER TABLE event_meta ALTER id DROP DEFAULT;");
         __try("ALTER TABLE event_meta ALTER key TYPE VARCHAR(255);");
         __try("ALTER TABLE event_meta DROP CONSTRAINT IF EXISTS FK_C839589E232D562B;");
         __try("ALTER TABLE event_meta ADD CONSTRAINT FK_C839589E232D562B FOREIGN KEY (object_id) REFERENCES event (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
-        __try("CREATE INDEX event_meta_owner_key_idx ON event_meta (object_id, key);");
-        __try("CREATE INDEX event_meta_owner_idx ON event_meta (object_id);");
+        __try("CREATE INDEX IF NOT EXISTS event_meta_owner_key_idx ON event_meta (object_id, key);");
+        __try("CREATE INDEX IF NOT EXISTS event_meta_owner_idx ON event_meta (object_id);");
 
         __try("ALTER TABLE space_meta DROP CONSTRAINT space_space_meta_fk;");
         __try("ALTER TABLE space_meta ALTER id DROP DEFAULT;");
         __try("ALTER TABLE space_meta ALTER key TYPE VARCHAR(255);");
         __try("ALTER TABLE space_meta DROP CONSTRAINT IF EXISTS FK_BC846EBF232D562B;");
         __try("ALTER TABLE space_meta ADD CONSTRAINT FK_BC846EBF232D562B FOREIGN KEY (object_id) REFERENCES space (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
-        __try("CREATE INDEX space_meta_owner_key_idx ON space_meta (object_id, key);");
-        __try("CREATE INDEX space_meta_owner_idx ON space_meta (object_id);");
+        __try("CREATE INDEX IF NOT EXISTS space_meta_owner_key_idx  ON space_meta (object_id, key);");
+        __try("CREATE INDEX IF NOT EXISTS space_meta_owner_idx ON space_meta (object_id);");
 
         __try("ALTER TABLE project_meta DROP CONSTRAINT project_project_meta_fk;");
         __try("ALTER TABLE project_meta ALTER id DROP DEFAULT;");
         __try("ALTER TABLE project_meta ALTER key TYPE VARCHAR(255);");
         __try("ALTER TABLE project_meta DROP CONSTRAINT IF EXISTS FK_EE63DC2D232D562B;");
         __try("ALTER TABLE project_meta ADD CONSTRAINT FK_EE63DC2D232D562B FOREIGN KEY (object_id) REFERENCES project (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
-        __try("CREATE INDEX project_meta_owner_key_idx ON project_meta (object_id, key);");
-        __try("CREATE INDEX project_meta_owner_idx ON project_meta (object_id);");
+        __try("CREATE INDEX IF NOT EXISTS project_meta_owner_key_idx ON project_meta (object_id, key);");
+        __try("CREATE INDEX IF NOT EXISTS project_meta_owner_idx ON project_meta (object_id);");
 
         __try("ALTER TABLE seal_meta DROP CONSTRAINT seal_meta_fk;");
         __try("ALTER TABLE seal_meta ALTER object_id SET NOT NULL;");
         __try("ALTER TABLE seal_meta DROP CONSTRAINT IF EXISTS FK_A92E5E22232D562B;");
         __try("ALTER TABLE seal_meta ADD CONSTRAINT FK_A92E5E22232D562B FOREIGN KEY (object_id) REFERENCES seal (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
-        __try("CREATE INDEX seal_meta_owner_key_idx ON seal_meta (object_id, key);");
-        __try("CREATE INDEX seal_meta_owner_idx ON seal_meta (object_id);");
+        __try("CREATE INDEX IF NOT EXISTS seal_meta_owner_key_idx ON seal_meta (object_id, key);");
+        __try("CREATE INDEX IF NOT EXISTS seal_meta_owner_idx ON seal_meta (object_id);");
 
         __try("ALTER TABLE registration ADD PRIMARY KEY(id);");
 
@@ -666,15 +666,15 @@ return [
         __try("ALTER TABLE registration_meta ALTER key TYPE VARCHAR(255);");
         __try("ALTER TABLE registration_meta DROP CONSTRAINT IF EXISTS FK_18CC03E9232D562B;");
         __try("ALTER TABLE registration_meta ADD CONSTRAINT FK_18CC03E9232D562B FOREIGN KEY (object_id) REFERENCES registration (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
-        __try("CREATE INDEX registration_meta_owner_key_idx ON registration_meta (object_id, key);");
-        __try("CREATE INDEX registration_meta_owner_idx ON registration_meta (object_id);");
+        __try("CREATE INDEX IF NOT EXISTS registration_meta_owner_key_idx ON registration_meta (object_id, key);");
+        __try("CREATE INDEX IF NOT EXISTS registration_meta_owner_idx ON registration_meta (object_id);");
 
         __try("ALTER TABLE notification_meta DROP CONSTRAINT notification_meta_fk;");
         __try("ALTER TABLE notification_meta ALTER object_id SET NOT NULL;");
         __try("ALTER TABLE notification_meta DROP CONSTRAINT IF EXISTS FK_6FCE5F0F232D562B;");
         __try("ALTER TABLE notification_meta ADD CONSTRAINT FK_6FCE5F0F232D562B FOREIGN KEY (object_id) REFERENCES notification (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
-        __try("CREATE INDEX notification_meta_owner_key_idx ON notification_meta (object_id, key);");
-        __try("CREATE INDEX notification_meta_owner_idx ON notification_meta (object_id);");
+        __try("CREATE INDEX IF NOT EXISTS notification_meta_owner_key_idx ON notification_meta (object_id, key);");
+        __try("CREATE INDEX IF NOT EXISTS notification_meta_owner_idx ON notification_meta (object_id);");
 
     },
 
@@ -686,7 +686,7 @@ return [
 
     'create opportunity tables' => function () {
         if(!__table_exists('opportunity')){
-            __exec("DELETE FROM registration_meta WHERE object_id NOT IN (SELECT id FROM registration WHERE project_id NOT IN (SELECT id FROM project))");
+            __exec("DELETE FROM registration_meta WHERE object_id IN (SELECT id FROM registration WHERE project_id NOT IN (SELECT id FROM project))");
             __exec("DELETE FROM registration WHERE project_id NOT IN (SELECT id FROM project)");
 
             // cria tabelas das oportunidades

--- a/src/protected/db-updates.php
+++ b/src/protected/db-updates.php
@@ -684,6 +684,22 @@ return [
      * - files do grupo rules
      */
 
+    'create permission cache pending table2' => function() use ($conn) {
+
+        if(__table_exists('permission_cache_pending')){
+            echo "TABLE permission_cache_pending ALREADY EXISTS";
+            return true;
+        }
+
+        $conn->executeQuery("CREATE TABLE permission_cache_pending (
+            id INT NOT NULL, 
+            object_id INT NOT NULL, 
+            object_type VARCHAR(255) NOT NULL, 
+            
+            PRIMARY KEY(id)
+        );");
+    },
+
     'create opportunity tables' => function () {
         if(!__table_exists('opportunity')){
             __exec("DELETE FROM registration_meta WHERE object_id IN (SELECT id FROM registration WHERE project_id NOT IN (SELECT id FROM project))");
@@ -961,16 +977,6 @@ return [
         $conn->executeQuery("UPDATE subsite_meta SET key = 'seals_color' where key = 'cor_selos';");
     },
 
-    'fix subsite verifiedSeals array' => function() use($app){
-        $subsites = $app->repo('Subsite')->findAll();
-        foreach($subsites as $subsite){
-            $subsite->setVerifiedSeals($subsite->verifiedSeals);
-            $subsite->save(true);
-        }
-
-        return false;
-    },
-    
     'ALTER TABLE file ADD private and update' => function () use ($conn) {
         if(__column_exists('file', 'private')){
             return true;
@@ -980,6 +986,16 @@ return [
         
         $conn->executeQuery("UPDATE file SET private = true WHERE grp LIKE 'rfc_%' OR grp = 'zipArchive'");
         
+    },
+
+    'fix subsite verifiedSeals array' => function() use($app){
+        $subsites = $app->repo('Subsite')->findAll();
+        foreach($subsites as $subsite){
+            $subsite->setVerifiedSeals($subsite->verifiedSeals);
+            $subsite->save(true);
+        }
+
+        return false;
     },
     
     'move private files' => function () use ($conn) {
@@ -1021,21 +1037,6 @@ return [
         
     },
 	
-	'create permission cache pending table2' => function() use ($conn) {
 
-        if(__table_exists('permission_cache_pending')){
-            echo "TABLE permission_cache_pending ALREADY EXISTS";
-            return true;
-        }
-
-        $conn->executeQuery("CREATE TABLE permission_cache_pending (
-			id INT NOT NULL, 
-			object_id INT NOT NULL, 
-			object_type VARCHAR(255) NOT NULL, 
-			
-			PRIMARY KEY(id)
-		);");
-
-    },
 
 ] + $updates ;

--- a/src/protected/db-updates.php
+++ b/src/protected/db-updates.php
@@ -850,15 +850,15 @@ return [
         __exec("CREATE INDEX evaluationMethodConfiguration_meta_owner_key_idx ON evaluationMethodConfiguration_meta (object_id, key);");
         __exec("ALTER TABLE evaluation_method_configuration ADD CONSTRAINT FK_330CB54C9A34590F FOREIGN KEY (opportunity_id) REFERENCES opportunity (id) NOT DEFERRABLE INITIALLY IMMEDIATE;");
         __exec("ALTER TABLE evaluationMethodConfiguration_meta ADD CONSTRAINT FK_D7EDF8B2232D562B FOREIGN KEY (object_id) REFERENCES evaluation_method_configuration (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
+        __exec("CREATE SEQUENCE evaluation_method_configuration_id_seq INCREMENT BY 1 MINVALUE 1 START 1;");
+        __exec("ALTER SEQUENCE evaluation_method_configuration_id_seq OWNED BY evaluation_method_configuration.id;");
+        __exec("ALTER TABLE ONLY evaluation_method_configuration ALTER COLUMN id SET DEFAULT nextval('evaluation_method_configuration_id_seq'::regclass);");
+
 
         $opportunities = $this->repo('Opportunity')->findAll();
 
         foreach($opportunities as $opportunity){
-            $emc = new Entities\EvaluationMethodConfiguration;
-
-            $emc->opportunity = $opportunity;
-            $emc->type = 'simple';
-            $emc->save(true);
+            __exec("INSERT INTO evaluation_method_configuration ( opportunity_id, type) VALUES ($opportunity->id, 'simple');");
         }
     },
 

--- a/src/protected/db-updates.php
+++ b/src/protected/db-updates.php
@@ -610,7 +610,7 @@ return [
         __try("ALTER TABLE subsite_meta ADD CONSTRAINT FK_780702F5232D562B FOREIGN KEY (object_id) REFERENCES subsite (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
         __try("ALTER TABLE subsite_meta ADD PRIMARY KEY (id);");
 
-        __try("CREATE INDEX subsite_meta_owner_key_idx  ON subsite_meta (object_id, key);");
+        __try("CREATE INDEX subsite_meta_owner_key_idx ON subsite_meta (object_id, key);");
         __try("CREATE INDEX subsite_meta_owner_idx ON subsite_meta (object_id);");
 
         __try("ALTER TABLE agent_meta DROP CONSTRAINT agent_agent_meta_fk;");
@@ -642,7 +642,7 @@ return [
         __try("ALTER TABLE space_meta ALTER key TYPE VARCHAR(255);");
         __try("ALTER TABLE space_meta DROP CONSTRAINT IF EXISTS FK_BC846EBF232D562B;");
         __try("ALTER TABLE space_meta ADD CONSTRAINT FK_BC846EBF232D562B FOREIGN KEY (object_id) REFERENCES space (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
-        __try("CREATE INDEX space_meta_owner_key_idx  ON space_meta (object_id, key);");
+        __try("CREATE INDEX space_meta_owner_key_idx ON space_meta (object_id, key);");
         __try("CREATE INDEX space_meta_owner_idx ON space_meta (object_id);");
 
         __try("ALTER TABLE project_meta DROP CONSTRAINT project_project_meta_fk;");

--- a/src/protected/db-updates.php
+++ b/src/protected/db-updates.php
@@ -610,55 +610,55 @@ return [
         __try("ALTER TABLE subsite_meta ADD CONSTRAINT FK_780702F5232D562B FOREIGN KEY (object_id) REFERENCES subsite (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
         __try("ALTER TABLE subsite_meta ADD PRIMARY KEY (id);");
 
-        __try("CREATE INDEX IF NOT EXISTS subsite_meta_owner_key_idx  ON subsite_meta (object_id, key);");
-        __try("CREATE INDEX IF NOT EXISTS subsite_meta_owner_idx ON subsite_meta (object_id);");
+        __try("CREATE INDEX subsite_meta_owner_key_idx  ON subsite_meta (object_id, key);");
+        __try("CREATE INDEX subsite_meta_owner_idx ON subsite_meta (object_id);");
 
         __try("ALTER TABLE agent_meta DROP CONSTRAINT agent_agent_meta_fk;");
         __try("ALTER TABLE agent_meta ALTER id DROP DEFAULT;");
         __try("ALTER TABLE agent_meta ALTER key TYPE VARCHAR(255);");
         __try("ALTER TABLE agent_meta DROP CONSTRAINT IF EXISTS FK_7A69AED6232D562B;");
         __try("ALTER TABLE agent_meta ADD CONSTRAINT FK_7A69AED6232D562B FOREIGN KEY (object_id) REFERENCES agent (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
-        __try("CREATE INDEX IF NOT EXISTS agent_meta_owner_key_idx ON agent_meta (object_id, key);");
-        __try("CREATE INDEX IF NOT EXISTS agent_meta_owner_idx ON agent_meta (object_id);");
+        __try("CREATE INDEX agent_meta_owner_key_idx ON agent_meta (object_id, key);");
+        __try("CREATE INDEX agent_meta_owner_idx ON agent_meta (object_id);");
 
         __try("ALTER TABLE user_meta ALTER key TYPE VARCHAR(255);");
         __try("ALTER TABLE user_meta DROP CONSTRAINT IF EXISTS FK_AD7358FC232D562B;");
         __try("ALTER TABLE user_meta ADD CONSTRAINT FK_AD7358FC232D562B FOREIGN KEY (object_id) REFERENCES usr (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
         __try("ALTER TABLE user_meta ADD PRIMARY KEY (id);");
 
-        __try("CREATE INDEX IF NOT EXISTS user_meta_owner_key_idx ON user_meta (object_id, key);");
-        __try("CREATE INDEX IF NOT EXISTS user_meta_owner_idx ON user_meta (object_id);");
+        __try("CREATE INDEX user_meta_owner_key_idx ON user_meta (object_id, key);");
+        __try("CREATE INDEX user_meta_owner_idx ON user_meta (object_id);");
 
         __try("ALTER TABLE event_meta DROP CONSTRAINT event_project_meta_fk;");
         __try("ALTER TABLE event_meta ALTER id DROP DEFAULT;");
         __try("ALTER TABLE event_meta ALTER key TYPE VARCHAR(255);");
         __try("ALTER TABLE event_meta DROP CONSTRAINT IF EXISTS FK_C839589E232D562B;");
         __try("ALTER TABLE event_meta ADD CONSTRAINT FK_C839589E232D562B FOREIGN KEY (object_id) REFERENCES event (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
-        __try("CREATE INDEX IF NOT EXISTS event_meta_owner_key_idx ON event_meta (object_id, key);");
-        __try("CREATE INDEX IF NOT EXISTS event_meta_owner_idx ON event_meta (object_id);");
+        __try("CREATE INDEX event_meta_owner_key_idx ON event_meta (object_id, key);");
+        __try("CREATE INDEX event_meta_owner_idx ON event_meta (object_id);");
 
         __try("ALTER TABLE space_meta DROP CONSTRAINT space_space_meta_fk;");
         __try("ALTER TABLE space_meta ALTER id DROP DEFAULT;");
         __try("ALTER TABLE space_meta ALTER key TYPE VARCHAR(255);");
         __try("ALTER TABLE space_meta DROP CONSTRAINT IF EXISTS FK_BC846EBF232D562B;");
         __try("ALTER TABLE space_meta ADD CONSTRAINT FK_BC846EBF232D562B FOREIGN KEY (object_id) REFERENCES space (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
-        __try("CREATE INDEX IF NOT EXISTS space_meta_owner_key_idx  ON space_meta (object_id, key);");
-        __try("CREATE INDEX IF NOT EXISTS space_meta_owner_idx ON space_meta (object_id);");
+        __try("CREATE INDEX space_meta_owner_key_idx  ON space_meta (object_id, key);");
+        __try("CREATE INDEX space_meta_owner_idx ON space_meta (object_id);");
 
         __try("ALTER TABLE project_meta DROP CONSTRAINT project_project_meta_fk;");
         __try("ALTER TABLE project_meta ALTER id DROP DEFAULT;");
         __try("ALTER TABLE project_meta ALTER key TYPE VARCHAR(255);");
         __try("ALTER TABLE project_meta DROP CONSTRAINT IF EXISTS FK_EE63DC2D232D562B;");
         __try("ALTER TABLE project_meta ADD CONSTRAINT FK_EE63DC2D232D562B FOREIGN KEY (object_id) REFERENCES project (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
-        __try("CREATE INDEX IF NOT EXISTS project_meta_owner_key_idx ON project_meta (object_id, key);");
-        __try("CREATE INDEX IF NOT EXISTS project_meta_owner_idx ON project_meta (object_id);");
+        __try("CREATE INDEX project_meta_owner_key_idx ON project_meta (object_id, key);");
+        __try("CREATE INDEX project_meta_owner_idx ON project_meta (object_id);");
 
         __try("ALTER TABLE seal_meta DROP CONSTRAINT seal_meta_fk;");
         __try("ALTER TABLE seal_meta ALTER object_id SET NOT NULL;");
         __try("ALTER TABLE seal_meta DROP CONSTRAINT IF EXISTS FK_A92E5E22232D562B;");
         __try("ALTER TABLE seal_meta ADD CONSTRAINT FK_A92E5E22232D562B FOREIGN KEY (object_id) REFERENCES seal (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
-        __try("CREATE INDEX IF NOT EXISTS seal_meta_owner_key_idx ON seal_meta (object_id, key);");
-        __try("CREATE INDEX IF NOT EXISTS seal_meta_owner_idx ON seal_meta (object_id);");
+        __try("CREATE INDEX seal_meta_owner_key_idx ON seal_meta (object_id, key);");
+        __try("CREATE INDEX seal_meta_owner_idx ON seal_meta (object_id);");
 
         __try("ALTER TABLE registration ADD PRIMARY KEY(id);");
 
@@ -666,15 +666,15 @@ return [
         __try("ALTER TABLE registration_meta ALTER key TYPE VARCHAR(255);");
         __try("ALTER TABLE registration_meta DROP CONSTRAINT IF EXISTS FK_18CC03E9232D562B;");
         __try("ALTER TABLE registration_meta ADD CONSTRAINT FK_18CC03E9232D562B FOREIGN KEY (object_id) REFERENCES registration (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
-        __try("CREATE INDEX IF NOT EXISTS registration_meta_owner_key_idx ON registration_meta (object_id, key);");
-        __try("CREATE INDEX IF NOT EXISTS registration_meta_owner_idx ON registration_meta (object_id);");
+        __try("CREATE INDEX registration_meta_owner_key_idx ON registration_meta (object_id, key);");
+        __try("CREATE INDEX registration_meta_owner_idx ON registration_meta (object_id);");
 
         __try("ALTER TABLE notification_meta DROP CONSTRAINT notification_meta_fk;");
         __try("ALTER TABLE notification_meta ALTER object_id SET NOT NULL;");
         __try("ALTER TABLE notification_meta DROP CONSTRAINT IF EXISTS FK_6FCE5F0F232D562B;");
         __try("ALTER TABLE notification_meta ADD CONSTRAINT FK_6FCE5F0F232D562B FOREIGN KEY (object_id) REFERENCES notification (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
-        __try("CREATE INDEX IF NOT EXISTS notification_meta_owner_key_idx ON notification_meta (object_id, key);");
-        __try("CREATE INDEX IF NOT EXISTS notification_meta_owner_idx ON notification_meta (object_id);");
+        __try("CREATE INDEX notification_meta_owner_key_idx ON notification_meta (object_id, key);");
+        __try("CREATE INDEX notification_meta_owner_idx ON notification_meta (object_id);");
 
     },
 


### PR DESCRIPTION
Arquivo **src/protected/db-updates.php**
> Adicionado INDEX IF NOT EXISTS:

Esse medida foi para não ficar informando inúmeros erros em bases de dados que já possuem os INDEX criados.

>  'create permission cache pending table2' 

Realocado a criação dessa tabela antes da criação da tabela oportunidade porque ao executar a criação dos metodos de avaliação, faz se necessário a existencia desta tabela.

>DELETE FROM registration_meta WHERE object_id IN **NOT**(SELECT id FROM registration WHERE project_id NOT IN (SELECT id FROM project

Removido o "NOT" porque acreditamos que o objetivo desta query seja apagar os registrations meta das inscrições orfãs, e o nome faz justamente o contrário.

**`Mais detalhes na issue`** https://github.com/secultce/mapasculturais/issues/85