### PR TITLE
Adicionando o filtro de status "Rascunho" na listagem das inscriçõe

### DIFF
--- a/src/protected/application/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
+++ b/src/protected/application/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
@@ -163,7 +163,8 @@
                 {value: 2, label: labels['invalid']},
                 {value: 3, label: labels['notSelected']},
                 {value: 8, label: labels['suplente']},
-                {value: 10, label: labels['selected']}
+                {value: 10, label: labels['selected']},
+                {value: 0, label: labels['draft']}
             ],
 
             registrationStatusesNames: [
@@ -1254,7 +1255,7 @@ module.controller('OpportunityController', ['$scope', '$rootScope', '$timeout', 
             '@select': 'id,singleUrl,category,status,owner.{id,name,singleUrl},consolidatedResult,evaluationResultString,' + select_fields.join(',')
         };
         for(var prop in $scope.registrationsFilters){
-            if($scope.registrationsFilters[prop]){
+            if($scope.registrationsFilters[prop] || $scope.registrationsFilters[prop] === 0){
                 qdata[prop] = 'EQ(' + $scope.registrationsFilters[prop] + ')'
             }
         }

--- a/src/protected/application/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
+++ b/src/protected/application/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
@@ -1249,7 +1249,7 @@ module.controller('OpportunityController', ['$scope', '$rootScope', '$timeout', 
 
     $scope.$watch('registrationsFilters', function(){
         var qdata = {
-            'status': 'GT(0)',
+            'status': 'GT(-1)',
             '@files': '(zipArchive):url',
             '@opportunity': getOpportunityId(),
             '@select': 'id,singleUrl,category,status,owner.{id,name,singleUrl},consolidatedResult,evaluationResultString,' + select_fields.join(',')


### PR DESCRIPTION
Adicionando o Status **rascunho** no filtro das inscrições onde o gerente pode filtrar as inscrições em rascunhos e ter um **feedback do total** de inscrições **não enviadas**, necessário para tomada de decisão na hora de pensar em plano de comunicação para a finalização das inscrições:

veja em anexo:
![issue 144](https://user-images.githubusercontent.com/2711728/41612539-9ab3ddca-73c9-11e8-8d90-32c34978fc53.png)

É possível testar usando nosso ambiente em : http://dev-mapa.cultura.ce.gov.br