### PR TITLE
As legendas das categorias configuradas pelo gerente do projeto não aparecem para o avaliador

### DIFF
--- a/src/protected/application/themes/BaseV1/layouts/parts/singles/registration-single--categories.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/singles/registration-single--categories.php
@@ -1,10 +1,15 @@
 <?php if($opportunity->registrationCategories): ?>
+    <?php
+        $category = $entity->category;
+        $infos = $opportunity->evaluationMethodConfiguration->infos
+    ?>
     <div class="registration-fieldset">
-        <!-- selecionar categoria -->
-        <h4><?php echo $opportunity->registrationCategTitle ?></h4>
-        <!-- <p class="registration-help"><?php echo $opportunity->registrationCategDescription ?></p> -->
+        <h4><?php echo $opportunity->registrationCategTitle; ?></h4>
+        <p class="registration-help"><?php echo $opportunity->registrationCategDescription; ?></p>
         <div>
-            <?php echo $entity->category ?>
+            <?php echo $category; ?>
+            <p><?php echo (isset($infos->$category)) ? $infos->$category : "" ;?>
+            </p>
         </div>
     </div>
 <?php endif; ?>


### PR DESCRIPTION
As legendas específicas para as categorias, que são configuradas pelo gerente do projeto (ver tela da esquerda)  não aparecem para o avaliador (tela da direita). Só aparece o texto do campo "para todas as inscrições".

![13- nao apareceu o texto especifico por categoria](https://user-images.githubusercontent.com/14170372/37866897-6d2bff5c-2f6f-11e8-8d09-e69f4f20e86f.png)

issue: https://github.com/secultce/mapasculturais/issues/74