### PR TITLE
#70 correcao na ordem de cadastro dos campos extras de oportunidade

### DIFF
--- a/src/protected/application/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
+++ b/src/protected/application/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
@@ -391,6 +391,7 @@ module.controller('RegistrationConfigurationsController', ['$scope', '$rootScope
 
         $scope.createFieldConfiguration = function(){
             $scope.data.fieldSpinner = true;
+            $scope.data.newFieldConfiguration.displayOrder = $scope.data.fields.length +1;
             fieldService.create($scope.data.newFieldConfiguration).then(function(response){
                 $scope.data.fieldSpinner = false;
 
@@ -461,6 +462,7 @@ module.controller('RegistrationConfigurationsController', ['$scope', '$rootScope
 
         $scope.createFileConfiguration = function(){
             $scope.data.uploadSpinner = true;
+            $scope.data.newFileConfiguration.displayOrder = $scope.data.fields.length +1;
             fileService.create($scope.data.newFileConfiguration).then(function(response){
                 $scope.data.uploadSpinner = false;
                 if (response.error) {


### PR DESCRIPTION
Este erro persistia criar uma nova ficha de inscrição,  ao salvar perdia-se a ordem em que os itens tinha sido criados ou ordenados.

Issues:
https://github.com/hacklabr/mapasculturais/issues/1341
https://github.com/secultce/mapasculturais/issues/70