### PR TITLE
Adicionando campo observações na avaliação simplificada

### DIFF
--- a/src/protected/application/plugins/EvaluationMethodSimple/Plugin.php
+++ b/src/protected/application/plugins/EvaluationMethodSimple/Plugin.php
@@ -68,7 +68,7 @@ class Plugin extends \MapasCulturais\EvaluationMethod {
                 'label' => i::__('Observações'),
                 'getValue' => function (Entities\RegistrationEvaluation $evaluation) {
                     $evaluation_data = (array)$evaluation->evaluationData;
-                    if (isset($evaluation_data)) {
+                    if (isset($evaluation_data) && isset($evaluation_data['obs'])) {
                         return $evaluation_data['obs'];
                     } else {
                         return '';

--- a/src/protected/application/plugins/EvaluationMethodSimple/Plugin.php
+++ b/src/protected/application/plugins/EvaluationMethodSimple/Plugin.php
@@ -39,11 +39,47 @@ class Plugin extends \MapasCulturais\EvaluationMethod {
         $app = App::i();
 
         $app->view->enqueueScript('app', 'simple-evaluation-form', 'js/ng.evaluationMethod.simple.js', ['entity.module.opportunity']);
+        $app->view->enqueueStyle('app', 'simple-evaluation-method', 'css/simple-evaluation-method.css');
+
         $app->view->jsObject['angularAppDependencies'][] = 'ng.evaluationMethod.simple';
     }
 
-    public function _init() {
-        ;
+    public function _init()
+    {
+        $app = App::i();
+        $app->hook('evaluationsReport(simple).sections', function (Entities\Opportunity $opportunity, &$sections) use ($app) {
+            $columns = [];
+            $evaluations = $opportunity->getEvaluations();
+
+            foreach ($evaluations as $eva) {
+                $evaluation = $eva['evaluation'];
+                $data = (array)$evaluation->evaluationData;
+                foreach ($data as $id => $d) {
+                    $columns[$id] = $d;
+                }
+            }
+
+            $result = [
+                'registration' => $sections['registration'],
+                'committee' => $sections['committee'],
+            ];
+
+            $sections['evaluation']->columns['obs'] =  (object)[
+                'label' => i::__('Observações'),
+                'getValue' => function (Entities\RegistrationEvaluation $evaluation) {
+                    $evaluation_data = (array)$evaluation->evaluationData;
+                    if (isset($evaluation_data)) {
+                        return $evaluation_data['obs'];
+                    } else {
+                        return '';
+                    }
+                }
+            ];
+
+            $result['evaluation'] = $sections['evaluation'];
+
+            $sections = $result;
+        });
     }
 
     public function _getConsolidatedResult(Entities\Registration $registration) {

--- a/src/protected/application/plugins/EvaluationMethodSimple/assets/css/simple-evaluation-method.css
+++ b/src/protected/application/plugins/EvaluationMethodSimple/assets/css/simple-evaluation-method.css
@@ -1,0 +1,50 @@
+/* Simple Evaluation Method Styles */
+
+.simple-evaluation-form {
+    font-size: 0.75rem;
+}
+
+.simple-evaluation-form label {
+    margin-bottom: 10px;
+    margin-top: 10px;
+}
+
+.simple-evaluation-form label.input-label {
+    font-size: 1.25em;
+    margin-right: 10px;
+}
+
+.simple-evaluation-form textarea {
+    width:100%;
+    height:250px;
+}
+
+mc-select div.dropdown {
+    width:100%;
+    margin-bottom: 10px;
+}
+
+.field-shadow {
+    box-shadow: 0px 0px 30px 0;
+}
+
+.evaluation-invalid,.evaluation-invalid:hover {
+    background-color: rgba(255,200,200,.5) !important;
+}
+
+.evaluation-valid,.evaluation-valid:hover {
+    background-color: rgba(200,255,200,.5) !important;
+}
+
+.evaluation-empty {
+
+}
+
+.simple-evaluation-view {
+    margin:-1em;
+    padding:1em;
+}
+
+.simple-evaluation-view p {
+    font-style: italic;
+}

--- a/src/protected/application/plugins/EvaluationMethodSimple/assets/js/ng.evaluationMethod.simple.js
+++ b/src/protected/application/plugins/EvaluationMethodSimple/assets/js/ng.evaluationMethod.simple.js
@@ -20,7 +20,7 @@
         });
         $scope.data = {
             registration: evaluation ? evaluation.evaluationData.status : null,
-            
+            obs: evaluation ? evaluation.evaluationData.obs : null,
             registrationStatusesNames: statuses,
 
         };

--- a/src/protected/application/plugins/EvaluationMethodSimple/layouts/parts/simple--evaluation-form.php
+++ b/src/protected/application/plugins/EvaluationMethodSimple/layouts/parts/simple--evaluation-form.php
@@ -1,12 +1,16 @@
 <?php
 use MapasCulturais\i;
 ?>
-<style>
-    .evaluation-form--simple mc-select div.dropdown { width:100%; }
-</style>
 
-<div ng-controller="SimpleEvaluationForm">
-    <h4><?php echo $evaluationMethod->getName(); ?></h4>
-    <mc-select class="{{getStatusSlug(data.registration.status)}}" model="data.registration" data="data.registrationStatusesNames" getter="getRegistrationStatus" setter="setRegistrationStatus" placeholder="<?php i::_e('Selecione o status') ?>"></mc-select>
-    <input type="hidden" name="data[status]" value="{{data.registration}}"/>
+
+<div ng-controller="SimpleEvaluationForm" >
+    <div class="simple-evaluation-form">
+        <h4><?php echo $evaluationMethod->getName(); ?></h4>
+        <mc-select class="{{getStatusSlug(data.registration.status)}}" model="data.registration" data="data.registrationStatusesNames" getter="getRegistrationStatus" setter="setRegistrationStatus" placeholder="<?php i::_e('Selecione o status') ?>"></mc-select>
+        <input type="hidden" name="data[status]" value="{{data.registration}}"/>
+        <label class="textarea-label">
+            <?php i::_e('Justificativa / Observações') ?><br>
+            <textarea name="data[obs]">{{data.obs}}</textarea>
+        </label>
+    </div>
 </div>

--- a/src/protected/application/plugins/EvaluationMethodSimple/layouts/parts/simple--evaluation-view.php
+++ b/src/protected/application/plugins/EvaluationMethodSimple/layouts/parts/simple--evaluation-view.php
@@ -1,5 +1,5 @@
 <?php use MapasCulturais\i; ?>
-<div ng-controller="SimpleEvaluationForm">
+<div ng-controller="SimpleEvaluationForm" class="simple-evaluation-view">
     <div ng-if="data.registration">
         <?php i::_e('Avaliação'); ?>: <strong>{{getStatusLabel(data.registration)}}</strong>
     </div>


### PR DESCRIPTION
O módulo de avaliação simplificada só tem o campo da caixa de seleção para indicar se o projeto é (selecionado e não selecionado). Porém, diversas situações necessitam de fundamentação na avaliação, fezendo-se necessário adicionar um campos para "observações" cujo preenchimento é opcional.

![captura de tela de 2018-06-28 14-57-09](https://user-images.githubusercontent.com/2711728/42051855-8d62f07c-7ae3-11e8-829f-b96a9cec98ea.png)
