### PR TITLE
Ajustes no recreate pcache

### DIFF
--- a/src/protected/mc-updates.php
+++ b/src/protected/mc-updates.php
@@ -5,9 +5,9 @@ return [
     $app = \MapasCulturais\App::i();
     $conn = $app->em->getConnection();
     $conn->executeQuery("DELETE FROM pcache");
-    foreach (['Agent', 'Space', 'Project', 'Event', 'Seal', 'Registration', 'Notification', 'Request', 'Opportunity'] as $class){
+    foreach (['Agent', 'Space', 'Project', 'Event', 'Seal', 'Registration', 'Notification', 'Request', 'Opportunity', 'EvaluationMethodConfiguration'] as $class){
             DB_UPDATE::enqueue($class, 'id > 0', function (MapasCulturais\Entity $entity) {
-                $entity->recreatePermissionCache();
+                $entity->createPermissionsCacheForUsers(null, true, false);
             });
         }
     },

--- a/src/protected/tools/apply-multicore-db-update.php
+++ b/src/protected/tools/apply-multicore-db-update.php
@@ -182,7 +182,7 @@ $finish_microtime = microtime(true);
 
 $execution_time = number_format($finish_microtime - $start_microtime, 4);
 
-$t = gmdate("H:i:s", $execution_time);
+$t = gmdate("H:i:s", (int) $execution_time);
 
 echo "
 ==========================================================================================


### PR DESCRIPTION
O script pcache quando é executado:

1 -  Php Notice na função gmdate em apply-multicore-db-update.php.

2- Executa o recreatePermission cache uma função recursiva, neste caso, da recriação total do pcache , não existe necessidade pois todas as entidades terão suas permissoes adicionadas no pache, mais indicado é utilizar o método createPermissionsCacheForUsers para cada entidade.

3 - Mesmo deletando todo o conteúdo do pcache , o método createPermissionsCacheForUsers executa o método deletePermissionsCache para todas as entidades por padrão, o mais indicado é passar o argumento delete_old = false para evitar essa solicitação ao banco de dados

4 - Em createPermissionsCacheForUsers executa o método deletePermissionsCache com o argumento $user_id , esse argumento não existe no método, indicado é remover

5- No metodo createPermissionsCacheForUsers existem dois foreachs encadeados, $foreach $users e para cada $user foreach $permissions, neste último temos o teste if (!is_null($user) , retestando o usuário sempre em todas as permissões, o mais indicado é testar apenas 1 vez no foreach do $users

6 - No método createPermissionsCacheForUsers no foreach de $permissions temos o teste com a permissão view, alguns testes são recalculados sem necessidade , então o mais indicado é refatorar e armazenar em variáveis
if($permission === 'view' && $this->status > 0 && !$class_name::isPrivateEntity() && !method_exists($this, 'canUserView')) {

7- Em mc-updates no foreach de entidades a entidade que possui permissões EvaluationMethodConfiguration não esta na lista, ou seja, essa entidade é somente verificada indiretamente pelo antigo método recreatePermission que verificava os relacionamento entre as entidades