### PR TITLE
PR3 — Publicação preliminar e final (APPEAL_TWO_STAGE_PUBLISH)

### DIFF
--- a/src/core/Controllers/Opportunity.php
+++ b/src/core/Controllers/Opportunity.php
@@ -185,6 +185,54 @@ class Opportunity extends EntityController {
     }
 
     /**
+     * Publica o resultado preliminar das inscrições (APPEAL_TWO_STAGE_PUBLISH).
+     */
+    function ALL_publishPreliminaryRegistrations(){
+        $this->requireAuthentication();
+
+        $app = App::i();
+
+        $opportunity = $this->requestedEntity;
+
+        if(!$opportunity) {
+            $app->pass();
+        }
+
+        $opportunity->registerRegistrationMetadata();
+        $opportunity->publishPreliminaryRegistrations();
+
+        if($this->isAjax()){
+            $this->json($opportunity);
+        }else{
+            $app->redirect($app->request->getReferer());
+        }
+    }
+
+    /**
+     * Despublica o resultado preliminar das inscrições (APPEAL_TWO_STAGE_PUBLISH).
+     */
+    function ALL_unPublishPreliminaryRegistrations() {
+        $this->requireAuthentication();
+
+        $app = App::i();
+
+        $opportunity = $this->requestedEntity;
+
+        if (!$opportunity) {
+            $app->pass();
+        }
+
+        $opportunity->registerRegistrationMetadata();
+        $opportunity->unPublishPreliminaryRegistrations();
+
+        if ($this->isAjax()) {
+            $this->json($opportunity);
+        } else {
+            $app->redirect($app->request->getReferer());
+        }
+    }
+
+    /**
     * Despublica as inscrições de uma oportunidade
     * 
     * Esta ação requer autenticação e permissão na oportunidade.

--- a/src/core/Entities/Opportunity.php
+++ b/src/core/Entities/Opportunity.php
@@ -25,6 +25,7 @@ use MapasCulturais\EvaluationMethod;
  * @property-read boolean $autoPublish
  * @property \DateTime $publishTimestamp
  * @property-read boolean $publishedRegistrations
+ * @property boolean $publishedPreliminaryRegistrations
  * @property-read int $totalRegistrations
  *
  *
@@ -1133,6 +1134,84 @@ abstract class Opportunity extends \MapasCulturais\Entity
         $app->applyHookBoundTo($this, "entity({$this->getHookClassPath()}).publishRegistrations:after");
 
         $app->em->commit();
+    }
+
+    /**
+     * Publica o resultado preliminar da fase avaliativa (sem aplicar selos).
+     * Requer feature flag APPEAL_TWO_STAGE_PUBLISH.
+     * Não altera publishedRegistrations (resultado final).
+     */
+    function publishPreliminaryRegistrations(){
+        $this->assertTwoStagePublishEnabled();
+        $this->checkPermission('publishRegistrations');
+
+        $app = App::i();
+        $app->em->beginTransaction();
+
+        $app->applyHookBoundTo($this, "entity({$this->getHookClassPath()}).publishPreliminaryRegistrations:before");
+
+        $this->publishedPreliminaryRegistrations = true;
+        $this->save(true);
+
+        $app->applyHookBoundTo($this, "entity({$this->getHookClassPath()}).publishPreliminaryRegistrations:after");
+
+        $app->em->commit();
+    }
+
+    /**
+     * Despublica o resultado preliminar. Não afeta publishedRegistrations nem selos.
+     */
+    function unPublishPreliminaryRegistrations()
+    {
+        $this->assertTwoStagePublishEnabled();
+        $this->checkPermission('publishRegistrations');
+
+        $app = App::i();
+        $app->em->beginTransaction();
+
+        $app->applyHookBoundTo($this, "entity({$this->getHookClassPath()}).unPublishPreliminaryRegistrations:before");
+
+        $this->publishedPreliminaryRegistrations = false;
+        $this->save(true);
+
+        $app->applyHookBoundTo($this, "entity({$this->getHookClassPath()}).unPublishPreliminaryRegistrations:after");
+
+        $app->em->commit();
+    }
+
+    /**
+     * Resultado visível ao proponente/público: final OU preliminar (com flag ON).
+     */
+    function areRegistrationResultsPublished(): bool
+    {
+        if ($this->publishedRegistrations) {
+            return true;
+        }
+
+        if (!$this->isTwoStagePublishEnabled()) {
+            return false;
+        }
+
+        return (bool) $this->publishedPreliminaryRegistrations;
+    }
+
+    protected function isTwoStagePublishEnabled(): bool
+    {
+        $module = App::i()->modules['OpportunityAppealPhase'] ?? null;
+        if ($module && method_exists($module, 'isTwoStagePublishEnabled')) {
+            return $module->isTwoStagePublishEnabled();
+        }
+
+        return (bool) env('APPEAL_TWO_STAGE_PUBLISH', false);
+    }
+
+    protected function assertTwoStagePublishEnabled(): void
+    {
+        if ($this->isTwoStagePublishEnabled()) {
+            return;
+        }
+
+        throw new PermissionDenied(App::i()->user, $this, 'publishPreliminaryRegistrations');
     }
 
     function unPublishRegistrations()

--- a/src/core/Entities/Registration.php
+++ b/src/core/Entities/Registration.php
@@ -477,7 +477,7 @@ class Registration extends \MapasCulturais\Entity
             }
         }
 
-        if($this->opportunity->publishedRegistrations || $this->opportunity->canUser('@control') || $this->status == self::STATUS_DRAFT) {
+        if($this->opportunity->areRegistrationResultsPublished() || $this->opportunity->canUser('@control') || $this->status == self::STATUS_DRAFT) {
             $json['status'] = $this->status;
         }
 

--- a/src/core/EvaluationMethod.php
+++ b/src/core/EvaluationMethod.php
@@ -562,7 +562,7 @@ abstract class EvaluationMethod extends Module implements \JsonSerializable{
      */
     function shouldDisplayEvaluationResults(Registration $registration): bool
     {
-        return $registration->opportunity->publishedRegistrations && $registration->opportunity->evaluationMethodConfiguration->publishEvaluationDetails;
+        return $registration->opportunity->areRegistrationResultsPublished() && $registration->opportunity->evaluationMethodConfiguration->publishEvaluationDetails;
     }
 
     /**
@@ -1819,7 +1819,7 @@ abstract class EvaluationMethod extends Module implements \JsonSerializable{
     function canUserViewConsolidatedResult(Entities\Registration $registration){
         $opp = $registration->opportunity;
 
-        if($opp->publishedRegistrations || $opp->canUser('@control')){
+        if($opp->areRegistrationResultsPublished() || $opp->canUser('@control')){
             return true;
         } else {
             return false;

--- a/src/modules/OpportunityAppealPhase/Module.php
+++ b/src/modules/OpportunityAppealPhase/Module.php
@@ -17,6 +17,7 @@ class Module extends \MapasCulturais\Module {
     {
         $config += [
             'sendMailNotification.opportunityAppealPhase' => env('SEND_MAIL_OPPORTUNITY_APPEAL_PHASE', false),
+            'featureFlag.appealTwoStagePublish' => env('APPEAL_TWO_STAGE_PUBLISH', false),
         ];
 
         parent::__construct($config);
@@ -313,6 +314,13 @@ class Module extends \MapasCulturais\Module {
             'default' => false,
         ]);
 
+        $this->registerOpportunityMetadata('publishedPreliminaryRegistrations', [
+            'label' => i::__('Resultado preliminar das inscrições publicado'),
+            'type'  => 'boolean',
+            'default' => false,
+            'private' => false,
+        ]);
+
         $this->registerEvauationMethodConfigurationMetadata('appealPhase', [
             'label'     => i::__('Indica se é uma fase de recurso'),
             'type'      => 'entity',
@@ -323,6 +331,11 @@ class Module extends \MapasCulturais\Module {
                 return $evaluationMethodConfiguration->opportunity->appealPhase;
             }
         ]);
+    }
+
+    public function isTwoStagePublishEnabled(): bool
+    {
+        return (bool) env('APPEAL_TWO_STAGE_PUBLISH', $this->config['featureFlag.appealTwoStagePublish']);
     }
 
     /**

--- a/tests/src/AppealTwoStagePublishTest.php
+++ b/tests/src/AppealTwoStagePublishTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tests;
+
+use MapasCulturais\App;
+use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\Exceptions\PermissionDenied;
+use Tests\Abstract\TestCase;
+use Tests\Builders\PhasePeriods\ConcurrentEndingAfter;
+use Tests\Builders\PhasePeriods\Open;
+use Tests\Enums\EvaluationMethods;
+use Tests\Traits\OpportunityBuilder;
+use Tests\Traits\RegistrationDirector;
+use Tests\Traits\UserDirector;
+
+class AppealTwoStagePublishTest extends TestCase
+{
+    use OpportunityBuilder,
+        RegistrationDirector,
+        UserDirector;
+
+    private function createEvaluatedOpportunityScenario(): array
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $evaluation_phase_builder = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase(EvaluationMethods::simple)
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->save()
+                ->addValuer('Comissão', 'Avaliador 1', $admin->profile)
+                    ->done()
+                ->done();
+
+        /** @var Opportunity $opportunity */
+        $opportunity = $evaluation_phase_builder->getInstance();
+        $registration = $this->registrationDirector->createSentRegistration($opportunity, data: []);
+
+        return compact('admin', 'opportunity', 'registration');
+    }
+
+    private function enableTwoStagePublish(): void
+    {
+        $_ENV['APPEAL_TWO_STAGE_PUBLISH'] = 'true';
+    }
+
+    private function disableTwoStagePublish(): void
+    {
+        unset($_ENV['APPEAL_TWO_STAGE_PUBLISH']);
+        putenv('APPEAL_TWO_STAGE_PUBLISH');
+    }
+
+    function testFlagOffBlocksPreliminaryPublish(): void
+    {
+        $this->disableTwoStagePublish();
+
+        ['opportunity' => $opportunity] = $this->createEvaluatedOpportunityScenario();
+
+        $this->expectException(PermissionDenied::class);
+        $opportunity->publishPreliminaryRegistrations();
+    }
+
+    function testFlagOffPreservesFinalPublish(): void
+    {
+        $this->disableTwoStagePublish();
+
+        ['opportunity' => $opportunity] = $this->createEvaluatedOpportunityScenario();
+
+        $app = App::i();
+        $app->disableAccessControl();
+        $opportunity->publishRegistrations();
+        $app->enableAccessControl();
+
+        $opportunity->refresh();
+        $this->assertTrue($opportunity->publishedRegistrations);
+        $this->assertTrue($opportunity->areRegistrationResultsPublished());
+        $this->assertFalse((bool) $opportunity->publishedPreliminaryRegistrations);
+    }
+
+    function testPreliminaryThenFinalPublish(): void
+    {
+        $this->enableTwoStagePublish();
+
+        ['admin' => $admin, 'opportunity' => $opportunity, 'registration' => $registration] = $this->createEvaluatedOpportunityScenario();
+
+        $proponent = $registration->owner->user;
+
+        $this->assertFalse($opportunity->areRegistrationResultsPublished());
+
+        $this->login($proponent);
+        $this->assertFalse($registration->canUser('viewConsolidatedResult'));
+
+        $this->login($admin);
+        $opportunity->publishPreliminaryRegistrations();
+        $opportunity->refresh();
+
+        $this->assertTrue((bool) $opportunity->publishedPreliminaryRegistrations);
+        $this->assertFalse($opportunity->publishedRegistrations);
+        $this->assertTrue($opportunity->areRegistrationResultsPublished());
+
+        $registration = App::i()->repo('Registration')->find($registration->id);
+        $this->login($proponent);
+        $this->assertTrue($registration->canUser('viewConsolidatedResult'));
+
+        $this->login($admin);
+        $opportunity->publishRegistrations();
+        $opportunity->refresh();
+
+        $this->assertTrue($opportunity->publishedRegistrations);
+        $this->assertTrue((bool) $opportunity->publishedPreliminaryRegistrations);
+        $this->assertTrue($opportunity->areRegistrationResultsPublished());
+    }
+
+    function testUnpublishPreliminaryDoesNotTouchFinal(): void
+    {
+        $this->enableTwoStagePublish();
+
+        ['opportunity' => $opportunity] = $this->createEvaluatedOpportunityScenario();
+
+        $opportunity->publishPreliminaryRegistrations();
+        $opportunity->publishRegistrations();
+        $opportunity->refresh();
+
+        $opportunity->unPublishPreliminaryRegistrations();
+        $opportunity->refresh();
+
+        $this->assertFalse((bool) $opportunity->publishedPreliminaryRegistrations);
+        $this->assertTrue($opportunity->publishedRegistrations);
+        $this->assertTrue($opportunity->areRegistrationResultsPublished());
+    }
+}


### PR DESCRIPTION
## Summary
Fecha a tarefa Stage 3 do épico #7:
- Closes #12 — PR3: publicação preliminar + final da fase avaliativa

## Conteúdo
- Metadado `publishedPreliminaryRegistrations` na `Opportunity`
- `publishPreliminaryRegistrations()` / `unPublishPreliminaryRegistrations()` (sem selos; não altera o final)
- Endpoints `ALL_publishPreliminaryRegistrations` / `ALL_unPublishPreliminaryRegistrations`
- Feature flag `APPEAL_TWO_STAGE_PUBLISH` (default OFF)
- Visibilidade do proponente via `areRegistrationResultsPublished()` (final **ou** preliminar com flag ON)
- BC: `publishedRegistrations` continua sendo o resultado final

## Validação
`tests/src/AppealTwoStagePublishTest.php` — **4 testes / 16 assertions / OK**

## Test plan
- [x] Flag OFF bloqueia publish preliminar (`PermissionDenied`)
- [x] Flag OFF preserva publish final atual
- [x] Preliminar → proponente vê consolidado; final depois sem limpar preliminar
- [x] Unpublish preliminar não desfaz o final