### PR TITLE
Possibilitar acompanhamento das inscrições em rascunho

### DIFF
--- a/src/protected/application/lib/MapasCulturais/Controllers/Registration.php
+++ b/src/protected/application/lib/MapasCulturais/Controllers/Registration.php
@@ -250,9 +250,9 @@ class Registration extends EntityController {
 
         $entity->checkPermission('view');
 
-        if($entity->status === Entities\Registration::STATUS_DRAFT && $this->canUser('modify')){
+        if($entity->status === Entities\Registration::STATUS_DRAFT && $entity->canUser('modify')){
             parent::GET_edit();
-        }else{
+        } else {
             parent::GET_single();
         }
     }

--- a/src/protected/application/lib/MapasCulturais/Controllers/Registration.php
+++ b/src/protected/application/lib/MapasCulturais/Controllers/Registration.php
@@ -250,7 +250,7 @@ class Registration extends EntityController {
 
         $entity->checkPermission('view');
 
-        if($entity->status === Entities\Registration::STATUS_DRAFT){
+        if($entity->status === Entities\Registration::STATUS_DRAFT && $this->canUser('modify')){
             parent::GET_edit();
         }else{
             parent::GET_single();

--- a/src/protected/application/themes/BaseV1/assets/css/sass/components/_registrations-tables.scss
+++ b/src/protected/application/themes/BaseV1/assets/css/sass/components/_registrations-tables.scss
@@ -108,6 +108,22 @@
 					}
 				}
 			}
+			&.draft {
+				border-left: 3px solid $brand-draft;
+				background-color: #b5dae6;
+				&:hover {
+					background-color: lighten(#b5dae6, 5%);
+				}
+				td {
+					border-bottom: 1px solid #fff;
+				}
+				.dropdown {
+					background-color: $brand-draft;
+					.placeholder {
+						color: #fff;
+					}
+				}
+			}
 			&.notapproved {
 				border-left: 3px solid $brand-danger;
 				background-color: #fcc;
@@ -292,5 +308,5 @@
 	background-color: #000;
 }
 .status-draft {
-	background-color: $gray-light;
+	background-color: $brand-draft;
 }

--- a/src/protected/application/themes/BaseV1/assets/css/sass/globals/_variables.scss
+++ b/src/protected/application/themes/BaseV1/assets/css/sass/globals/_variables.scss
@@ -29,6 +29,7 @@ $brand-info: #40b4b4 !default;
 $brand-warning: #cc9933 !default;
 $brand-danger: #cc3333 !default;
 $brand-success: #66cc66 !default;
+$brand-draft: #0d9ecc !default;
 $brand-default: $gray-light !default;
 
 

--- a/src/protected/application/themes/BaseV1/layouts/parts/singles/registration-single--header.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/singles/registration-single--header.php
@@ -1,7 +1,10 @@
+<?php $sentDate = $entity->sentTimestamp; ?>
+<?php if ($sentDate): ?>
 <div class="alert success">
     <?php \MapasCulturais\i::_e("Inscrição enviada no dia");?>    
-    <?php echo $entity->sentTimestamp->format(\MapasCulturais\i::__('d/m/Y à\s H:i:s')); ?>
+    <?php echo $sentDate->format(\MapasCulturais\i::__('d/m/Y à\s H:i:s')); ?>
 </div>
+<?php endif; ?>
 
 <h3 class="registration-header"><?php \MapasCulturais\i::_e("Formulário de Inscrição");?></h3>
 


### PR DESCRIPTION
O padrão atual do sistema é que o gerente do projeto consegue ver as inscrições que estão como rascunho, mas não pode acessá-las (O agente repassa o "link" ou o "número" da inscrição para o gerente visualizar).
Assim, o gerente ao clicar em uma inscrição ele consiga abrir em modo rascunho, o que já era utilizado na plataforma.