### PR TITLE
correção do erro ao excluir administrador da oportunidade

### DIFF
--- a/src/protected/application/themes/BaseV1/assets/js/ng.entity.module.relatedAgents.js
+++ b/src/protected/application/themes/BaseV1/assets/js/ng.entity.module.relatedAgents.js
@@ -246,7 +246,7 @@
         $scope.deleteAdminRelation = function(admin){
             var admins = $scope.admins;
             var oldRelations = admins.slice();
-            var i = admins.indexOf(admin);
+            var i = admins.map(function(e){ return e.agent.id; }).indexOf(admin.id);
 
             admins.splice(i,1);
 


### PR DESCRIPTION
A funcionalidade Excluir Administrador de Oportunidade está removendo o último da lista, ao invés de excluir o administrador selecionado.

issue: https://github.com/secultce/mapasculturais/issues/102