### PR TITLE
Adicionado hook para tratamento do resultado do API Query

### DIFF
--- a/src/protected/application/lib/MapasCulturais/Traits/ControllerAPI.php
+++ b/src/protected/application/lib/MapasCulturais/Traits/ControllerAPI.php
@@ -225,6 +225,8 @@ trait ControllerAPI{
             }
             $this->apiAddHeaderMetadata($api_params, $result, $count);
         }
+
+        $app->applyHookBoundTo($this, "API.{$this->action}({$this->id}).result" , [&$api_params,  &$result]);
         
         return $result;
     }


### PR DESCRIPTION
Precisamos remover resultados duplicados, para não alterar o ApiQuery estamos enviando um hook para tratamento do resultado da consulta.