### PR TITLE
Alteracoes para permitir visualizar uma inscricao rascunho

### DIFF
--- a/src/protected/application/lib/MapasCulturais/Controllers/Registration.php
+++ b/src/protected/application/lib/MapasCulturais/Controllers/Registration.php
@@ -250,7 +250,7 @@ class Registration extends EntityController {
 
         $entity->checkPermission('view');
 
-        if($entity->status === Entities\Registration::STATUS_DRAFT){
+        if($entity->status === Entities\Registration::STATUS_DRAFT && $this->canUser('modify')){
             parent::GET_edit();
         }else{
             parent::GET_single();

--- a/src/protected/application/themes/BaseV1/layouts/parts/singles/registration-single--header.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/singles/registration-single--header.php
@@ -1,7 +1,10 @@
+<?php $sentDate = $entity->sentTimestamp; ?>
+<?php if ($sentDate): ?>
 <div class="alert success">
     <?php \MapasCulturais\i::_e("Inscrição enviada no dia");?>    
-    <?php echo $entity->sentTimestamp->format(\MapasCulturais\i::__('d/m/Y à\s H:i:s')); ?>
+    <?php echo $sentDate->format(\MapasCulturais\i::__('d/m/Y à\s H:i:s')); ?>
 </div>
+<?php endif; ?>
 
 <h3 class="registration-header"><?php \MapasCulturais\i::_e("Formulário de Inscrição");?></h3>
 


### PR DESCRIPTION
Essa correção visa sanar o problema do gerente ou administrador não acessar a inscrição em rascunho, o que anteriormente era possível e com o módulo oportunidade estava ocasionando erro ao tentar abrir uma inscrição em rascunho clicando na inscrição pelo painel das inscrições.
![captura de tela de 2018-07-20 15-35-59](https://user-images.githubusercontent.com/2711728/43019232-a6cae6a4-8c32-11e8-82fe-2bf85f04090c.png)

issue:https://github.com/secultce/mapasculturais/issues/48