### PR TITLE
Feature/adicionar avaliador

### DIFF
--- a/src/protected/application/themes/BaseV1/Theme.php
+++ b/src/protected/application/themes/BaseV1/Theme.php
@@ -1504,7 +1504,7 @@ class Theme extends MapasCulturais\Theme {
 
         $this->enqueueScript('app', 'evaluations', 'js/evaluations.js');
         $this->localizeScript('evaluations', [
-            'saveMessage' => i::__('A avaiação foi salva')
+            'saveMessage' => i::__('A avaliação foi salva')
         ]);
     }
 
@@ -1689,6 +1689,7 @@ class Theme extends MapasCulturais\Theme {
             'savedAsDraft' =>  i::__('Eventos transformados em rascunho.'),
             'confirmRemoveAttachment' =>  i::__('Deseja remover este anexo?'),
             'registrationOwnerDefault' =>  i::__('Agente responsável pela inscrição'),
+            'agentRelationIsAlreadyExists' =>  i::__('O Agente selecionado já foi adicionado na comissão de avaliadores'),
             'allStatus' =>  i::__('Todas'),
             'pending' =>  i::__('Pendente'),
             'invalid' =>  i::__('Inválida'),

--- a/src/protected/application/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
+++ b/src/protected/application/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
@@ -1081,22 +1081,24 @@ module.controller('RegistrationFieldsController', ['$scope', '$rootScope', '$int
 
         $scope.createAdminRelation = function(entity){
             var _scope = this.$parent;
-            var groupName = 'group-admin';
-            var hasControl = true;
             var isAgentRelation = false;
-
-            EditBox.close('add-committee-agent');
+            _scope.spinnerCondition = true;
+            _scope.noEntityFound  = true;
 
             isAgentRelation = $scope.data.committee.some( item => item.agent.id === entity.id);
 
             if (!isAgentRelation) {
-                RelatedAgentsService.create(groupName, entity.id, true).
-                success(function(data){
+                RelatedAgentsService.create('group-admin', entity.id, true).success(function(data) {
                     $scope.data.committee.push(data);
+                    _scope.spinnerCondition = false;
+                    _scope.noEntityFound  = false;
                     _scope.$parent.searchText = '';
                     _scope.$parent.result = [];
+                    EditBox.close('add-committee-agent');
                 });
             } else {
+                _scope.spinnerCondition = false;
+                _scope.noEntityFound  = false;
                 MapasCulturais.Messages.error(labels['agentRelationIsAlreadyExists']);
             }
         };

--- a/src/protected/application/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
+++ b/src/protected/application/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
@@ -1083,16 +1083,13 @@ module.controller('RegistrationFieldsController', ['$scope', '$rootScope', '$int
             var _scope = this.$parent;
             var groupName = 'group-admin';
             var hasControl = true;
-            var isNewAgent = true;
+            var isAgentRelation = false;
 
             EditBox.close('add-committee-agent');
 
-            $scope.data.committee.forEach(function(item){
-                if (item.agent.id == entity.id)
-                    isNewAgent = false;
-            });
+            isAgentRelation = $scope.data.committee.some( item => item.agent.id === entity.id);
 
-            if (isNewAgent) {
+            if (!isAgentRelation) {
                 RelatedAgentsService.create(groupName, entity.id, true).
                 success(function(data){
                     $scope.data.committee.push(data);

--- a/src/protected/application/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
+++ b/src/protected/application/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
@@ -1083,14 +1083,25 @@ module.controller('RegistrationFieldsController', ['$scope', '$rootScope', '$int
             var _scope = this.$parent;
             var groupName = 'group-admin';
             var hasControl = true;
+            var isNewAgent = true;
 
-            RelatedAgentsService.create(groupName, entity.id, true).
-                    success(function(data){
-                        $scope.data.committee.push(data);
-                        _scope.$parent.searchText = '';
-                        _scope.$parent.result = [];
-                        EditBox.close('add-committee-agent');
-                    });
+            EditBox.close('add-committee-agent');
+
+            $scope.data.committee.forEach(function(item){
+                if (item.agent.id == entity.id)
+                    isNewAgent = false;
+            });
+
+            if (isNewAgent) {
+                RelatedAgentsService.create(groupName, entity.id, true).
+                success(function(data){
+                    $scope.data.committee.push(data);
+                    _scope.$parent.searchText = '';
+                    _scope.$parent.result = [];
+                });
+            } else {
+                MapasCulturais.Messages.error(labels['agentRelationIsAlreadyExists']);
+            }
         };
 
         $scope.deleteAdminRelation = function(relation){

--- a/src/protected/application/themes/BaseV1/layouts/parts/singles/opportunity-evaluations--committee.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/singles/opportunity-evaluations--committee.php
@@ -89,8 +89,8 @@ $method = $entity->getEvaluationMethod();
         <p ng-if="committee.length < 1"><?php i::_e('Não há nenhum avaliador definido.'); ?></p>
         <span class="btn btn-default add" ng-click="editbox.open('add-committee-agent', $event)" ><?php i::esc_attr_e('Adicionar avaliador'); ?></span>
 
-        <edit-box ng-if="isEditable" id="add-committee-agent" position="right" title="Adicionar agente à comissão de avaliadores" cancel-label="Cancelar" close-on-cancel='true'>
-            <find-entity entity="agent" api-query="findQuery" no-results-text="<?php i::esc_attr_e('Nenhum agente encontrado'); ?>" description="" spinner-condition="false" select="createAdminRelation"></find-entity>
+        <edit-box id="add-committee-agent" ng-if="isEditable" position="right" title="<?php \MapasCulturais\i::esc_attr_e("Adicionar agente à comissão de avaliadores");?>" spinner-condition="spinners['add-committee-agent']" cancel-label="<?php \MapasCulturais\i::esc_attr_e("Cancelar");?>" close-on-cancel='true'>
+            <find-entity entity="agent" api-query="findQuery" no-results-text="<?php i::esc_attr_e('Nenhum agente encontrado'); ?>" description="" spinner-condition="spinners['add-committee-agent']" group="add-committee-agent" select="createAdminRelation"></find-entity>
         </edit-box>
     </div>
 </div>


### PR DESCRIPTION
**Problemática:**
Se o gerente da oportunidade der múltiplos cliques ao adicionar ou excluir um avaliador:
1. Adiciona várias vezes o mesmo avaliador (1 vez para cada "clique" do gerente);
2. Sai excluindo os avalaidores (1 exclusão para cada "clique") que o gerente der no botão excluir;

**Ajustes:** 
1. Foi adicionado uma validação para não permitir o mesmo avaliador ser adicionado mais de uma vez.
2. Ao clicar em adicionar fecha o modal para que o gerente não fique forçando vários cliques sucessivos durante o processamento.
3. Foi corrigido a descrição da mensagem ao salvar uma avaliação.

https://github.com/secultce/mapasculturais/issues/97