### PR TITLE
Avaliador não ver os campos da ficha de inscrição em uma oportunidade com multiplas fases

### DIFF
--- a/src/protected/application/lib/modules/OpportunityPhases/Module.php
+++ b/src/protected/application/lib/modules/OpportunityPhases/Module.php
@@ -592,6 +592,19 @@ class Module extends \MapasCulturais\Module{
             }
         });
 
+        $app->hook('entity(Registration).canUser(viewPrivateData)', function($user, &$result) use($app){
+            if($result){
+                return;
+            }
+
+            $registration_id = $this->getMetadata('nextPhaseRegistrationId');
+
+            if($registration_id ){
+                $next_phase_registration = $app->repo('Registration')->find($registration_id);
+                $result = $next_phase_registration->canUser('viewPrivateData', $user);
+            }
+        });
+
         $app->hook('entity(Registration).canUser(view)', function($user, &$result) use($app){
             if($result){
                 return;


### PR DESCRIPTION
O problema ocorre ao adicionar multiplas fases em uma oportunidade. Neste caso o avaliador não consegue visualizar as informações preenchidas na fase anterior. conforme anexo:


Exemplo: http://dev-mapa.cultura.ce.gov.br/oportunidade/1023/ 

![0001 na apresenta](https://user-images.githubusercontent.com/14170372/40065670-af8578aa-5838-11e8-8aae-18ecebeab4a7.png)
