### PR TITLE
Removendo o processamento do pending cache do metodo run e adicionando uma configuracao

### DIFF
--- a/scripts/process-pending-cache.sh
+++ b/scripts/process-pending-cache.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [[ $1 ]]; then
+    SERVER_NAME=$1;
+else
+    SERVER_NAME="127.0.0.1";
+fi
+
+if [[ $2 ]]; then
+    URL=$2;
+else
+    URL="permissionCache/recreate";
+fi
+
+if [[ $3 ]]; then
+    SERVER_PORT=$3;
+else
+    SERVER_PORT="80";
+fi
+
+
+if [[ $4 ]]; then
+    SERVER_PROTOCOL=$4;
+else
+    SERVER_PROTOCOL="http";
+fi
+
+wget $SERVER_PROTOCOL://$SERVER_NAME:$SERVER_PORT/$URL --delete-after

--- a/src/protected/application/lib/MapasCulturais/App.php
+++ b/src/protected/application/lib/MapasCulturais/App.php
@@ -522,13 +522,31 @@ class App extends \Slim\Slim{
         if(defined('DB_UPDATES_FILE') && file_exists(DB_UPDATES_FILE))
             $this->_dbUpdates();
 
+        // ===================================== //
+
+        //pending cache hook
+
+        $this->hook('mapasculturais.run:after', function () {
+            $recreate_permissions_by_cron = (isset($this->_config['pendingcache.recreatePermissions.cron.enable'])) ? $this->_config['pendingcache.recreatePermissions.cron.enable'] : FALSE;
+            if ( $recreate_permissions_by_cron ) {
+                //Apenas salva a lista de entidades pendentes para atualizacao do cache de permissoes
+                $this->savePendingCacheList();
+            } else {
+                //Salva e Consome a lista de entidades pendentes para atualizacao do cache de permissoes
+                $this->recreatePermissionsCacheOfListedEntities();
+            }
+
+        });
+
+        // ===================================== //
+
+
         return $this;
     }
 
     public function run() {
         $this->applyHookBoundTo($this, 'mapasculturais.run:before');
         parent::run();
-        $this->recreatePermissionsCacheOfListedEntities();
         $this->applyHookBoundTo($this, 'mapasculturais.run:after');
     }
 
@@ -1518,7 +1536,7 @@ class App extends \Slim\Slim{
         $this->_entitiesToRecreatePermissionsCache["$entity"] = $entity;
     }
 
-    public function recreatePermissionsCacheOfListedEntities($step = 20){
+    public function savePendingCacheList() {
         if($this->skipPermissionCacheRecreation){
             return;
         }
@@ -1535,6 +1553,16 @@ class App extends \Slim\Slim{
             }
         }
 
+        $this->_entitiesToRecreatePermissionsCache = [];
+    }
+
+    public function recreatePermissionsCacheOfListedEntities($step = 20){
+        if($this->skipPermissionCacheRecreation){
+            return;
+        }
+
+        $this->savePendingCacheList();
+
 		$queue = $this->repo('PermissionCachePending')->findBy([], ['id' => 'ASC'], $step);
 		if (is_array($queue) && count($queue) > 0) {
             $conn = $this->em->getConnection();
@@ -1550,7 +1578,6 @@ class App extends \Slim\Slim{
 
             $conn->commit();
             $this->em->flush();
-            $this->_entitiesToRecreatePermissionsCache = [];
         }
     }
 


### PR DESCRIPTION
Esta alteração:
1 -  remove a chamada do recreate permissions do metodo App->run, e utiliza hooks do sitema
2 - Propõe uma configuração opcional para quem desejar processar o pending cache sem utilizar a requisição da aplicaçao, ou seja, separa a execução da aplicação do processamento do cache
3 - A aplicacao apenas salva a lista de pendentes, e o processamento da lista deverá ser através do script process-pending-cache.sh utilizando cron