### PR TITLE
Torna colapsáveis as seções de textos explicativos e selos na config de avaliação

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [UNRELEASED]
 ### Melhorias
 - Ajusta tamanho dos cards da seção "Em destaque" na página inicial
+- Torna colapsáveis as seções de textos explicativos e selos na config de avaliação
 
 ## [7.8.6] - 2026-08-13
 ### Correções

--- a/src/modules/Components/components/mc-accordion/script.js
+++ b/src/modules/Components/components/mc-accordion/script.js
@@ -12,11 +12,15 @@ app.component('mc-accordion', {
             type: Boolean,
             default: false,
         },
+        open: {
+            type: Boolean,
+            default: false,
+        },
     },
 
     data() {
         return {
-            active: false,
+            active: this.open,
         }
     },
     

--- a/src/modules/Opportunities/components/opportunity-phase-config-evaluation/template.php
+++ b/src/modules/Opportunities/components/opportunity-phase-config-evaluation/template.php
@@ -10,6 +10,7 @@ use MapasCulturais\i;
 $this->import('
     entity-field
     fields-visible-evaluators
+    mc-accordion
     mc-confirm-button
     mc-modal
     opportunity-committee-groups
@@ -69,20 +70,28 @@ $evaluation_methods = $app->getRegisteredEvaluationMethods();
         </section>
 
         <section class="evaluation-section col-12">
-            <div class="evaluation-section__header">
-                <span class="title"><?= i::__("Adicionar textos explicativos das avaliações") ?></span>
-            </div>
+            <mc-accordion :withText="true">
+                <template #title>
+                    <div class="evaluation-section__header">
+                        <span class="title"><?= i::__("Adicionar textos explicativos das avaliações") ?></span>
+                    </div>
+                </template>
+                <template #content>
+                    <div class="field evaluation-section__field">
+                        <label for="field-info-general" class="evaluation-section__label semibold"><?= i::__("Texto configuração geral") ?></label>
+                        <textarea id="field-info-general" v-model="phase.infos['general']" @change="savePhase()" class="evaluation-config__area" rows="10"></textarea>
+                    </div>
 
-            <div class="field evaluation-section__field">
-                <label for="field-info-general" class="evaluation-section__label semibold"><?= i::__("Texto configuração geral") ?></label>
-                <textarea id="field-info-general" v-model="phase.infos['general']" @change="savePhase()" class="evaluation-config__area" rows="10"></textarea>
-            </div>
+                    <!-- Keep the category fields in a grid so they keep the original two-column layout inside the accordion content -->
+                    <div class="grid-12">
+                        <div class="col-6 sm:col-12 field evaluation-section__field" v-for="(category, index) in categories">
+                            <label :for="`field-info-${category}`" class="evaluation-section__label semibold" :key="index"> {{ category }}</label>
+                            <textarea :id="`field-info-${category}`" v-model="phase.infos[category]" @change="savePhase()" style="width: 100%" rows="10" class="evaluation-config__input"></textarea>
+                        </div>
+                    </div>
+                </template>
+            </mc-accordion>
         </section>
-
-        <div class="col-6 sm:col-12 field evaluation-section__field" v-for="(category, index) in categories">
-            <label :for="`field-info-${category}`" class="evaluation-section__label semibold" :key="index"> {{ category }}</label>
-            <textarea :id="`field-info-${category}`" v-model="phase.infos[category]" @change="savePhase()" style="width: 100%" rows="10" class="evaluation-config__input"></textarea>
-        </div>
         
         <opportunity-phase-config-status :phase="phase.opportunity"></opportunity-phase-config-status>
 

--- a/src/modules/Opportunities/components/opportunity-phase-config-evaluation/template.php
+++ b/src/modules/Opportunities/components/opportunity-phase-config-evaluation/template.php
@@ -70,7 +70,7 @@ $evaluation_methods = $app->getRegisteredEvaluationMethods();
         </section>
 
         <section class="evaluation-section col-12">
-            <mc-accordion :withText="true">
+            <mc-accordion :withText="true" open>
                 <template #title>
                     <div class="evaluation-section__header">
                         <span class="title"><?= i::__("Adicionar textos explicativos das avaliações") ?></span>

--- a/src/modules/Opportunities/components/seals-certifier/template.php
+++ b/src/modules/Opportunities/components/seals-certifier/template.php
@@ -18,7 +18,7 @@ $this->import('
 ?>
 
 <div v-if="entity.seals.length > 0 || editable" class="seals-certifier col-12">
-    <mc-accordion :withText="true">
+    <mc-accordion :withText="true" open>
         <template #title>
             <h3><?= i::__('Selos certificadores') ?></h3>
         </template>

--- a/src/modules/Opportunities/components/seals-certifier/template.php
+++ b/src/modules/Opportunities/components/seals-certifier/template.php
@@ -9,6 +9,7 @@ use MapasCulturais\i;
 
 $this->import('
    select-entity
+   mc-accordion
    mc-avatar
    mc-confirm-button
    mc-icon
@@ -17,93 +18,99 @@ $this->import('
 ?>
 
 <div v-if="entity.seals.length > 0 || editable" class="seals-certifier col-12">
-    <h3><?= i::__('Selos certificadores') ?></h3>
-    <h4 class="seals-certifier__title bold"> {{title}} <?php i::_e(' para proponentes') ?> </h4>
-    <div class="seals-certifier__proponents">
-        <div v-for="(seals, proponentType) in proponentSeals" :key="proponentType" class="seals-certifier__proponent field">
-            <label v-if="proponentType !== 'default'"><?php i::_e('Selecione o(s) selo(s) para {{ proponentType }}:') ?></label>
-            <label v-else><?php i::_e('Selecione o(s) selo(s) para todos proponentes:') ?></label>
-            <div class="seals-certifier__proponent--seals">
-                <div v-for="seal in seals" :key="seal.id" class="seals-certifier__proponent--seal">
-                    <div class="seal-icon">
-                        <a :href="getSealDetails(seal).singleUrl" class="link">
-                            <div v-if="getSealDetails(seal).files?.avatar" class="image">
-                                <mc-avatar :entity="getSealDetails(seal)" size="small" square></mc-avatar>
+    <mc-accordion :withText="true">
+        <template #title>
+            <h3><?= i::__('Selos certificadores') ?></h3>
+        </template>
+        <template #content>
+            <h4 class="seals-certifier__title bold"> {{title}} <?php i::_e(' para proponentes') ?> </h4>
+            <div class="seals-certifier__proponents">
+                <div v-for="(seals, proponentType) in proponentSeals" :key="proponentType" class="seals-certifier__proponent field">
+                    <label v-if="proponentType !== 'default'"><?php i::_e('Selecione o(s) selo(s) para {{ proponentType }}:') ?></label>
+                    <label v-else><?php i::_e('Selecione o(s) selo(s) para todos proponentes:') ?></label>
+                    <div class="seals-certifier__proponent--seals">
+                        <div v-for="seal in seals" :key="seal.id" class="seals-certifier__proponent--seal">
+                            <div class="seal-icon">
+                                <a :href="getSealDetails(seal).singleUrl" class="link">
+                                    <div v-if="getSealDetails(seal).files?.avatar" class="image">
+                                        <mc-avatar :entity="getSealDetails(seal)" size="small" square></mc-avatar>
+                                    </div>
+                                    <div v-if="!(getSealDetails(seal).files?.avatar)">
+                                        <mc-icon name="seal"></mc-icon>
+                                    </div>
+                                </a>
+                                <div v-if="editable" class="icon">
+                                    <mc-confirm-button @confirm="removeSeal(proponentType, seal, 'proponent')">
+                                        <template #button="modal">
+                                            <mc-icon @click="modal.open()" name="delete"></mc-icon>
+                                        </template>
+                                        <template #message="message">
+                                            <?php i::_e('Remover selo?') ?>
+                                        </template>
+                                    </mc-confirm-button>
+                                </div>
                             </div>
-                            <div v-if="!(getSealDetails(seal).files?.avatar)">
-                                <mc-icon name="seal"></mc-icon>
-                            </div>
-                        </a>
-                        <div v-if="editable" class="icon">
-                            <mc-confirm-button @confirm="removeSeal(proponentType, seal, 'proponent')">
-                                <template #button="modal">
-                                    <mc-icon @click="modal.open()" name="delete"></mc-icon>
-                                </template>
-                                <template #message="message">
-                                    <?php i::_e('Remover selo?') ?>
-                                </template>
-                            </mc-confirm-button>
+                            <span class="seal-label" v-if="showName">{{getSealDetails(seal).name}}</span>
                         </div>
+                        <select-entity
+                            :type="'seal'"
+                            @select="addSeal(proponentType, $event, 'proponent')"
+                            :query="getSealQuery(proponentType, 'proponent')"
+                            openside="down-right"
+                            >
+                            <template #button="{ toggle }">
+                                <div class="seals-certifier__proponent--addSeal" @click="toggle()">
+                                    <mc-icon name="add"></mc-icon>
+                                </div>
+                            </template>
+                        </select-entity>
                     </div>
-                    <span class="seal-label" v-if="showName">{{getSealDetails(seal).name}}</span>
                 </div>
-                <select-entity
-                    :type="'seal'"
-                    @select="addSeal(proponentType, $event, 'proponent')"
-                    :query="getSealQuery(proponentType, 'proponent')"
-                    openside="down-right"
-                    >
-                    <template #button="{ toggle }">
-                        <div class="seals-certifier__proponent--addSeal" @click="toggle()">
-                            <mc-icon name="add"></mc-icon>
-                        </div>
-                    </template>
-                </select-entity>
             </div>
-        </div>
-    </div>
-    
-    <h4 class="seals-certifier__title bold"> {{title}} <?php i::_e(' para categorias') ?> </h4>
-    <div class="seals-certifier__categories">
-        <div v-for="(seals, category) in categorySeals" :key="category" class="seals-certifier__category field">
-            <label v-if="category !== 'default'"><?php i::_e('Selecione o(s) selo(s) para {{ category }}:') ?></label>
-            <label v-else><?php i::_e('Selecione o(s) selo(s) para todas categorias:') ?></label>
-            <div class="seals-certifier__category--seals">
-                <div v-for="seal in seals" :key="seal.id" class="seals-certifier__category--seal">
-                    <div class="seal-icon">
-                        <a :href="getSealDetails(seal).singleUrl" class="link">
-                            <div v-if="getSealDetails(seal).files?.avatar" class="image">
-                                <mc-avatar :entity="getSealDetails(seal)" size="small" square></mc-avatar>
+
+            <h4 class="seals-certifier__title bold"> {{title}} <?php i::_e(' para categorias') ?> </h4>
+            <div class="seals-certifier__categories">
+                <div v-for="(seals, category) in categorySeals" :key="category" class="seals-certifier__category field">
+                    <label v-if="category !== 'default'"><?php i::_e('Selecione o(s) selo(s) para {{ category }}:') ?></label>
+                    <label v-else><?php i::_e('Selecione o(s) selo(s) para todas categorias:') ?></label>
+                    <div class="seals-certifier__category--seals">
+                        <div v-for="seal in seals" :key="seal.id" class="seals-certifier__category--seal">
+                            <div class="seal-icon">
+                                <a :href="getSealDetails(seal).singleUrl" class="link">
+                                    <div v-if="getSealDetails(seal).files?.avatar" class="image">
+                                        <mc-avatar :entity="getSealDetails(seal)" size="small" square></mc-avatar>
+                                    </div>
+                                    <div v-if="!(getSealDetails(seal).files?.avatar)">
+                                        <mc-icon name="seal"></mc-icon>
+                                    </div>
+                                </a>
+                                <div v-if="editable" class="icon">
+                                    <mc-confirm-button @confirm="removeSeal(category, seal, 'category')">
+                                        <template #button="modal">
+                                            <mc-icon @click="modal.open()" name="delete"></mc-icon>
+                                        </template>
+                                        <template #message="message">
+                                            <?php i::_e('Remover selo?') ?>
+                                        </template>
+                                    </mc-confirm-button>
+                                </div>
                             </div>
-                            <div v-if="!(getSealDetails(seal).files?.avatar)">
-                                <mc-icon name="seal"></mc-icon>
-                            </div>
-                        </a>
-                        <div v-if="editable" class="icon">
-                            <mc-confirm-button @confirm="removeSeal(category, seal, 'category')">
-                                <template #button="modal">
-                                    <mc-icon @click="modal.open()" name="delete"></mc-icon>
-                                </template>
-                                <template #message="message">
-                                    <?php i::_e('Remover selo?') ?>
-                                </template>
-                            </mc-confirm-button>
+                            <span class="seal-label" v-if="showName">{{getSealDetails(seal).name}}</span>
                         </div>
+                        <select-entity
+                            :type="'seal'"
+                            @select="addSeal(category, $event, 'category')"
+                            :query="getSealQuery(category, 'category')"
+                            openside="down-right">
+                            <template #button="{ toggle }">
+                                <div class="seals-certifier__category--addSeal" @click="toggle()">
+                                    <mc-icon name="add"></mc-icon>
+                                </div>
+                            </template>
+                        </select-entity>
                     </div>
-                    <span class="seal-label" v-if="showName">{{getSealDetails(seal).name}}</span>
                 </div>
-                <select-entity
-                    :type="'seal'"
-                    @select="addSeal(category, $event, 'category')"
-                    :query="getSealQuery(category, 'category')"
-                    openside="down-right">
-                    <template #button="{ toggle }">
-                        <div class="seals-certifier__category--addSeal" @click="toggle()">
-                            <mc-icon name="add"></mc-icon>
-                        </div>
-                    </template>
-                </select-entity>
             </div>
-        </div>
-    </div>
+        </template>
+    </mc-accordion>
 </div>

--- a/src/themes/BaseV2/assets-src/sass/2.components/_mc-stepper-vertical.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_mc-stepper-vertical.scss
@@ -313,6 +313,48 @@ ol.mc-stepper-vertical>li.active::before {
             border: 1px solid var(--mc-gray-100);
         }
     }
+
+    // Overrides com escopo para o mc-accordion da seção
+    // "Adicionar textos explicativos das avaliações" (não alterar o base).
+    .mc-accordion {
+        background-color: transparent;
+
+        &__header {
+            background-color: transparent;
+            grid-template-columns: 1fr size(124);
+            max-width: 100%;
+            padding: size(8) 0;
+
+            @media (max-width: 488px) {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        &__content {
+            background-color: transparent;
+            border-top: var(--mc-border-hairline) var(--mc-gray-300);
+            max-width: 100%;
+            padding: size(16) 0;
+        }
+
+        &__icon {
+            align-items: center;
+            color: var(--mc-primary-500);
+            display: flex;
+            gap: size(4);
+            justify-content: flex-end;
+
+            @media (max-width: 488px) {
+                justify-content: center;
+            }
+
+            label {
+                font-size: size(14);
+                font-weight: 700;
+                line-height: size(19);
+            }
+        }
+    }
 }
 
 .phase {

--- a/src/themes/BaseV2/assets-src/sass/2.components/_mc-stepper-vertical.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_mc-stepper-vertical.scss
@@ -321,9 +321,10 @@ ol.mc-stepper-vertical>li.active::before {
 
         &__header {
             background-color: transparent;
+            border-bottom: var(--mc-border-hairline) var(--mc-gray-300);
             grid-template-columns: 1fr size(124);
             max-width: 100%;
-            padding: size(8) 0;
+            padding: size(8) 0 size(16);
 
             @media (max-width: 488px) {
                 grid-template-columns: 1fr;
@@ -332,7 +333,9 @@ ol.mc-stepper-vertical>li.active::before {
 
         &__content {
             background-color: transparent;
-            border-top: var(--mc-border-hairline) var(--mc-gray-300);
+            display: flex;
+            flex-direction: column;
+            gap: size(24);
             max-width: 100%;
             padding: size(16) 0;
         }

--- a/src/themes/BaseV2/assets-src/sass/2.components/_seals-certifier.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_seals-certifier.scss
@@ -103,4 +103,46 @@
             cursor: pointer;
         }
     }
+
+    // Overrides com escopo para o mc-accordion de "Selos certificadores"
+    // (não alterar o base — outros consumidores dependem dele).
+    .mc-accordion {
+        background-color: transparent;
+
+        &__header {
+            background-color: transparent;
+            grid-template-columns: 1fr size(124);
+            max-width: 100%;
+            padding: size(8) 0;
+
+            @media (max-width: 488px) {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        &__content {
+            background-color: transparent;
+            border-top: var(--mc-border-hairline) var(--mc-gray-300);
+            max-width: 100%;
+            padding: size(16) 0;
+        }
+
+        &__icon {
+            align-items: center;
+            color: var(--mc-primary-500);
+            display: flex;
+            gap: size(4);
+            justify-content: flex-end;
+
+            @media (max-width: 488px) {
+                justify-content: center;
+            }
+
+            label {
+                font-size: size(14);
+                font-weight: 700;
+                line-height: size(19);
+            }
+        }
+    }
 }

--- a/src/themes/BaseV2/assets-src/sass/2.components/_seals-certifier.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_seals-certifier.scss
@@ -111,9 +111,10 @@
 
         &__header {
             background-color: transparent;
+            border-bottom: var(--mc-border-hairline) var(--mc-gray-300);
             grid-template-columns: 1fr size(124);
             max-width: 100%;
-            padding: size(8) 0;
+            padding: size(8) 0 size(16);
 
             @media (max-width: 488px) {
                 grid-template-columns: 1fr;
@@ -122,7 +123,6 @@
 
         &__content {
             background-color: transparent;
-            border-top: var(--mc-border-hairline) var(--mc-gray-300);
             max-width: 100%;
             padding: size(16) 0;
         }


### PR DESCRIPTION
## O que faz

Torna colapsáveis as seções "Adicionar textos explicativos das avaliações" e "Selos certificadores" na configuração de fase de avaliação de uma oportunidade, usando o componente `mc-accordion` do design system interno (mesmo padrão da tela de configuração de fase de recurso). As seções iniciam **expandidas** e podem ser recolhidas/expandidas independentemente. Nenhum comportamento funcional foi alterado (autosave dos textos, adição/remoção de selos preservados).

## Mudanças

- `opportunity-phase-config-evaluation/template.php` e `seals-certifier/template.php`: seções envolvidas em `mc-accordion :withText="true" open`
- `mc-accordion/script.js`: nova prop opcional `open` (default `false`, retrocompatível — demais consumidores inalterados)
- `_mc-stepper-vertical.scss` e `_seals-certifier.scss`: overrides com escopo para layout do accordion nestes contextos (header full-width, ícone expandir/diminuir alinhado, hairline sob o título sempre visível, espaçamento entre campos)

## Validação

Verificado no browser (configuração de fase de avaliação): estado inicial expandido, toggle expandir/recolher funcionando, edição e salvamento dos textos e selos preservados.

Ref.: #26