### PR TITLE
Removendo o formato de data no campo Data Final do projeto

### DIFF
--- a/src/protected/application/lib/MapasCulturais/Entities/Project.php
+++ b/src/protected/application/lib/MapasCulturais/Entities/Project.php
@@ -258,7 +258,7 @@ class Project extends \MapasCulturais\Entity
         if($date instanceof \DateTime){
             $this->registrationTo = $date;
         }elseif($date){
-            $this->registrationTo = \DateTime::createFromFormat('Y-m-d H:i', $date);
+            $this->registrationTo =  new \DateTime($date);
         }else{
             $this->registrationTo = null;
         }


### PR DESCRIPTION
Com a entidade "Oportunidades" realizando o processo de inscrição a entidade "Projeto" 
torna-se um agregador das oportunidades.

- Assim, invés de projeto ter a mensagem : "inscrições abertas de xx:xx : xx:xx às xx." 
![projeto-inscricao](https://user-images.githubusercontent.com/2711728/41038780-bf1edc84-696d-11e8-9ee5-8bd21aa68ce3.png)

Essa mensagem torna-se um: "Período de Execução de xx:xx : xx:xx às xx."

Contudo, não há necessidade de usar o horário, apenas periodo de início e fim. Por isso, foi preciso ajustar essa formatação.


