### PR TITLE
Atualizar o filtro das inscrições e possibilitar que o gerente selecione os filtros das proximas fases

### DIFF
--- a/src/protected/application/themes/BaseV1/Theme.php
+++ b/src/protected/application/themes/BaseV1/Theme.php
@@ -2359,12 +2359,16 @@ class Theme extends MapasCulturais\Theme {
     function addOpportunitySelectFieldsToJs(Entities\Opportunity $entity){
         $this->jsObject['opportunitySelectFields'] = isset($this->jsObject['opportunitySelectFields']) ? $this->jsObject['opportunitySelectFields'] : [];
 
-        foreach($entity->registrationFieldConfigurations as $field){
-            if($field->fieldType == 'select'){
-                if(!in_array($field, $this->jsObject['opportunitySelectFields'])){
-                    $this->jsObject['opportunitySelectFields'][] = $field;
+        $_opportunity = $entity;
+        while($_opportunity !== null){
+            foreach($_opportunity->registrationFieldConfigurations as $field){
+                if($field->fieldType == 'select'){
+                    if(!in_array($field, $this->jsObject['opportunitySelectFields'])){
+                        $this->jsObject['opportunitySelectFields'][] = $field;
+                    }
                 }
             }
+            $_opportunity = $_opportunity->parent;
         }
     }
 

--- a/src/protected/application/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
+++ b/src/protected/application/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
@@ -1226,6 +1226,29 @@ module.controller('OpportunityController', ['$scope', '$rootScope', '$timeout', 
     $scope.registrationsFilters = {};
     $scope.evaluationsFilters = {};
 
+    $scope.isSelected = function(object, key){
+        var selected  = false;
+        for(var index in object) {
+            if (key == index){
+                selected =  object[key];
+                break;
+            }
+        }
+        return selected;
+    };
+
+    $scope.toggleSelection = function(object, key){
+        var value  = true;
+        for(var index in object) {
+            if (key == index){
+                value = !object[key];
+                break;
+            }
+        }
+        object[key] = value;
+        return;
+    };
+
     $scope.findRegistrations = function(){
         if(registrationsApi.finish()){
             return null;
@@ -1298,6 +1321,17 @@ module.controller('OpportunityController', ['$scope', '$rootScope', '$timeout', 
         return { value: e, label: e };
     }) : [];
 
+
+
+    var defaultSelectFields = [
+        {fieldName: "number", title:"Inscrição" ,required:true},
+        {fieldName: "category", title:"Categorias" ,required:true},
+        {fieldName: "agents", title:"Agentes" ,required:true},
+        {fieldName: "attachments", title: "Anexos" ,required:true},
+        {fieldName: "evaluation", title: "Avaliação" ,required:true},
+        {fieldName: "status", title:"Status" ,required:true},
+    ];
+
     MapasCulturais.opportunitySelectFields.forEach(function(e){
         e.options = [{ value: null, label: e.title }].concat(e.fieldOptions.map(function(e){
             return {value: e, label: e};
@@ -1367,6 +1401,8 @@ module.controller('OpportunityController', ['$scope', '$rootScope', '$timeout', 
         publishedRegistrationStatus: 10,
 
         propLabels : [],
+
+        defaultSelectFields : defaultSelectFields,
 
         registrationTableColumns: {
             number: true,

--- a/src/protected/application/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
+++ b/src/protected/application/themes/BaseV1/assets/js/ng.entity.module.opportunity.js
@@ -1249,6 +1249,26 @@ module.controller('OpportunityController', ['$scope', '$rootScope', '$timeout', 
         return;
     };
 
+    $scope.toggleSelectionColumn = function(object, key){
+
+        $scope.toggleSelection(object, key);
+
+        if ($scope.numberOfEnabledColumns() == 0) {
+            object[key] = true;
+            alert('Não é permitido desabilitar todas as colunas da tabela');
+            return;
+        }
+
+        if (key == 'number' ) {
+            var columnObj = $scope.getColumnByKey(key);
+            object[key] = true;
+            alert('Não é permitido desabilitar a coluna ' + columnObj.title);
+            return;
+        }
+
+        return;
+    };
+
     $scope.findRegistrations = function(){
         if(registrationsApi.finish()){
             return null;
@@ -1463,6 +1483,15 @@ module.controller('OpportunityController', ['$scope', '$rootScope', '$timeout', 
         }
     });
 
+    $scope.getColumnByKey = function(key){
+        for(var index in $scope.data.defaultSelectFields){
+            if($scope.data.defaultSelectFields[index].fieldName == key ){
+                return $scope.data.defaultSelectFields[index];
+            }
+        }
+
+        return null;
+    };
 
     $scope.numberOfEnabledColumns = function(){
         var result = 0;

--- a/src/protected/application/themes/BaseV1/layouts/parts/singles/opportunity-registrations--tables--manager.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/singles/opportunity-registrations--tables--manager.php
@@ -28,21 +28,36 @@ use MapasCulturais\i;
     <input ng-model="data.registrations.filtro" placeholder="<?php i::_e('Busque pelo nome do responsável, status ou número de inscrição') ?>" />
 </div>
 
-<p>
-    <strong> <?php i::_e("Colunas Habilitadas:") ?> </strong><br>
-    <label><input type="checkbox" ng-model="data.registrationTableColumns.number" /> <?php i::_e('Inscrição') ?> </label>
-    <label><input type="checkbox" ng-model="data.registrationTableColumns.category" /> <?php i::_e('Categorias') ?> </label>
-    <label><input type="checkbox" ng-model="data.registrationTableColumns.agents" /> <?php i::_e('Agentes') ?> </label>
-    <label ng-if="data.entity.registrationFileConfigurations.length > 0">
-        <input type="checkbox" ng-model="data.registrationTableColumns.attachments" /> <?php i::_e('Anexos') ?>
-    </label>
-    <label><input type="checkbox" ng-model="data.registrationTableColumns.evaluation" /> <?php i::_e('Avaliação') ?> </label>
-    <label><input type="checkbox" ng-model="data.registrationTableColumns.status" /> <?php i::_e('Status') ?> </label>
+<div class="dropdown" style="width:100%; margin:10px 0px;">
+    <div class="placeholder" ng-click="filter_dropdown = ''"><?php i::_e("Colunas Habilitadas:") ?></div>
+    <div class="submenu-dropdown" style="background: #fff;">
+        <div class="filter-search" style="padding: 5px;">
+            <input type="text" ng-model="filter_dropdown" style="width:100%;"/>
+        </div>
+        <ul class="filter-list">
 
-    <label ng-repeat="field in data.opportunitySelectFields" ng-if="field.required">
-        <input type="checkbox" ng-model="data.registrationTableColumns[field.fieldName]" />{{field.title}}
-    </label>
-</p>
+            <li ng-repeat="field in data.defaultSelectFields | filter:filter_dropdown" ng-if="field.required"
+                ng-class="{'selected':isSelected(data.registrationTableColumns, field.fieldName)}"
+                ng-click="toggleSelection(data.registrationTableColumns, field.fieldName)" >
+                <span>{{field.title}}</span>
+            </li>
+            <li ng-repeat="field in data.opportunitySelectFields | filter:filter_dropdown" ng-if="field.required"
+                ng-class="{'selected':isSelected(data.registrationTableColumns, field.fieldName)}"
+                ng-click="toggleSelection(data.registrationTableColumns, field.fieldName)" >
+                <span>{{field.title}}</span>
+            </li>
+        </ul>
+    </div>
+</div>
+
+<!--
+<div id="selected-filters">
+     <span>
+        <a class="tag-selected tag-opportunity" >Artes Integradas</a>
+        <a class="tag-selected tag-opportunity" >Artes Visuais</a>
+     </span>
+</div>
+-->
 
 <style>
     table.fullscreen {

--- a/src/protected/application/themes/BaseV1/layouts/parts/singles/opportunity-registrations--tables--manager.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/singles/opportunity-registrations--tables--manager.php
@@ -32,17 +32,17 @@ use MapasCulturais\i;
     <div class="placeholder" ng-click="filter_dropdown = ''"><?php i::_e("Colunas Habilitadas:") ?></div>
     <div class="submenu-dropdown" style="background: #fff;">
         <div class="filter-search" style="padding: 5px;">
-            <input type="text" ng-model="filter_dropdown" style="width:100%;"/>
+            <input type="text" ng-model="filter_dropdown" style="width:100%;" placeholder="Busque pelo nome dos campos do formulário de inscrição e selecione as colunas visíveis" />
         </div>
         <ul class="filter-list">
             <li ng-repeat="field in data.defaultSelectFields | filter:filter_dropdown" ng-if="field.required"
                 ng-class="{'selected':isSelected(data.registrationTableColumns, field.fieldName)}"
-                ng-click="toggleSelection(data.registrationTableColumns, field.fieldName)" >
+                ng-click="toggleSelectionColumn(data.registrationTableColumns, field.fieldName)" >
                 <span>{{field.title}}</span>
             </li>
             <li ng-repeat="field in data.opportunitySelectFields | filter:filter_dropdown" ng-if="field.required"
                 ng-class="{'selected':isSelected(data.registrationTableColumns, field.fieldName)}"
-                ng-click="toggleSelection(data.registrationTableColumns, field.fieldName)" >
+                ng-click="toggleSelectionColumn(data.registrationTableColumns, field.fieldName)" >
                 <span>{{field.title}}</span>
             </li>
         </ul>
@@ -52,8 +52,8 @@ use MapasCulturais\i;
 
 <div id="selected-filters" style="width:100%; margin:10px 0px;">
      <span>
-        <a ng-repeat="field in data.defaultSelectFields" ng-click="toggleSelection(data.registrationTableColumns, field.fieldName)"  class="tag-selected tag-opportunity" ng-if="isSelected(data.registrationTableColumns, field.fieldName)" >{{field.title}}</a>
-        <a ng-repeat="field in data.opportunitySelectFields" ng-click="toggleSelection(data.registrationTableColumns, field.fieldName)"  class="tag-selected tag-opportunity" ng-if="isSelected(data.registrationTableColumns, field.fieldName)" >{{field.title}}</a>
+        <a ng-repeat="field in data.defaultSelectFields" ng-click="toggleSelectionColumn(data.registrationTableColumns, field.fieldName)"  class="tag-selected tag-opportunity" ng-if="isSelected(data.registrationTableColumns, field.fieldName)" >{{field.title}}</a>
+        <a ng-repeat="field in data.opportunitySelectFields" ng-click="toggleSelectionColumn(data.registrationTableColumns, field.fieldName)"  class="tag-selected tag-opportunity" ng-if="isSelected(data.registrationTableColumns, field.fieldName)" >{{field.title}}</a>
      </span>
 </div>
 

--- a/src/protected/application/themes/BaseV1/layouts/parts/singles/opportunity-registrations--tables--manager.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/singles/opportunity-registrations--tables--manager.php
@@ -35,7 +35,6 @@ use MapasCulturais\i;
             <input type="text" ng-model="filter_dropdown" style="width:100%;"/>
         </div>
         <ul class="filter-list">
-
             <li ng-repeat="field in data.defaultSelectFields | filter:filter_dropdown" ng-if="field.required"
                 ng-class="{'selected':isSelected(data.registrationTableColumns, field.fieldName)}"
                 ng-click="toggleSelection(data.registrationTableColumns, field.fieldName)" >
@@ -50,14 +49,14 @@ use MapasCulturais\i;
     </div>
 </div>
 
-<!--
-<div id="selected-filters">
+
+<div id="selected-filters" style="width:100%; margin:10px 0px;">
      <span>
-        <a class="tag-selected tag-opportunity" >Artes Integradas</a>
-        <a class="tag-selected tag-opportunity" >Artes Visuais</a>
+        <a ng-repeat="field in data.defaultSelectFields" ng-click="toggleSelection(data.registrationTableColumns, field.fieldName)"  class="tag-selected tag-opportunity" ng-if="isSelected(data.registrationTableColumns, field.fieldName)" >{{field.title}}</a>
+        <a ng-repeat="field in data.opportunitySelectFields" ng-click="toggleSelection(data.registrationTableColumns, field.fieldName)"  class="tag-selected tag-opportunity" ng-if="isSelected(data.registrationTableColumns, field.fieldName)" >{{field.title}}</a>
      </span>
 </div>
--->
+
 
 <style>
     table.fullscreen {


### PR DESCRIPTION
As perguntas de seleção única do questionário aparecem como opções a serem habilitadas, pelo gerente do projeto, na tabela de resumo. Isso é muito importante para o gerente garantir de forma fácil a distribuição das aprovações de acordo com as cotas do edital. Por exemplo, além de conhecer a categoria do projeto, o gerente precisa saber da resposta a questão se o projeto é da capital ou interior. 

Foi atualizado o filtro para ficar muito parecido com os filtros padrões do sistema, conforme abaixo:
![captura de tela de 2018-07-20 15-29-29](https://user-images.githubusercontent.com/2711728/43019028-e97c8864-8c31-11e8-87f0-c7d52448a44e.png)

Além disso, possibilitar que apareça também as perguntas das fases seguintes.

Issue: https://github.com/secultce/mapasculturais/issues/80