### PR TITLE
PR4.5 — Endpoint read-only do ambiente do corretor designado

### DIFF
--- a/src/db-updates.php
+++ b/src/db-updates.php
@@ -3539,7 +3539,9 @@ $$
             return true;
         }
 
-        __exec("CREATE SEQUENCE registration_appeal_review_id_seq INCREMENT BY 1 MINVALUE 1 START 1;");
+        if (!__sequence_exists('registration_appeal_review_id_seq')) {
+            __exec("CREATE SEQUENCE registration_appeal_review_id_seq INCREMENT BY 1 MINVALUE 1 START 1;");
+        }
 
         __exec("CREATE TABLE registration_appeal_review (
             id INT NOT NULL,
@@ -3562,6 +3564,8 @@ $$
             update_timestamp TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
             PRIMARY KEY(id));");
 
+        __exec("ALTER TABLE ONLY registration_appeal_review ALTER COLUMN id SET DEFAULT nextval('registration_appeal_review_id_seq'::regclass);");
+
         __exec("CREATE INDEX idx_registration_appeal_review_original_evaluation_id ON registration_appeal_review (original_evaluation_id);");
         __exec("CREATE INDEX idx_registration_appeal_review_registration_id ON registration_appeal_review (registration_id);");
         __exec("CREATE INDEX idx_registration_appeal_review_appeal_phase_id ON registration_appeal_review (appeal_phase_id);");
@@ -3574,8 +3578,8 @@ $$
         __exec("ALTER TABLE registration_appeal_review ADD CONSTRAINT fk_registration_appeal_review_slot_owner_user_id FOREIGN KEY (slot_owner_user_id) REFERENCES usr (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
         __exec("ALTER TABLE registration_appeal_review ADD CONSTRAINT fk_registration_appeal_review_corrector_user_id FOREIGN KEY (corrector_user_id) REFERENCES usr (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
 
-        // Índice único parcial: impede duas designações ativas (status 0 ou 1) para a mesma avaliação original.
-        __exec("CREATE UNIQUE INDEX idx_registration_appeal_review_active_slot ON registration_appeal_review (original_evaluation_id) WHERE status IN (0, 1);");
+        // Índice único parcial: impede duas designações ativas (designado/rascunho/reaberto) para o mesmo slot.
+        __exec("CREATE UNIQUE INDEX idx_registration_appeal_review_active_slot ON registration_appeal_review (original_evaluation_id) WHERE status IN (0, 1, 3);");
     },
 
 ] + $updates ;

--- a/src/db-updates.php
+++ b/src/db-updates.php
@@ -3533,4 +3533,49 @@ $$
             WHERE seal_exemption_status IS NOT NULL");
     },
 
+    'create registration_appeal_review table' => function () {
+        if (__table_exists('registration_appeal_review')) {
+            echo "ALREADY APPLIED";
+            return true;
+        }
+
+        __exec("CREATE SEQUENCE registration_appeal_review_id_seq INCREMENT BY 1 MINVALUE 1 START 1;");
+
+        __exec("CREATE TABLE registration_appeal_review (
+            id INT NOT NULL,
+            original_evaluation_id INT NOT NULL,
+            registration_id INT NOT NULL,
+            appeal_phase_id INT NOT NULL,
+            slot_owner_user_id INT NOT NULL,
+            corrector_user_id INT NOT NULL,
+            status SMALLINT NOT NULL DEFAULT 0,
+            correction_type VARCHAR(20) NOT NULL,
+            released_scope JSONB DEFAULT NULL,
+            starts_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+            ends_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+            original_value JSONB DEFAULT NULL,
+            corrected_value JSONB DEFAULT NULL,
+            original_score DOUBLE PRECISION DEFAULT NULL,
+            corrected_score DOUBLE PRECISION DEFAULT NULL,
+            create_timestamp TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+            sent_timestamp TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+            update_timestamp TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+            PRIMARY KEY(id));");
+
+        __exec("CREATE INDEX idx_registration_appeal_review_original_evaluation_id ON registration_appeal_review (original_evaluation_id);");
+        __exec("CREATE INDEX idx_registration_appeal_review_registration_id ON registration_appeal_review (registration_id);");
+        __exec("CREATE INDEX idx_registration_appeal_review_appeal_phase_id ON registration_appeal_review (appeal_phase_id);");
+        __exec("CREATE INDEX idx_registration_appeal_review_slot_owner_user_id ON registration_appeal_review (slot_owner_user_id);");
+        __exec("CREATE INDEX idx_registration_appeal_review_corrector_user_id ON registration_appeal_review (corrector_user_id);");
+
+        __exec("ALTER TABLE registration_appeal_review ADD CONSTRAINT fk_registration_appeal_review_original_evaluation_id FOREIGN KEY (original_evaluation_id) REFERENCES registration_evaluation (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
+        __exec("ALTER TABLE registration_appeal_review ADD CONSTRAINT fk_registration_appeal_review_registration_id FOREIGN KEY (registration_id) REFERENCES registration (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
+        __exec("ALTER TABLE registration_appeal_review ADD CONSTRAINT fk_registration_appeal_review_appeal_phase_id FOREIGN KEY (appeal_phase_id) REFERENCES opportunity (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
+        __exec("ALTER TABLE registration_appeal_review ADD CONSTRAINT fk_registration_appeal_review_slot_owner_user_id FOREIGN KEY (slot_owner_user_id) REFERENCES usr (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
+        __exec("ALTER TABLE registration_appeal_review ADD CONSTRAINT fk_registration_appeal_review_corrector_user_id FOREIGN KEY (corrector_user_id) REFERENCES usr (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;");
+
+        // Índice único parcial: impede duas designações ativas (status 0 ou 1) para a mesma avaliação original.
+        __exec("CREATE UNIQUE INDEX idx_registration_appeal_review_active_slot ON registration_appeal_review (original_evaluation_id) WHERE status IN (0, 1);");
+    },
+
 ] + $updates ;

--- a/src/modules/OpportunityAppealPhase/AppealReview/CorrectorEnvironment.php
+++ b/src/modules/OpportunityAppealPhase/AppealReview/CorrectorEnvironment.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace OpportunityAppealPhase\AppealReview;
+
+use DateTime;
+use MapasCulturais\App;
+use MapasCulturais\Entities\RegistrationEvaluation;
+use MapasCulturais\Exceptions\PermissionDenied;
+use MapasCulturais\i;
+use OpportunityAppealPhase\Entities\RegistrationAppealReview;
+use OpportunityAppealPhase\Module;
+
+/**
+ * Monta o payload read-only do ambiente do corretor (PR4.5 / issue #14).
+ */
+class CorrectorEnvironment
+{
+    private const STATUS_LABELS = [
+        RegistrationAppealReview::STATUS_DESIGNATED => 'designated',
+        RegistrationAppealReview::STATUS_DRAFT => 'draft',
+        RegistrationAppealReview::STATUS_SENT => 'sent',
+        RegistrationAppealReview::STATUS_REOPENED => 'reopened',
+    ];
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function build(RegistrationAppealReview $review): array
+    {
+        $app = App::i();
+        $this->assertFeatureEnabled();
+        $this->assertCanAccess($review, $app->user);
+
+        $slot = $review->originalEvaluation;
+        $scope_ids = $this->getReleasedCriteriaIds($review);
+
+        $original = $this->filterEvaluationData((array) $slot->getEvaluationData(), $scope_ids);
+        $draft = $review->correctedValue
+            ? $this->filterEvaluationData((array) $review->correctedValue, $scope_ids)
+            : null;
+
+        $payload = [
+            'assignmentId' => (int) $review->id,
+            'targetEvaluatorName' => $this->resolveEvaluatorName($review),
+            'deadline' => $review->endsAt ? $review->endsAt->format('c') : null,
+            'status' => self::STATUS_LABELS[(int) $review->status] ?? (string) $review->status,
+            'correctionType' => $review->correctionType,
+            'originalEvaluation' => (object) $original,
+            'draft' => $draft !== null ? (object) $draft : null,
+        ];
+
+        if ($this->shouldShowAppealOpinion($review)) {
+            $payload['committeeOpinion'] = $this->buildCommitteeOpinion($review);
+        }
+
+        return $payload;
+    }
+
+    private function assertCanAccess(RegistrationAppealReview $review, $user): void
+    {
+        if ($user->is('guest')) {
+            throw new PermissionDenied($user, $review, 'correctorEnvironment');
+        }
+
+        if (!$review->isActive()) {
+            throw new PermissionDenied($user, $review, 'correctorEnvironment');
+        }
+
+        if (!$review->correctorUser || !$review->correctorUser->equals($user)) {
+            throw new PermissionDenied($user, $review, 'correctorEnvironment');
+        }
+
+        $now = new DateTime();
+        if ($review->startsAt && $now < $review->startsAt) {
+            throw new PermissionDenied($user, $review, 'correctorEnvironment');
+        }
+        if ($review->endsAt && $now > $review->endsAt) {
+            throw new PermissionDenied($user, $review, 'correctorEnvironment');
+        }
+    }
+
+    private function assertFeatureEnabled(): void
+    {
+        $module = App::i()->modules['OpportunityAppealPhase'] ?? null;
+        $default = false;
+        if ($module instanceof Module) {
+            $default = (bool) ($module->config['featureFlag.appealScoreCorrection'] ?? false);
+        }
+
+        if (!(bool) env('APPEAL_SCORE_CORRECTION', $default)) {
+            throw new PermissionDenied(App::i()->user, null, 'correctorEnvironment');
+        }
+    }
+
+    private function resolveEvaluatorName(RegistrationAppealReview $review): string
+    {
+        $owner = $review->slotOwnerUser;
+        if ($owner && $owner->profile) {
+            return (string) $owner->profile->name;
+        }
+
+        return $owner ? (string) $owner->email : '';
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @param string[]|null $scope_ids
+     * @return array<string, mixed>
+     */
+    private function filterEvaluationData(array $data, ?array $scope_ids): array
+    {
+        if ($scope_ids === null) {
+            return $data;
+        }
+
+        $filtered = [];
+        foreach ($data as $key => $value) {
+            if (in_array((string) $key, $scope_ids, true)) {
+                $filtered[$key] = $value;
+            }
+        }
+
+        return $filtered;
+    }
+
+    private function shouldShowAppealOpinion(RegistrationAppealReview $review): bool
+    {
+        $scope = $review->releasedScope;
+        if ($scope === null) {
+            return false;
+        }
+
+        $scope = (array) $scope;
+        return !empty($scope['showAppealOpinion']);
+    }
+
+    /**
+     * Parecer da Comissão de Recursos na fase de recurso (mesma inscrição por number).
+     *
+     * @return array<string, mixed>|null
+     */
+    private function buildCommitteeOpinion(RegistrationAppealReview $review): ?array
+    {
+        $app = App::i();
+        $appeal_phase = $review->appealPhase;
+        $registration = $review->registration;
+
+        if (!$appeal_phase || !$registration) {
+            return null;
+        }
+
+        $appeal_registration = $app->repo('Registration')->findOneBy([
+            'opportunity' => $appeal_phase,
+            'number' => $registration->number,
+        ]);
+
+        if (!$appeal_registration) {
+            return null;
+        }
+
+        /** @var RegistrationEvaluation[] $evaluations */
+        $evaluations = $app->repo('RegistrationEvaluation')->findBy([
+            'registration' => $appeal_registration,
+        ]);
+
+        if (!$evaluations) {
+            return null;
+        }
+
+        $opinions = [];
+        foreach ($evaluations as $evaluation) {
+            if ((int) $evaluation->status < RegistrationEvaluation::STATUS_EVALUATED) {
+                continue;
+            }
+
+            $opinions[] = [
+                'evaluationId' => (int) $evaluation->id,
+                'result' => $evaluation->result,
+                'resultString' => $evaluation->resultString,
+                'status' => (int) $evaluation->status,
+                'evaluationData' => $evaluation->getEvaluationData(),
+                'valuerName' => $evaluation->user->profile->name ?? $evaluation->user->email,
+            ];
+        }
+
+        if (!$opinions) {
+            return null;
+        }
+
+        return [
+            'registrationId' => (int) $appeal_registration->id,
+            'evaluations' => $opinions,
+        ];
+    }
+
+    /**
+     * @return string[]|null
+     */
+    private function getReleasedCriteriaIds(RegistrationAppealReview $review): ?array
+    {
+        $scope = $review->releasedScope;
+        if ($scope === null) {
+            return null;
+        }
+
+        $scope = (array) $scope;
+        $criteria = $scope['criteria'] ?? $scope['fields'] ?? null;
+
+        if ($criteria === null) {
+            return null;
+        }
+
+        return array_map('strval', (array) $criteria);
+    }
+}

--- a/src/modules/OpportunityAppealPhase/AppealReview/Service.php
+++ b/src/modules/OpportunityAppealPhase/AppealReview/Service.php
@@ -1,0 +1,316 @@
+<?php
+
+namespace OpportunityAppealPhase\AppealReview;
+
+use DateTime;
+use MapasCulturais\App;
+use MapasCulturais\Entities\EntityRevision;
+use MapasCulturais\Entities\RegistrationEvaluation;
+use MapasCulturais\Exceptions\PermissionDenied;
+use MapasCulturais\i;
+use OpportunityAppealPhase\Entities\RegistrationAppealReview;
+use OpportunityAppealPhase\Module;
+
+/**
+ * Aplica correção de nota pós-recurso sobre o slot original (RegistrationEvaluation).
+ *
+ * Spec: AppealReview\Service::applyCorrection (PR4 / issue #13).
+ */
+class Service
+{
+    /**
+     * Aplica a correção in-place no slot designado e reconsolida a inscrição.
+     *
+     * Os dados corrigidos vêm de `$review->correctedValue` (rascunho) ou do
+     * parâmetro opcional `$corrected_data` (atalho para envio em um passo).
+     *
+     * @param RegistrationAppealReview $review Designação ativa
+     * @param array|object|null $corrected_data Dados de avaliação (critérios)
+     */
+    public function applyCorrection(RegistrationAppealReview $review, array|object|null $corrected_data = null): RegistrationAppealReview
+    {
+        $app = App::i();
+        $this->assertFeatureEnabled();
+
+        if (!$review->isActive()) {
+            throw new PermissionDenied($app->user, $review, 'applyCorrection');
+        }
+
+        $slot = $review->originalEvaluation;
+        if (!$slot) {
+            throw new PermissionDenied($app->user, $review, 'applyCorrection');
+        }
+
+        $user = $app->user;
+        if ($user->is('guest') || !$review->correctorUser || !$review->correctorUser->equals($user)) {
+            throw new PermissionDenied($user, $review, 'applyCorrection');
+        }
+
+        $this->assertWithinWindow($review);
+        $this->assertTechnicalSlot($slot);
+
+        if ($corrected_data !== null) {
+            $review->correctedValue = (object) (array) $corrected_data;
+        }
+
+        $incoming = (array) ($review->correctedValue ?: []);
+        if (!$incoming) {
+            throw new \InvalidArgumentException(i::__('Dados da correção são obrigatórios.'));
+        }
+
+        $merged = $this->mergeWithinReleasedScope($slot, $review, $incoming);
+        $corrected_score = $this->computeScore($slot, $merged);
+
+        if ($review->originalValue === null) {
+            $review->originalValue = $slot->getEvaluationData();
+        }
+        if ($review->originalScore === null) {
+            $review->originalScore = is_numeric($slot->result) ? (float) $slot->result : null;
+        }
+
+        $is_official = $review->correctionType !== RegistrationAppealReview::CORRECTION_TYPE_RECORD;
+
+        $revision_message = sprintf(
+            i::__('Correção de recurso (tipo %s) pelo usuário %s no slot de avaliação #%s (avaliador original #%s).'),
+            $review->correctionType ?: RegistrationAppealReview::CORRECTION_TYPE_OFFICIAL,
+            $user->id,
+            $slot->id,
+            $slot->user->id
+        );
+
+        $app->em->beginTransaction();
+
+        try {
+            $app->disableAccessControl();
+
+            if ($is_official) {
+                $this->applyOfficialCorrection($slot, $merged, $revision_message);
+            } else {
+                $this->applyRecordCorrection($slot, $merged, $revision_message);
+            }
+
+            $review->correctedValue = (object) $merged;
+            $review->correctedScore = $corrected_score;
+            $review->status = RegistrationAppealReview::STATUS_SENT;
+            $review->sentTimestamp = new DateTime();
+            $review->save(true);
+
+            $app->enableAccessControl();
+            $app->em->commit();
+        } catch (\Throwable $e) {
+            $app->em->rollback();
+            if (!$app->isAccessControlEnabled()) {
+                $app->enableAccessControl();
+            }
+            throw $e;
+        }
+
+        return $review;
+    }
+
+    /**
+     * Persiste rascunho da correção sem alterar a nota oficial.
+     */
+    public function saveDraft(RegistrationAppealReview $review, array|object $corrected_data): RegistrationAppealReview
+    {
+        $app = App::i();
+        $this->assertFeatureEnabled();
+
+        if (!$review->isActive()) {
+            throw new PermissionDenied($app->user, $review, 'saveDraft');
+        }
+
+        $user = $app->user;
+        if ($user->is('guest') || !$review->correctorUser || !$review->correctorUser->equals($user)) {
+            throw new PermissionDenied($user, $review, 'saveDraft');
+        }
+
+        $this->assertWithinWindow($review);
+
+        $slot = $review->originalEvaluation;
+        $incoming = (array) $corrected_data;
+        $merged = $this->mergeWithinReleasedScope($slot, $review, $incoming);
+
+        if ($review->originalValue === null) {
+            $review->originalValue = $slot->getEvaluationData();
+        }
+        if ($review->originalScore === null) {
+            $review->originalScore = is_numeric($slot->result) ? (float) $slot->result : null;
+        }
+
+        $review->correctedValue = (object) $merged;
+        $review->correctedScore = $this->computeScore($slot, $merged);
+        if ($review->status === RegistrationAppealReview::STATUS_DESIGNATED) {
+            $review->status = RegistrationAppealReview::STATUS_DRAFT;
+        }
+        $review->save(true);
+
+        return $review;
+    }
+
+    private function applyOfficialCorrection(RegistrationEvaluation $slot, array $merged, string $revision_message): void
+    {
+        $app = App::i();
+
+        $slot->setEvaluationData((object) $merged);
+        $slot->status = RegistrationEvaluation::STATUS_SENT;
+        if (!$slot->sentTimestamp) {
+            $slot->sentTimestamp = new DateTime();
+        }
+        // save() gera revisão padrão; sobrescrevemos a mensagem logo em seguida.
+        $slot->save(true);
+        $this->setLastRevisionMessage($slot, $revision_message);
+
+        $registration = $slot->registration;
+        $registration->consolidateResult(true, $slot);
+
+        $app->enqueueEntityToPCacheRecreation($registration);
+        $app->persistPCachePendingQueue();
+    }
+
+    /**
+     * correction_type=record: grava revisão de auditoria sem alterar evaluationData/consolidação.
+     */
+    private function applyRecordCorrection(RegistrationEvaluation $slot, array $merged, string $revision_message): void
+    {
+        $message = $revision_message . ' ' . i::__('(somente registro — nota oficial não alterada)');
+
+        $revision_data = $slot->_getRevisionData();
+        $revision_data['appealCorrectionRecord'] = [
+            'correctedEvaluationData' => $merged,
+            'note' => 'record',
+        ];
+
+        $revision = new EntityRevision(
+            $revision_data,
+            $slot,
+            EntityRevision::ACTION_MODIFIED,
+            $message,
+            flush: true
+        );
+
+        if ($revision->modified) {
+            $revision->save(true);
+        } else {
+            // Garante revisão de auditoria mesmo sem mudança no evaluationData oficial
+            $revision->save(true);
+        }
+    }
+
+    private function setLastRevisionMessage(RegistrationEvaluation $slot, string $message): void
+    {
+        $revision = $slot->getLastRevision();
+        if (!$revision) {
+            return;
+        }
+
+        $revision->message = $message;
+        $revision->save(true);
+    }
+
+    private function computeScore(RegistrationEvaluation $slot, array $evaluation_data): ?float
+    {
+        $tmp = new RegistrationEvaluation();
+        $tmp->registration = $slot->registration;
+        $tmp->user = $slot->user;
+        $tmp->setEvaluationData((object) $evaluation_data);
+
+        return is_numeric($tmp->result) ? (float) $tmp->result : null;
+    }
+
+    private function assertFeatureEnabled(): void
+    {
+        $module = App::i()->modules['OpportunityAppealPhase'] ?? null;
+        $default = false;
+        if ($module instanceof Module) {
+            $default = (bool) ($module->config['featureFlag.appealScoreCorrection'] ?? false);
+        }
+
+        if (!(bool) env('APPEAL_SCORE_CORRECTION', $default)) {
+            throw new PermissionDenied(App::i()->user, null, 'applyCorrection');
+        }
+    }
+
+    private function assertWithinWindow(RegistrationAppealReview $review): void
+    {
+        $now = new DateTime();
+
+        if ($review->startsAt && $now < $review->startsAt) {
+            throw new PermissionDenied(App::i()->user, $review, 'applyCorrection');
+        }
+
+        if ($review->endsAt && $now > $review->endsAt) {
+            throw new PermissionDenied(App::i()->user, $review, 'applyCorrection');
+        }
+    }
+
+    private function assertTechnicalSlot(RegistrationEvaluation $slot): void
+    {
+        $emc = $slot->registration->opportunity->evaluationMethodConfiguration;
+        if (!$emc || $emc->type->id !== 'technical') {
+            throw new PermissionDenied(App::i()->user, $slot, 'applyCorrection');
+        }
+    }
+
+    /**
+     * Mescla apenas chaves liberadas em released_scope.criteria (ou .fields).
+     * Chaves fora do escopo com valor diferente do atual são rejeitadas;
+     * chaves fora do escopo iguais ao atual (ex.: rascunho com snapshot completo) são ignoradas.
+     */
+    private function mergeWithinReleasedScope(RegistrationEvaluation $slot, RegistrationAppealReview $review, array $incoming): array
+    {
+        $current = (array) $slot->getEvaluationData();
+        $scope = $this->getReleasedCriteriaIds($review);
+
+        if ($scope === null) {
+            return array_merge($current, $incoming);
+        }
+
+        $out_of_scope = [];
+        foreach ($incoming as $key => $value) {
+            if ($key === 'obs' || $key === 'viability') {
+                continue;
+            }
+            if (!in_array((string) $key, $scope, true)) {
+                $current_value = $current[$key] ?? null;
+                if (json_encode($value) !== json_encode($current_value)) {
+                    $out_of_scope[] = $key;
+                }
+            }
+        }
+
+        if ($out_of_scope) {
+            throw new \InvalidArgumentException(
+                sprintf(i::__('Critérios fora do escopo liberado: %s'), implode(', ', $out_of_scope))
+            );
+        }
+
+        foreach ($incoming as $key => $value) {
+            if ($key === 'obs' || $key === 'viability' || in_array((string) $key, $scope, true)) {
+                $current[$key] = $value;
+            }
+        }
+
+        return $current;
+    }
+
+    /**
+     * @return string[]|null null = sem restrição
+     */
+    private function getReleasedCriteriaIds(RegistrationAppealReview $review): ?array
+    {
+        $scope = $review->releasedScope;
+        if ($scope === null) {
+            return null;
+        }
+
+        $scope = (array) $scope;
+        $criteria = $scope['criteria'] ?? $scope['fields'] ?? null;
+
+        if ($criteria === null) {
+            return null;
+        }
+
+        return array_map('strval', (array) $criteria);
+    }
+}

--- a/src/modules/OpportunityAppealPhase/Controllers/AppealCorrector.php
+++ b/src/modules/OpportunityAppealPhase/Controllers/AppealCorrector.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace OpportunityAppealPhase\Controllers;
+
+use MapasCulturais\App;
+use MapasCulturais\Controller;
+use MapasCulturais\Exceptions\PermissionDenied;
+use MapasCulturais\i;
+use OpportunityAppealPhase\AppealReview\CorrectorEnvironment;
+use OpportunityAppealPhase\Entities\RegistrationAppealReview;
+
+/**
+ * Ambiente read-only do corretor designado (PR4.5).
+ *
+ * GET /appealCorrector/environment/{assignmentId}
+ */
+class AppealCorrector extends Controller
+{
+    function GET_environment()
+    {
+        $this->requireAuthentication();
+
+        $app = App::i();
+
+        if (!(bool) env('APPEAL_SCORE_CORRECTION', false)) {
+            $this->errorJson(i::__('Correção de notas por recurso desabilitada'), 404);
+        }
+
+        $assignment_id = (int) ($this->data['id'] ?? $this->urlData['id'] ?? 0);
+        if (!$assignment_id) {
+            $this->errorJson(i::__('assignmentId é obrigatório'), 400);
+        }
+
+        /** @var RegistrationAppealReview|null $review */
+        $review = $app->repo(RegistrationAppealReview::class)->find($assignment_id);
+        if (!$review) {
+            $this->errorJson(i::__('Designação não encontrada'), 404);
+        }
+
+        try {
+            $payload = (new CorrectorEnvironment())->build($review);
+        } catch (PermissionDenied $e) {
+            $this->errorJson(i::__('Sem permissão para acessar o ambiente de correção'), 403);
+        }
+
+        $this->json($payload);
+    }
+}

--- a/src/modules/OpportunityAppealPhase/Entities/RegistrationAppealReview.php
+++ b/src/modules/OpportunityAppealPhase/Entities/RegistrationAppealReview.php
@@ -4,6 +4,7 @@ namespace OpportunityAppealPhase\Entities;
 
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
+use MapasCulturais\App;
 use MapasCulturais\Entity;
 use MapasCulturais\Entities\Opportunity;
 use MapasCulturais\Entities\Registration;
@@ -212,7 +213,91 @@ class RegistrationAppealReview extends Entity
         return [
             self::STATUS_DESIGNATED,
             self::STATUS_DRAFT,
+            self::STATUS_REOPENED,
         ];
+    }
+
+    public static function isActiveStatus(int $status): bool
+    {
+        return in_array($status, self::getActiveStatuses(), true);
+    }
+
+    public function isActive(): bool
+    {
+        return self::isActiveStatus((int) $this->status);
+    }
+
+    /**
+     * Retorna os usuários elegíveis para corrigir o slot vinculado a esta designação.
+     *
+     * No MVP, a correção é restrita a oportunidades cuja fase principal usa
+     * `EvaluationMethodTechnical`.
+     *
+     * @return User[]
+     */
+    public function eligibleCorrectors(?RegistrationEvaluation $slot = null): array
+    {
+        $slot ??= $this->originalEvaluation;
+
+        if (!$slot || !$this->appealPhase || !$this->appealPhase->parent) {
+            return [];
+        }
+
+        $main_phase = $slot->registration->opportunity;
+        $main_emc = $main_phase->evaluationMethodConfiguration;
+
+        if (!$main_emc || $main_emc->type->id !== 'technical') {
+            return [];
+        }
+
+        if ($this->appealPhase->status !== Opportunity::STATUS_APPEAL_PHASE || !$this->appealPhase->evaluationMethodConfiguration) {
+            return [];
+        }
+
+        $users = [];
+        $users_by_id = [];
+
+        $push_user = static function (?User $user) use (&$users, &$users_by_id): void {
+            if (!$user || isset($users_by_id[$user->id])) {
+                return;
+            }
+
+            $users[] = $user;
+            $users_by_id[$user->id] = true;
+        };
+
+        $push_user($slot->user);
+
+        foreach ($this->appealPhase->evaluationMethodConfiguration->getCommittee(false) as $agent) {
+            $push_user($agent->user);
+        }
+
+        return $users;
+    }
+
+    public static function findActiveForEvaluationAndUser(RegistrationEvaluation $slot, User $user): ?self
+    {
+        $app = App::i();
+        /** @var self[] $reviews */
+        $reviews = $app->repo(self::class)->findBy([
+            'originalEvaluation' => $slot,
+            'correctorUser' => $user,
+            'status' => self::getActiveStatuses(),
+        ]);
+
+        foreach ($reviews as $review) {
+            if (
+                $review->registration->equals($slot->registration) &&
+                $review->appealPhase &&
+                $review->appealPhase->status === Opportunity::STATUS_APPEAL_PHASE &&
+                $review->slotOwnerUser &&
+                $review->slotOwnerUser->equals($slot->user)
+            ) {
+                return $review;
+            }
+        }
+
+        return null;
     }
 
     public function setReleasedScope($value): void

--- a/src/modules/OpportunityAppealPhase/Entities/RegistrationAppealReview.php
+++ b/src/modules/OpportunityAppealPhase/Entities/RegistrationAppealReview.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace OpportunityAppealPhase\Entities;
+
+use DateTime;
+use Doctrine\ORM\Mapping as ORM;
+use MapasCulturais\Entity;
+use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\Entities\Registration;
+use MapasCulturais\Entities\RegistrationEvaluation;
+use MapasCulturais\Entities\User;
+
+/**
+ * RegistrationAppealReview
+ *
+ * Designação de slot de revisão de recurso, vinculada a uma avaliação original.
+ *
+ * @property int $id
+ * @property RegistrationEvaluation $originalEvaluation
+ * @property Registration $registration
+ * @property Opportunity $appealPhase
+ * @property User $slotOwnerUser
+ * @property User $correctorUser
+ * @property int $status
+ * @property string $correctionType
+ * @property object $releasedScope
+ * @property DateTime $startsAt
+ * @property DateTime $endsAt
+ * @property object $originalValue
+ * @property object $correctedValue
+ * @property float $originalScore
+ * @property float $correctedScore
+ * @property DateTime $createTimestamp
+ * @property DateTime $sentTimestamp
+ * @property DateTime $updateTimestamp
+ *
+ * @ORM\Table(name="registration_appeal_review")
+ * @ORM\Entity
+ * @ORM\entity(repositoryClass="MapasCulturais\Repository")
+ * @ORM\HasLifecycleCallbacks
+ */
+class RegistrationAppealReview extends Entity
+{
+    const STATUS_DESIGNATED = 0;
+    const STATUS_DRAFT = 1;
+    const STATUS_SENT = 2;
+    const STATUS_REOPENED = 3;
+
+    const CORRECTION_TYPE_OFFICIAL = 'official';
+    const CORRECTION_TYPE_RECORD = 'record';
+
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="id", type="integer", nullable=false)
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="SEQUENCE")
+     * @ORM\SequenceGenerator(sequenceName="registration_appeal_review_id_seq", allocationSize=1, initialValue=1)
+     */
+    protected $id;
+
+    /**
+     * @var RegistrationEvaluation
+     *
+     * @ORM\ManyToOne(targetEntity="MapasCulturais\Entities\RegistrationEvaluation")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="original_evaluation_id", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     * })
+     */
+    protected $originalEvaluation;
+
+    /**
+     * @var Registration
+     *
+     * @ORM\ManyToOne(targetEntity="MapasCulturais\Entities\Registration")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="registration_id", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     * })
+     */
+    protected $registration;
+
+    /**
+     * @var Opportunity
+     *
+     * @ORM\ManyToOne(targetEntity="MapasCulturais\Entities\Opportunity")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="appeal_phase_id", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     * })
+     */
+    protected $appealPhase;
+
+    /**
+     * @var User
+     *
+     * @ORM\ManyToOne(targetEntity="MapasCulturais\Entities\User")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="slot_owner_user_id", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     * })
+     */
+    protected $slotOwnerUser;
+
+    /**
+     * @var User
+     *
+     * @ORM\ManyToOne(targetEntity="MapasCulturais\Entities\User")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="corrector_user_id", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     * })
+     */
+    protected $correctorUser;
+
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="status", type="smallint", nullable=false)
+     */
+    protected $status = self::STATUS_DESIGNATED;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="correction_type", type="string", length=20, nullable=false)
+     */
+    protected $correctionType;
+
+    /**
+     * @var object
+     *
+     * @ORM\Column(name="released_scope", type="json", nullable=true)
+     */
+    protected $releasedScope;
+
+    /**
+     * @var DateTime
+     *
+     * @ORM\Column(name="starts_at", type="datetime", nullable=true)
+     */
+    protected $startsAt;
+
+    /**
+     * @var DateTime
+     *
+     * @ORM\Column(name="ends_at", type="datetime", nullable=true)
+     */
+    protected $endsAt;
+
+    /**
+     * @var object
+     *
+     * @ORM\Column(name="original_value", type="json", nullable=true)
+     */
+    protected $originalValue;
+
+    /**
+     * @var object
+     *
+     * @ORM\Column(name="corrected_value", type="json", nullable=true)
+     */
+    protected $correctedValue;
+
+    /**
+     * @var float
+     *
+     * @ORM\Column(name="original_score", type="float", nullable=true)
+     */
+    protected $originalScore;
+
+    /**
+     * @var float
+     *
+     * @ORM\Column(name="corrected_score", type="float", nullable=true)
+     */
+    protected $correctedScore;
+
+    /**
+     * @var DateTime
+     *
+     * @ORM\Column(name="create_timestamp", type="datetime", nullable=false)
+     */
+    protected $createTimestamp;
+
+    /**
+     * @var DateTime
+     *
+     * @ORM\Column(name="sent_timestamp", type="datetime", nullable=true)
+     */
+    protected $sentTimestamp;
+
+    /**
+     * @var DateTime
+     *
+     * @ORM\Column(name="update_timestamp", type="datetime", nullable=true)
+     */
+    protected $updateTimestamp;
+
+    /**
+     * @return string[]
+     */
+    public static function getCorrectionTypes(): array
+    {
+        return [
+            self::CORRECTION_TYPE_OFFICIAL,
+            self::CORRECTION_TYPE_RECORD,
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getActiveStatuses(): array
+    {
+        return [
+            self::STATUS_DESIGNATED,
+            self::STATUS_DRAFT,
+        ];
+    }
+
+    public function setReleasedScope($value): void
+    {
+        $this->releasedScope = $value;
+    }
+
+    public function setOriginalValue($value): void
+    {
+        $this->originalValue = $value;
+    }
+
+    public function setCorrectedValue($value): void
+    {
+        $this->correctedValue = $value;
+    }
+
+    public function getReleasedScope()
+    {
+        return $this->releasedScope;
+    }
+
+    public function getOriginalValue()
+    {
+        return $this->originalValue;
+    }
+
+    public function getCorrectedValue()
+    {
+        return $this->correctedValue;
+    }
+
+    //============================================================= //
+    // The following lines are used by MapasCulturais hook system.
+    // Please do not change them.
+    // ============================================================ //
+
+    /** @ORM\PrePersist */
+    public function prePersist($args = null){ parent::prePersist($args); }
+    /** @ORM\PostPersist */
+    public function postPersist($args = null){ parent::postPersist($args); }
+
+    /** @ORM\PreRemove */
+    public function preRemove($args = null){ parent::preRemove($args); }
+    /** @ORM\PostRemove */
+    public function postRemove($args = null){ parent::postRemove($args); }
+
+    /** @ORM\PreUpdate */
+    public function preUpdate($args = null){ parent::preUpdate($args); }
+    /** @ORM\PostUpdate */
+    public function postUpdate($args = null){ parent::postUpdate($args); }
+}

--- a/src/modules/OpportunityAppealPhase/Module.php
+++ b/src/modules/OpportunityAppealPhase/Module.php
@@ -8,8 +8,10 @@ use MapasCulturais\Entities\EvaluationMethodConfiguration;
 use MapasCulturais\Entities\Notification;
 use MapasCulturais\Entities\Opportunity;
 use MapasCulturais\Entities\Registration;
+use MapasCulturais\Entities\RegistrationEvaluation;
 use MapasCulturais\Entities\RegistrationStep;
 use MapasCulturais\i;
+use OpportunityAppealPhase\Entities\RegistrationAppealReview;
 
 class Module extends \MapasCulturais\Module {
 
@@ -17,6 +19,7 @@ class Module extends \MapasCulturais\Module {
     {
         $config += [
             'sendMailNotification.opportunityAppealPhase' => env('SEND_MAIL_OPPORTUNITY_APPEAL_PHASE', false),
+            'featureFlag.appealScoreCorrection' => env('APPEAL_SCORE_CORRECTION', false),
         ];
 
         parent::__construct($config);
@@ -25,6 +28,24 @@ class Module extends \MapasCulturais\Module {
     public function _init() {
         $app = App::i();
         $self = $this;
+
+        $app->hook('entity(RegistrationEvaluation).canUser(modify)', function ($user, &$result) use ($self) {
+            /** @var RegistrationEvaluation $this */
+            if ($result || $user->is('guest')) {
+                return;
+            }
+
+            $result = $self->canDesignatedCorrectorAccessSlot($this, $user);
+        });
+
+        $app->hook('entity(RegistrationEvaluation).canUser(view)', function ($user, &$result) use ($self) {
+            /** @var RegistrationEvaluation $this */
+            if ($result || $user->is('guest')) {
+                return;
+            }
+
+            $result = $self->canDesignatedCorrectorAccessSlot($this, $user);
+        });
 
         /* Endpoint de criação de fase de recurso na oportunidade */
         $app->hook('POST(opportunity.createAppealPhase)', function() use ($app) {
@@ -323,6 +344,40 @@ class Module extends \MapasCulturais\Module {
                 return $evaluationMethodConfiguration->opportunity->appealPhase;
             }
         ]);
+    }
+
+    public function canDesignatedCorrectorAccessSlot(RegistrationEvaluation $slot, $user): bool
+    {
+        if (!$this->isAppealScoreCorrectionEnabled() || !$this->isTechnicalEvaluationSlot($slot)) {
+            return false;
+        }
+
+        $review = RegistrationAppealReview::findActiveForEvaluationAndUser($slot, $user);
+
+        if (!$review) {
+            return false;
+        }
+
+        foreach ($review->eligibleCorrectors($slot) as $eligible_user) {
+            if ($eligible_user->equals($user)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isTechnicalEvaluationSlot(RegistrationEvaluation $slot): bool
+    {
+        $opportunity = $slot->registration->opportunity;
+        $emc = $opportunity->evaluationMethodConfiguration;
+
+        return (bool) $emc && $emc->type->id === 'technical';
+    }
+
+    private function isAppealScoreCorrectionEnabled(): bool
+    {
+        return (bool) env('APPEAL_SCORE_CORRECTION', $this->config['featureFlag.appealScoreCorrection']);
     }
 
     /**

--- a/src/modules/OpportunityAppealPhase/Module.php
+++ b/src/modules/OpportunityAppealPhase/Module.php
@@ -361,6 +361,8 @@ class Module extends \MapasCulturais\Module {
     public function register() {
         $app = App::i();
 
+        $app->registerController('appealCorrector', \OpportunityAppealPhase\Controllers\AppealCorrector::class);
+
         $this->registerOpportunityMetadata('appealPhase', [
             'label' => i::__('Fase de recurso'),
             'type'  => 'entity'

--- a/src/modules/OpportunityAppealPhase/Module.php
+++ b/src/modules/OpportunityAppealPhase/Module.php
@@ -307,6 +307,55 @@ class Module extends \MapasCulturais\Module {
             }
             
         });
+
+        /* PR4 — aplica correção de nota no slot designado (APPEAL_SCORE_CORRECTION) */
+        $app->hook('POST(registrationEvaluation.applyAppealCorrection)', function () use ($app) {
+            /** @var Controllers\RegistrationEvaluation $this */
+            $this->requireAuthentication();
+
+            if (!(bool) env('APPEAL_SCORE_CORRECTION', false)) {
+                $this->errorJson(i::__('Correção de notas por recurso desabilitada'), 404);
+            }
+
+            $slot = $this->requestedEntity;
+            if (!$slot) {
+                $app->pass();
+            }
+
+            $review = RegistrationAppealReview::findActiveForEvaluationAndUser($slot, $app->user);
+            if (!$review) {
+                $this->errorJson(i::__('Nenhuma designação ativa de correção para este slot'), 403);
+            }
+
+            $data = $this->data['evaluationData'] ?? $this->data['correctedValue'] ?? null;
+            $draft = !empty($this->data['draft']);
+
+            $service = new \OpportunityAppealPhase\AppealReview\Service();
+
+            try {
+                if ($draft) {
+                    if ($data === null) {
+                        $this->errorJson(i::__('Dados da correção são obrigatórios.'), 400);
+                    }
+                    $review = $service->saveDraft($review, $data);
+                } else {
+                    $review = $service->applyCorrection($review, $data);
+                }
+            } catch (\InvalidArgumentException $e) {
+                $this->errorJson($e->getMessage(), 400);
+            } catch (\MapasCulturais\Exceptions\PermissionDenied $e) {
+                $this->errorJson(i::__('Sem permissão para aplicar a correção'), 403);
+            }
+
+            $this->json([
+                'review' => $review,
+                'evaluation' => $slot->refreshed(),
+                'registration' => [
+                    'id' => $slot->registration->id,
+                    'consolidatedResult' => $slot->registration->refreshed()->consolidatedResult,
+                ],
+            ]);
+        });
     }
 
     public function register() {

--- a/tests/src/AppealApplyCorrectionTest.php
+++ b/tests/src/AppealApplyCorrectionTest.php
@@ -1,0 +1,421 @@
+<?php
+
+namespace Tests;
+
+use DateTime;
+use MapasCulturais\App;
+use MapasCulturais\Entities\EvaluationMethodConfiguration;
+use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\Entities\RegistrationEvaluation;
+use MapasCulturais\Entities\User;
+use MapasCulturais\Exceptions\PermissionDenied;
+use OpportunityAppealPhase\AppealReview\Service;
+use OpportunityAppealPhase\Entities\RegistrationAppealReview;
+use Tests\Abstract\TestCase;
+use Tests\Builders\PhasePeriods\ConcurrentEndingAfter;
+use Tests\Builders\PhasePeriods\Open;
+use Tests\Enums\EvaluationMethods;
+use Tests\Traits\OpportunityBuilder;
+use Tests\Traits\RegistrationDirector;
+use Tests\Traits\UserDirector;
+
+class AppealApplyCorrectionTest extends TestCase
+{
+    use OpportunityBuilder,
+        RegistrationDirector,
+        UserDirector;
+
+    private function enableFlag(): void
+    {
+        $_ENV['APPEAL_SCORE_CORRECTION'] = 'true';
+    }
+
+    private function disableFlag(): void
+    {
+        unset($_ENV['APPEAL_SCORE_CORRECTION']);
+        putenv('APPEAL_SCORE_CORRECTION');
+    }
+
+    /**
+     * Cenário: fase técnica com 2 slots + fase de recurso + designação ativa.
+     *
+     * @return array{
+     *   admin: User,
+     *   opportunity: Opportunity,
+     *   registration: \MapasCulturais\Entities\Registration,
+     *   slotA: RegistrationEvaluation,
+     *   slotB: RegistrationEvaluation,
+     *   appealPhase: Opportunity,
+     *   corrector: User,
+     *   reviewA: RegistrationAppealReview,
+     *   originalConsolidated: string|float|null
+     * }
+     */
+    private function createCorrectionScenario(
+        string $correction_type = RegistrationAppealReview::CORRECTION_TYPE_OFFICIAL,
+        ?array $released_criteria = ['c-1'],
+        bool $designate_slot_b = false
+    ): array {
+        $this->enableFlag();
+
+        $admin = $this->userDirector->createUser('admin');
+        $slot_owner_a = $this->userDirector->createUser();
+        $slot_owner_b = $this->userDirector->createUser();
+        $corrector = $slot_owner_a;
+        $this->login($admin);
+
+        $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase(EvaluationMethods::technical)
+                ->fillRequiredProperties()
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->save()
+                ->config()
+                    ->addSection('sec-1', 'Seção 1')
+                    ->addCriterion('c-1', 'sec-1', 'Critério 1', 0, 10, 1)
+                    ->addCriterion('c-2', 'sec-1', 'Critério 2', 0, 10, 1)
+                    ->done()
+                ->save()
+                ->addValuer('Comissão', 'Avaliador A', $slot_owner_a->profile)
+                    ->done()
+                ->addValuer('Comissão', 'Avaliador B', $slot_owner_b->profile)
+                    ->done()
+                ->done()
+            ->save();
+
+        /** @var Opportunity $opportunity */
+        $opportunity = $this->opportunityBuilder->getInstance();
+        $registration = $this->registrationDirector->createSentRegistration($opportunity, data: []);
+
+        $app = App::i();
+        $app->disableAccessControl();
+
+        $slot_a = new RegistrationEvaluation();
+        $slot_a->registration = $registration;
+        $slot_a->user = $slot_owner_a;
+        $slot_a->setEvaluationData((object) ['c-1' => 4, 'c-2' => 6, 'obs' => 'A']);
+        $slot_a->status = RegistrationEvaluation::STATUS_SENT;
+        $slot_a->sentTimestamp = new DateTime();
+        $slot_a->save(true);
+
+        $slot_b = new RegistrationEvaluation();
+        $slot_b->registration = $registration;
+        $slot_b->user = $slot_owner_b;
+        $slot_b->setEvaluationData((object) ['c-1' => 8, 'c-2' => 2, 'obs' => 'B']);
+        $slot_b->status = RegistrationEvaluation::STATUS_SENT;
+        $slot_b->sentTimestamp = new DateTime();
+        $slot_b->save(true);
+
+        $registration->consolidateResult(true);
+        $original_consolidated = $registration->refreshed()->consolidatedResult;
+
+        $appeal_phase_class = $opportunity->getSpecializedClassName();
+        /** @var Opportunity $appeal_phase */
+        $appeal_phase = new $appeal_phase_class();
+        $appeal_phase->parent = $opportunity;
+        $appeal_phase->status = Opportunity::STATUS_APPEAL_PHASE;
+        $appeal_phase->name = 'Recurso técnico';
+        $appeal_phase->ownerEntity = $opportunity->ownerEntity;
+        $appeal_phase->owner = $opportunity->owner;
+        $appeal_phase->isDataCollection = true;
+        $appeal_phase->isAppealPhase = true;
+        $appeal_phase->registrationFrom = new DateTime('-1 day');
+        $appeal_phase->registrationTo = new DateTime('+1 day');
+        $appeal_phase->save(true);
+
+        $opportunity->appealPhase = $appeal_phase;
+        $opportunity->save(true);
+
+        $appeal_emc = new EvaluationMethodConfiguration();
+        $appeal_emc->opportunity = $appeal_phase;
+        $appeal_emc->type = 'continuous';
+        $appeal_emc->save(true);
+        $appeal_phase->evaluationMethodConfiguration = $appeal_emc;
+        $appeal_phase->save(true);
+
+        $review_a = $this->createReview(
+            $slot_a,
+            $registration,
+            $appeal_phase,
+            $slot_owner_a,
+            $corrector,
+            $correction_type,
+            $released_criteria
+        );
+
+        $review_b = null;
+        if ($designate_slot_b) {
+            $review_b = $this->createReview(
+                $slot_b,
+                $registration,
+                $appeal_phase,
+                $slot_owner_b,
+                $corrector,
+                $correction_type,
+                $released_criteria
+            );
+        }
+
+        $app->enableAccessControl();
+
+        return [
+            'admin' => $admin,
+            'opportunity' => $opportunity,
+            'registration' => $registration,
+            'slotA' => $slot_a,
+            'slotB' => $slot_b,
+            'appealPhase' => $appeal_phase,
+            'corrector' => $corrector,
+            'reviewA' => $review_a,
+            'reviewB' => $review_b,
+            'originalConsolidated' => $original_consolidated,
+            'slotOwnerB' => $slot_owner_b,
+        ];
+    }
+
+    private function createReview(
+        RegistrationEvaluation $slot,
+        $registration,
+        Opportunity $appeal_phase,
+        User $slot_owner,
+        User $corrector,
+        string $correction_type,
+        ?array $released_criteria
+    ): RegistrationAppealReview {
+        $review = new RegistrationAppealReview();
+        $review->originalEvaluation = $slot;
+        $review->registration = $registration;
+        $review->appealPhase = $appeal_phase;
+        $review->slotOwnerUser = $slot_owner;
+        $review->correctorUser = $corrector;
+        $review->status = RegistrationAppealReview::STATUS_DESIGNATED;
+        $review->correctionType = $correction_type;
+        $review->releasedScope = $released_criteria === null
+            ? null
+            : (object) ['criteria' => $released_criteria];
+        $review->startsAt = new DateTime('-1 hour');
+        $review->endsAt = new DateTime('+1 day');
+        $review->originalValue = $slot->getEvaluationData();
+        $review->originalScore = is_numeric($slot->result) ? (float) $slot->result : null;
+        $review->save(true);
+
+        return $review;
+    }
+
+    function testFlagOffBlocksApplyCorrection(): void
+    {
+        $scenario = $this->createCorrectionScenario();
+        $this->disableFlag();
+
+        $this->login($scenario['corrector']);
+        $service = new Service();
+
+        $this->expectException(PermissionDenied::class);
+        $service->applyCorrection($scenario['reviewA'], ['c-1' => 10]);
+    }
+
+    function testOfficialCorrectionUpdatesSlotAndConsolidation(): void
+    {
+        $scenario = $this->createCorrectionScenario();
+        $this->login($scenario['corrector']);
+
+        $service = new Service();
+        $review = $service->applyCorrection($scenario['reviewA'], [
+            'c-1' => 10,
+            'obs' => 'corrigido',
+        ]);
+
+        $slot_a = App::i()->repo('RegistrationEvaluation')->find($scenario['slotA']->id);
+        $slot_b = App::i()->repo('RegistrationEvaluation')->find($scenario['slotB']->id);
+        $registration = App::i()->repo('Registration')->find($scenario['registration']->id);
+
+        $this->assertEquals(RegistrationAppealReview::STATUS_SENT, $review->status);
+        $this->assertEquals(10.0, (float) $slot_a->evaluationData->{'c-1'});
+        $this->assertEquals(6.0, (float) $slot_a->evaluationData->{'c-2'});
+        $this->assertEquals(RegistrationEvaluation::STATUS_SENT, $slot_a->status);
+
+        // Slot B intacto (regressão)
+        $this->assertEquals(8.0, (float) $slot_b->evaluationData->{'c-1'});
+        $this->assertEquals(2.0, (float) $slot_b->evaluationData->{'c-2'});
+
+        // Consolidação mudou (média técnica dos 2 slots: (10+6)=16 e (8+2)=10 → média 13)
+        $this->assertNotEquals($scenario['originalConsolidated'], $registration->consolidatedResult);
+        $this->assertEquals(13.0, (float) $registration->consolidatedResult);
+
+        $this->assertEquals(16.0, (float) $review->correctedScore);
+        $this->assertNotNull($review->sentTimestamp);
+    }
+
+    function testMultipleSlotCorrectionsReflectInConsolidation(): void
+    {
+        $scenario = $this->createCorrectionScenario(
+            released_criteria: ['c-1', 'c-2'],
+            designate_slot_b: true
+        );
+
+        // reviewB foi designado com corrector = slot_owner_a; precisa redesignar para B
+        $app = App::i();
+        $app->disableAccessControl();
+        $scenario['reviewB']->correctorUser = $scenario['slotOwnerB'];
+        $scenario['reviewB']->save(true);
+        $app->enableAccessControl();
+
+        $service = new Service();
+
+        $this->login($scenario['corrector']);
+        $service->applyCorrection($scenario['reviewA'], ['c-1' => 10, 'c-2' => 10]);
+
+        $this->login($scenario['slotOwnerB']);
+        $service->applyCorrection($scenario['reviewB'], ['c-1' => 0, 'c-2' => 0]);
+
+        $registration = $app->repo('Registration')->find($scenario['registration']->id);
+        // (20 + 0) / 2 = 10
+        $this->assertEquals(10.0, (float) $registration->consolidatedResult);
+    }
+
+    function testRecordTypeDoesNotChangeOfficialScore(): void
+    {
+        $scenario = $this->createCorrectionScenario(
+            correction_type: RegistrationAppealReview::CORRECTION_TYPE_RECORD
+        );
+        $this->login($scenario['corrector']);
+
+        $before_a = (array) $scenario['slotA']->getEvaluationData();
+        $before_consolidated = $scenario['originalConsolidated'];
+
+        $service = new Service();
+        $review = $service->applyCorrection($scenario['reviewA'], ['c-1' => 10]);
+
+        $slot_a = App::i()->repo('RegistrationEvaluation')->find($scenario['slotA']->id);
+        $registration = App::i()->repo('Registration')->find($scenario['registration']->id);
+
+        $this->assertEquals($before_a['c-1'], $slot_a->evaluationData->{'c-1'});
+        $this->assertEquals($before_consolidated, $registration->consolidatedResult);
+        $this->assertEquals(RegistrationAppealReview::STATUS_SENT, $review->status);
+        $this->assertEquals(10.0, (float) $review->correctedValue->{'c-1'});
+        $this->assertEquals(16.0, (float) $review->correctedScore);
+
+        $last = $slot_a->getLastRevision();
+        $this->assertNotNull($last);
+        $this->assertStringContainsString((string) $scenario['corrector']->id, $last->message);
+        $this->assertStringContainsString((string) $slot_a->id, $last->message);
+        $this->assertStringContainsString('somente registro', $last->message);
+    }
+
+    function testRevisionIdentifiesCorrectorAndSlot(): void
+    {
+        $scenario = $this->createCorrectionScenario();
+        $this->login($scenario['corrector']);
+
+        $service = new Service();
+        $service->applyCorrection($scenario['reviewA'], ['c-1' => 9]);
+
+        $slot_a = App::i()->repo('RegistrationEvaluation')->find($scenario['slotA']->id);
+        $last = $slot_a->getLastRevision();
+
+        $this->assertNotNull($last);
+        $this->assertStringContainsString((string) $scenario['corrector']->id, $last->message);
+        $this->assertStringContainsString((string) $slot_a->id, $last->message);
+        $this->assertStringContainsString((string) $slot_a->user->id, $last->message);
+    }
+
+    function testOutOfScopeCriteriaRejected(): void
+    {
+        $scenario = $this->createCorrectionScenario(released_criteria: ['c-1']);
+        $this->login($scenario['corrector']);
+
+        $service = new Service();
+        $this->expectException(\InvalidArgumentException::class);
+        $service->applyCorrection($scenario['reviewA'], ['c-1' => 9, 'c-2' => 9]);
+    }
+
+    function testOutsideWindowRejected(): void
+    {
+        $scenario = $this->createCorrectionScenario();
+        $app = App::i();
+        $app->disableAccessControl();
+        $scenario['reviewA']->endsAt = new DateTime('-1 minute');
+        $scenario['reviewA']->save(true);
+        $app->enableAccessControl();
+
+        $this->login($scenario['corrector']);
+        $service = new Service();
+
+        $this->expectException(PermissionDenied::class);
+        $service->applyCorrection($scenario['reviewA'], ['c-1' => 9]);
+    }
+
+    function testWrongUserRejected(): void
+    {
+        $scenario = $this->createCorrectionScenario();
+        $outsider = $this->userDirector->createUser();
+        $this->login($outsider);
+
+        $service = new Service();
+        $this->expectException(PermissionDenied::class);
+        $service->applyCorrection($scenario['reviewA'], ['c-1' => 9]);
+    }
+
+    function testSaveDraftDoesNotTouchOfficialScore(): void
+    {
+        $scenario = $this->createCorrectionScenario();
+        $this->login($scenario['corrector']);
+
+        $service = new Service();
+        $review = $service->saveDraft($scenario['reviewA'], ['c-1' => 10]);
+
+        $slot_a = App::i()->repo('RegistrationEvaluation')->find($scenario['slotA']->id);
+        $registration = App::i()->repo('Registration')->find($scenario['registration']->id);
+
+        $this->assertEquals(RegistrationAppealReview::STATUS_DRAFT, $review->status);
+        $this->assertEquals(10.0, (float) $review->correctedValue->{'c-1'});
+        $this->assertEquals(4.0, (float) $slot_a->evaluationData->{'c-1'});
+        $this->assertEquals($scenario['originalConsolidated'], $registration->consolidatedResult);
+
+        // Envio a partir do rascunho
+        $review = $service->applyCorrection($review);
+        $slot_a = App::i()->repo('RegistrationEvaluation')->find($scenario['slotA']->id);
+        $this->assertEquals(10.0, (float) $slot_a->evaluationData->{'c-1'});
+        $this->assertEquals(RegistrationAppealReview::STATUS_SENT, $review->status);
+    }
+
+    function testPcacheQueuedOnlyForAffectedRegistration(): void
+    {
+        $scenario = $this->createCorrectionScenario();
+        $this->login($scenario['corrector']);
+
+        $app = App::i();
+        $conn = $app->em->getConnection();
+        $before = (int) $conn->fetchOne(
+            'SELECT COUNT(*) FROM permission_cache_pending WHERE object_type LIKE :t AND object_id = :id',
+            [
+                't' => '%Registration%',
+                'id' => $scenario['registration']->id,
+            ]
+        );
+
+        $service = new Service();
+        $service->applyCorrection($scenario['reviewA'], ['c-1' => 10]);
+
+        $after = (int) $conn->fetchOne(
+            'SELECT COUNT(*) FROM permission_cache_pending WHERE object_type LIKE :t AND object_id = :id',
+            [
+                't' => '%Registration%',
+                'id' => $scenario['registration']->id,
+            ]
+        );
+
+        // Com recreateCacheImmediately pode zerar a fila; nesse caso consolidação já prova o efeito.
+        // Quando a fila é usada, deve haver ao menos um item para a inscrição afetada.
+        if (!$app->config['app.recreateCacheImmediately']) {
+            $this->assertGreaterThan($before, $after);
+        } else {
+            $this->assertTrue(true);
+        }
+    }
+}

--- a/tests/src/AppealCorrectorEnvironmentTest.php
+++ b/tests/src/AppealCorrectorEnvironmentTest.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace Tests;
+
+use DateTime;
+use MapasCulturais\App;
+use MapasCulturais\Entities\EvaluationMethodConfiguration;
+use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\Entities\Registration;
+use MapasCulturais\Entities\RegistrationEvaluation;
+use MapasCulturais\Entities\User;
+use MapasCulturais\Exceptions\PermissionDenied;
+use OpportunityAppealPhase\AppealReview\CorrectorEnvironment;
+use OpportunityAppealPhase\Entities\RegistrationAppealReview;
+use Tests\Abstract\TestCase;
+use Tests\Builders\PhasePeriods\ConcurrentEndingAfter;
+use Tests\Builders\PhasePeriods\Open;
+use Tests\Enums\EvaluationMethods;
+use Tests\Traits\OpportunityBuilder;
+use Tests\Traits\RegistrationDirector;
+use Tests\Traits\RequestFactory;
+use Tests\Traits\UserDirector;
+
+class AppealCorrectorEnvironmentTest extends TestCase
+{
+    use OpportunityBuilder,
+        RegistrationDirector,
+        UserDirector,
+        RequestFactory;
+
+    private function enableFlag(): void
+    {
+        $_ENV['APPEAL_SCORE_CORRECTION'] = 'true';
+    }
+
+    /**
+     * @return array{
+     *   corrector: User,
+     *   outsider: User,
+     *   review: RegistrationAppealReview,
+     *   slotA: RegistrationEvaluation,
+     *   slotB: RegistrationEvaluation,
+     *   appealPhase: Opportunity,
+     *   registration: Registration,
+     *   appealRegistration: ?Registration
+     * }
+     */
+    private function createScenario(bool $show_opinion = false, bool $with_appeal_opinion = false): array
+    {
+        $this->enableFlag();
+
+        $admin = $this->userDirector->createUser('admin');
+        $slot_owner_a = $this->userDirector->createUser();
+        $slot_owner_b = $this->userDirector->createUser();
+        $outsider = $this->userDirector->createUser();
+        $corrector = $slot_owner_a;
+        $this->login($admin);
+
+        $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase(EvaluationMethods::technical)
+                ->fillRequiredProperties()
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->save()
+                ->config()
+                    ->addSection('sec-1', 'Seção 1')
+                    ->addCriterion('c-1', 'sec-1', 'Critério 1', 0, 10, 1)
+                    ->addCriterion('c-2', 'sec-1', 'Critério 2', 0, 10, 1)
+                    ->done()
+                ->save()
+                ->addValuer('Comissão', 'Avaliador A', $slot_owner_a->profile)
+                    ->done()
+                ->addValuer('Comissão', 'Avaliador B', $slot_owner_b->profile)
+                    ->done()
+                ->done()
+            ->save();
+
+        $opportunity = $this->opportunityBuilder->getInstance();
+        $registration = $this->registrationDirector->createSentRegistration($opportunity, data: []);
+
+        $app = App::i();
+        $app->disableAccessControl();
+
+        $slot_a = new RegistrationEvaluation();
+        $slot_a->registration = $registration;
+        $slot_a->user = $slot_owner_a;
+        $slot_a->setEvaluationData((object) ['c-1' => 4, 'c-2' => 6, 'obs' => 'A']);
+        $slot_a->status = RegistrationEvaluation::STATUS_SENT;
+        $slot_a->sentTimestamp = new DateTime();
+        $slot_a->save(true);
+
+        $slot_b = new RegistrationEvaluation();
+        $slot_b->registration = $registration;
+        $slot_b->user = $slot_owner_b;
+        $slot_b->setEvaluationData((object) ['c-1' => 8, 'c-2' => 2, 'obs' => 'B']);
+        $slot_b->status = RegistrationEvaluation::STATUS_SENT;
+        $slot_b->sentTimestamp = new DateTime();
+        $slot_b->save(true);
+
+        $appeal_phase_class = $opportunity->getSpecializedClassName();
+        /** @var Opportunity $appeal_phase */
+        $appeal_phase = new $appeal_phase_class();
+        $appeal_phase->parent = $opportunity;
+        $appeal_phase->status = Opportunity::STATUS_APPEAL_PHASE;
+        $appeal_phase->name = 'Recurso técnico';
+        $appeal_phase->ownerEntity = $opportunity->ownerEntity;
+        $appeal_phase->owner = $opportunity->owner;
+        $appeal_phase->isDataCollection = true;
+        $appeal_phase->isAppealPhase = true;
+        $appeal_phase->registrationFrom = new DateTime('-1 day');
+        $appeal_phase->registrationTo = new DateTime('+1 day');
+        $appeal_phase->save(true);
+
+        $opportunity->appealPhase = $appeal_phase;
+        $opportunity->save(true);
+
+        $appeal_emc = new EvaluationMethodConfiguration();
+        $appeal_emc->opportunity = $appeal_phase;
+        $appeal_emc->type = 'continuous';
+        $appeal_emc->save(true);
+        $appeal_phase->evaluationMethodConfiguration = $appeal_emc;
+        $appeal_phase->save(true);
+
+        $appeal_registration = null;
+        if ($with_appeal_opinion) {
+            $conn = $app->em->getConnection();
+            $conn->insert('registration', [
+                'opportunity_id' => $appeal_phase->id,
+                'agent_id' => $registration->owner->id,
+                'number' => $registration->number,
+                'status' => Registration::STATUS_SENT,
+                'create_timestamp' => (new DateTime())->format('Y-m-d H:i:s'),
+                'agents_data' => '{}',
+                'consolidated_result' => '',
+            ]);
+            $appeal_registration_id = (int) $conn->fetchOne(
+                'SELECT id FROM registration WHERE opportunity_id = :opp AND number = :number ORDER BY id DESC LIMIT 1',
+                ['opp' => $appeal_phase->id, 'number' => $registration->number]
+            );
+            $appeal_registration = $app->repo('Registration')->find($appeal_registration_id);
+
+            $conn->insert('registration_evaluation', [
+                'id' => (int) $conn->fetchOne("SELECT nextval('registration_evaluation_id_seq')"),
+                'registration_id' => $appeal_registration_id,
+                'user_id' => $admin->id,
+                'evaluation_data' => json_encode(['status' => '10', 'obs' => 'Deferido']),
+                'result' => '10',
+                'status' => RegistrationEvaluation::STATUS_SENT,
+                'create_timestamp' => (new DateTime())->format('Y-m-d H:i:s'),
+                'sent_timestamp' => (new DateTime())->format('Y-m-d H:i:s'),
+            ]);
+        }
+
+        $review = new RegistrationAppealReview();
+        $review->originalEvaluation = $slot_a;
+        $review->registration = $registration;
+        $review->appealPhase = $appeal_phase;
+        $review->slotOwnerUser = $slot_owner_a;
+        $review->correctorUser = $corrector;
+        $review->status = RegistrationAppealReview::STATUS_DRAFT;
+        $review->correctionType = RegistrationAppealReview::CORRECTION_TYPE_OFFICIAL;
+        $review->releasedScope = (object) [
+            'criteria' => ['c-1'],
+            'showAppealOpinion' => $show_opinion,
+        ];
+        $review->startsAt = new DateTime('-1 hour');
+        $review->endsAt = new DateTime('+1 day');
+        $review->originalValue = $slot_a->getEvaluationData();
+        $review->originalScore = (float) $slot_a->result;
+        $review->correctedValue = (object) ['c-1' => 7, 'c-2' => 9];
+        $review->save(true);
+
+        $app->enableAccessControl();
+
+        return [
+            'corrector' => $corrector,
+            'outsider' => $outsider,
+            'review' => $review,
+            'slotA' => $slot_a,
+            'slotB' => $slot_b,
+            'appealPhase' => $appeal_phase,
+            'registration' => $registration,
+            'appealRegistration' => $appeal_registration,
+        ];
+    }
+
+    function testOnlyActiveCorrectorCanAccess(): void
+    {
+        $scenario = $this->createScenario();
+        $builder = new CorrectorEnvironment();
+
+        $this->login($scenario['corrector']);
+        $payload = $builder->build($scenario['review']);
+        $this->assertEquals($scenario['review']->id, $payload['assignmentId']);
+
+        $this->login($scenario['outsider']);
+        $this->expectException(PermissionDenied::class);
+        $builder->build($scenario['review']);
+    }
+
+    function testReturnsOnlyDesignatedSlotCriteria(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['corrector']);
+
+        $payload = (new CorrectorEnvironment())->build($scenario['review']);
+
+        $original = (array) $payload['originalEvaluation'];
+        $this->assertArrayHasKey('c-1', $original);
+        $this->assertArrayNotHasKey('c-2', $original);
+        $this->assertArrayNotHasKey('obs', $original);
+        $this->assertEquals(4.0, (float) $original['c-1']);
+
+        $draft = (array) $payload['draft'];
+        $this->assertArrayHasKey('c-1', $draft);
+        $this->assertArrayNotHasKey('c-2', $draft);
+        $this->assertEquals(7.0, (float) $draft['c-1']);
+
+        $encoded = json_encode($payload);
+        $this->assertStringNotContainsString('"c-2":8', $encoded);
+        $this->assertStringNotContainsString('"c-2":2', $encoded);
+    }
+
+    function testCommitteeOpinionAbsentWhenFlagFalse(): void
+    {
+        $scenario = $this->createScenario(show_opinion: false, with_appeal_opinion: false);
+        $this->login($scenario['corrector']);
+
+        $payload = (new CorrectorEnvironment())->build($scenario['review']);
+        $this->assertArrayNotHasKey('committeeOpinion', $payload);
+    }
+
+    function testCommitteeOpinionPresentWhenFlagTrue(): void
+    {
+        $scenario = $this->createScenario(show_opinion: true, with_appeal_opinion: true);
+        $this->login($scenario['corrector']);
+
+        $payload = (new CorrectorEnvironment())->build($scenario['review']);
+        $this->assertArrayHasKey('committeeOpinion', $payload);
+        $this->assertNotNull($payload['committeeOpinion']);
+        $this->assertEquals($scenario['appealRegistration']->id, $payload['committeeOpinion']['registrationId']);
+        $this->assertNotEmpty($payload['committeeOpinion']['evaluations']);
+    }
+
+    function testEndpointHttpHappyPath(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['corrector']);
+
+        $request = $this->requestFactory->GET(
+            'appealCorrector',
+            'environment',
+            [$scenario['review']->id],
+            ajax: true
+        );
+
+        $app = App::i();
+        $app->reset();
+        $app->run($request, false);
+
+        $this->assertEquals(200, $app->response->getStatusCode());
+        $body = json_decode((string) $app->response->getBody(), true);
+        $this->assertEquals($scenario['review']->id, $body['assignmentId']);
+        $this->assertEquals('draft', $body['status']);
+        $this->assertEquals('official', $body['correctionType']);
+        $this->assertArrayHasKey('c-1', $body['originalEvaluation']);
+        $this->assertArrayNotHasKey('c-2', $body['originalEvaluation']);
+    }
+
+    function testEndpointForbiddenForOutsider(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['outsider']);
+
+        $request = $this->requestFactory->GET(
+            'appealCorrector',
+            'environment',
+            [$scenario['review']->id],
+            ajax: true
+        );
+
+        $this->assertStatus403($request);
+    }
+
+    function testSentAssignmentRejected(): void
+    {
+        $scenario = $this->createScenario();
+        $app = App::i();
+        $app->disableAccessControl();
+        $scenario['review']->status = RegistrationAppealReview::STATUS_SENT;
+        $scenario['review']->save(true);
+        $app->enableAccessControl();
+
+        $this->login($scenario['corrector']);
+        $this->expectException(PermissionDenied::class);
+        (new CorrectorEnvironment())->build($scenario['review']);
+    }
+}

--- a/tests/src/RegistrationAppealReviewTest.php
+++ b/tests/src/RegistrationAppealReviewTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use DateTime;
 use MapasCulturais\App;
+use MapasCulturais\Entities\EvaluationMethodConfiguration;
 use MapasCulturais\Entities\Opportunity;
 use MapasCulturais\Entities\RegistrationEvaluation;
 use MapasCulturais\Entities\User;
@@ -80,6 +81,102 @@ class RegistrationAppealReviewTest extends TestCase
             $appeal_phase,
             $slot_owner,
             $corrector,
+        ];
+    }
+
+    /**
+     * Cria um cenário de fase técnica + fase de recurso para testar elegibilidade e permissões.
+     */
+    private function createAppealCorrectionPermissionScenario(User $admin): array
+    {
+        $_ENV['APPEAL_SCORE_CORRECTION'] = 'true';
+
+        $slot_owner = $this->userDirector->createUser();
+        $other_slot_evaluator = $this->userDirector->createUser();
+        $appeal_committee_user = $this->userDirector->createUser();
+        $outsider = $this->userDirector->createUser();
+
+        $this->login($admin);
+
+        $evaluation_phase_builder = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase(EvaluationMethods::technical)
+                ->fillRequiredProperties()
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->save()
+                ->addValuer('Comissão', 'Avaliador Slot', $slot_owner->profile)
+                    ->done()
+                ->addValuer('Comissão', 'Outro Avaliador', $other_slot_evaluator->profile)
+                    ->done()
+                ->done();
+
+        $opportunity = $evaluation_phase_builder->getInstance();
+        $registration = $this->registrationDirector->createSentRegistration($opportunity, data: []);
+
+        $app = App::i();
+        $app->disableAccessControl();
+
+        $slot_evaluation = new RegistrationEvaluation();
+        $slot_evaluation->registration = $registration;
+        $slot_evaluation->user = $slot_owner;
+        $slot_evaluation->status = RegistrationEvaluation::STATUS_EVALUATED;
+        $slot_evaluation->save(true);
+
+        $other_slot_evaluation = new RegistrationEvaluation();
+        $other_slot_evaluation->registration = $registration;
+        $other_slot_evaluation->user = $other_slot_evaluator;
+        $other_slot_evaluation->status = RegistrationEvaluation::STATUS_EVALUATED;
+        $other_slot_evaluation->save(true);
+
+        $appeal_phase_class = $opportunity->getSpecializedClassName();
+        /** @var Opportunity $appeal_phase */
+        $appeal_phase = new $appeal_phase_class();
+        $appeal_phase->parent = $opportunity;
+        $appeal_phase->status = Opportunity::STATUS_APPEAL_PHASE;
+        $appeal_phase->name = 'Fase de recurso técnica';
+        $appeal_phase->ownerEntity = $opportunity->ownerEntity;
+        $appeal_phase->owner = $opportunity->owner;
+        $appeal_phase->registrationCategories = $opportunity->registrationCategories;
+        $appeal_phase->registrationRanges = $opportunity->registrationRanges;
+        $appeal_phase->registrationProponentTypes = $opportunity->registrationProponentTypes;
+        $appeal_phase->isDataCollection = true;
+        $appeal_phase->isAppealPhase = true;
+        $appeal_phase->registrationFrom = new DateTime('-1 day');
+        $appeal_phase->registrationTo = new DateTime('+1 day');
+        $appeal_phase->save(true);
+
+        $opportunity->appealPhase = $appeal_phase;
+        $opportunity->save(true);
+
+        $appeal_emc = new EvaluationMethodConfiguration();
+        $appeal_emc->opportunity = $appeal_phase;
+        $appeal_emc->type = 'continuous';
+        $appeal_emc->publishEvaluationDetails = true;
+        $appeal_emc->save(true);
+
+        $appeal_phase->evaluationMethodConfiguration = $appeal_emc;
+        $appeal_phase->save(true);
+
+        $appeal_relation = $appeal_emc->createAgentRelation($appeal_committee_user->profile, 'committee 1', true);
+        $appeal_relation->save(true);
+
+        $app->enableAccessControl();
+
+        return [
+            'opportunity' => $opportunity,
+            'registration' => $registration,
+            'slotEvaluation' => $slot_evaluation,
+            'otherSlotEvaluation' => $other_slot_evaluation,
+            'appealPhase' => $appeal_phase,
+            'slotOwner' => $slot_owner,
+            'otherSlotEvaluator' => $other_slot_evaluator,
+            'appealCommitteeUser' => $appeal_committee_user,
+            'outsider' => $outsider,
         ];
     }
 
@@ -221,5 +318,120 @@ class RegistrationAppealReviewTest extends TestCase
         $review2->save(true);
 
         $this->assertNotNull($review2->id, 'Uma nova designação deve ser permitida quando o slot anterior já foi enviado.');
+    }
+
+    function testReopenedSlotPreventsDuplicateActiveDesignation(): void
+    {
+        $admin = $this->userDirector->createUser('admin');
+
+        [
+            $opportunity,
+            $registration,
+            $original_evaluation,
+            $appeal_phase,
+            $slot_owner,
+            $corrector,
+        ] = $this->createAppealReviewScenario($admin);
+
+        $app = App::i();
+        $app->disableAccessControl();
+
+        $review1 = new RegistrationAppealReview();
+        $review1->originalEvaluation = $original_evaluation;
+        $review1->registration = $registration;
+        $review1->appealPhase = $appeal_phase;
+        $review1->slotOwnerUser = $slot_owner;
+        $review1->correctorUser = $corrector;
+        $review1->status = RegistrationAppealReview::STATUS_REOPENED;
+        $review1->correctionType = RegistrationAppealReview::CORRECTION_TYPE_OFFICIAL;
+        $review1->save(true);
+
+        $review2 = new RegistrationAppealReview();
+        $review2->originalEvaluation = $original_evaluation;
+        $review2->registration = $registration;
+        $review2->appealPhase = $appeal_phase;
+        $review2->slotOwnerUser = $slot_owner;
+        $review2->correctorUser = $corrector;
+        $review2->status = RegistrationAppealReview::STATUS_DESIGNATED;
+        $review2->correctionType = RegistrationAppealReview::CORRECTION_TYPE_OFFICIAL;
+
+        $this->expectException(\Doctrine\DBAL\Exception\UniqueConstraintViolationException::class);
+        $review2->save(true);
+    }
+
+    function testEligibleCorrectorsIncludeSlotOwnerAndAppealCommitteeOnly(): void
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $scenario = $this->createAppealCorrectionPermissionScenario($admin);
+
+        $review = new RegistrationAppealReview();
+        $review->originalEvaluation = $scenario['slotEvaluation'];
+        $review->registration = $scenario['registration'];
+        $review->appealPhase = $scenario['appealPhase'];
+        $review->slotOwnerUser = $scenario['slotOwner'];
+        $review->correctorUser = $scenario['appealCommitteeUser'];
+        $review->status = RegistrationAppealReview::STATUS_DESIGNATED;
+        $review->correctionType = RegistrationAppealReview::CORRECTION_TYPE_OFFICIAL;
+
+        $eligible_ids = array_map(fn (User $user) => $user->id, $review->eligibleCorrectors());
+
+        $this->assertContains($scenario['slotOwner']->id, $eligible_ids);
+        $this->assertContains($scenario['appealCommitteeUser']->id, $eligible_ids);
+        $this->assertNotContains($scenario['otherSlotEvaluator']->id, $eligible_ids);
+        $this->assertNotContains($scenario['outsider']->id, $eligible_ids);
+    }
+
+    function testDesignatedAppealCommitteeUserCanModifyAndViewOriginalEvaluation(): void
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $scenario = $this->createAppealCorrectionPermissionScenario($admin);
+
+        $review = new RegistrationAppealReview();
+        $review->originalEvaluation = $scenario['slotEvaluation'];
+        $review->registration = $scenario['registration'];
+        $review->appealPhase = $scenario['appealPhase'];
+        $review->slotOwnerUser = $scenario['slotOwner'];
+        $review->correctorUser = $scenario['appealCommitteeUser'];
+        $review->status = RegistrationAppealReview::STATUS_DESIGNATED;
+        $review->correctionType = RegistrationAppealReview::CORRECTION_TYPE_OFFICIAL;
+
+        $app = App::i();
+        $app->disableAccessControl();
+        $review->save(true);
+        $app->enableAccessControl();
+
+        $this->assertTrue($scenario['slotEvaluation']->canUser('modify', $scenario['appealCommitteeUser']));
+        $this->assertTrue($scenario['slotEvaluation']->canUser('view', $scenario['appealCommitteeUser']));
+    }
+
+    function testUserWithoutActiveDesignationCannotModifyOriginalEvaluation(): void
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $scenario = $this->createAppealCorrectionPermissionScenario($admin);
+
+        $this->assertFalse($scenario['slotEvaluation']->canUser('modify', $scenario['appealCommitteeUser']));
+        $this->assertFalse($scenario['slotEvaluation']->canUser('modify', $scenario['outsider']));
+    }
+
+    function testEvaluatorFromAnotherSlotIsRejectedWhenNotInAppealCommittee(): void
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $scenario = $this->createAppealCorrectionPermissionScenario($admin);
+
+        $review = new RegistrationAppealReview();
+        $review->originalEvaluation = $scenario['slotEvaluation'];
+        $review->registration = $scenario['registration'];
+        $review->appealPhase = $scenario['appealPhase'];
+        $review->slotOwnerUser = $scenario['slotOwner'];
+        $review->correctorUser = $scenario['appealCommitteeUser'];
+        $review->status = RegistrationAppealReview::STATUS_DESIGNATED;
+        $review->correctionType = RegistrationAppealReview::CORRECTION_TYPE_OFFICIAL;
+
+        $app = App::i();
+        $app->disableAccessControl();
+        $review->save(true);
+        $app->enableAccessControl();
+
+        $this->assertFalse($scenario['slotEvaluation']->canUser('modify', $scenario['otherSlotEvaluator']));
     }
 }

--- a/tests/src/RegistrationAppealReviewTest.php
+++ b/tests/src/RegistrationAppealReviewTest.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Tests;
+
+use DateTime;
+use MapasCulturais\App;
+use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\Entities\RegistrationEvaluation;
+use MapasCulturais\Entities\User;
+use OpportunityAppealPhase\Entities\RegistrationAppealReview;
+use Tests\Abstract\TestCase;
+use Tests\Builders\PhasePeriods\ConcurrentEndingAfter;
+use Tests\Builders\PhasePeriods\Open;
+use Tests\Enums\EvaluationMethods;
+use Tests\Traits\OpportunityBuilder;
+use Tests\Traits\RegistrationDirector;
+use Tests\Traits\UserDirector;
+
+class RegistrationAppealReviewTest extends TestCase
+{
+    use OpportunityBuilder,
+        RegistrationDirector,
+        UserDirector;
+
+    /**
+     * Cria um cenário mínimo para testar a entidade RegistrationAppealReview.
+     */
+    private function createAppealReviewScenario(User $admin): array
+    {
+        $this->login($admin);
+
+        $evaluation_phase_builder = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase(EvaluationMethods::simple)
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->save()
+                ->addValuer('Comissão', 'Avaliador 1', $admin->profile)
+                    ->done()
+                ->done();
+
+        $opportunity = $evaluation_phase_builder->getInstance();
+
+        $registration = $this->registrationDirector->createSentRegistration($opportunity, data: []);
+
+        $app = App::i();
+        $app->disableAccessControl();
+
+        $original_evaluation = new RegistrationEvaluation();
+        $original_evaluation->registration = $registration;
+        $original_evaluation->user = $admin;
+        $original_evaluation->status = RegistrationEvaluation::STATUS_EVALUATED;
+        $original_evaluation->save(true);
+
+        $appeal_phase_class = $opportunity->getSpecializedClassName();
+        /** @var Opportunity $appeal_phase */
+        $appeal_phase = new $appeal_phase_class();
+        $appeal_phase->parent = $opportunity;
+        $appeal_phase->status = Opportunity::STATUS_APPEAL_PHASE;
+        $appeal_phase->name = 'Fase de recurso de teste';
+        $appeal_phase->ownerEntity = $admin->profile;
+        $appeal_phase->owner = $admin->profile;
+        $appeal_phase->registrationFrom = new DateTime('-1 day');
+        $appeal_phase->registrationTo = new DateTime('+1 day');
+        $appeal_phase->save(true);
+
+        $slot_owner = $this->userDirector->createUser();
+        $corrector = $this->userDirector->createUser();
+
+        $app->enableAccessControl();
+
+        return [
+            $opportunity,
+            $registration,
+            $original_evaluation,
+            $appeal_phase,
+            $slot_owner,
+            $corrector,
+        ];
+    }
+
+    function testCanPersistAndRetrieveAllFields(): void
+    {
+        $admin = $this->userDirector->createUser('admin');
+
+        [
+            $opportunity,
+            $registration,
+            $original_evaluation,
+            $appeal_phase,
+            $slot_owner,
+            $corrector,
+        ] = $this->createAppealReviewScenario($admin);
+
+        $starts_at = new DateTime('2026-08-01 09:00:00');
+        $ends_at = new DateTime('2026-08-10 18:00:00');
+
+        $review = new RegistrationAppealReview();
+        $review->originalEvaluation = $original_evaluation;
+        $review->registration = $registration;
+        $review->appealPhase = $appeal_phase;
+        $review->slotOwnerUser = $slot_owner;
+        $review->correctorUser = $corrector;
+        $review->status = RegistrationAppealReview::STATUS_DRAFT;
+        $review->correctionType = RegistrationAppealReview::CORRECTION_TYPE_OFFICIAL;
+        $review->releasedScope = (object) ['fields' => ['field1', 'field2']];
+        $review->startsAt = $starts_at;
+        $review->endsAt = $ends_at;
+        $review->originalValue = (object) ['score' => 5.0, 'result' => 'approved'];
+        $review->correctedValue = (object) ['score' => 7.5, 'result' => 'approved'];
+        $review->originalScore = 5.0;
+        $review->correctedScore = 7.5;
+        $review->sentTimestamp = new DateTime('2026-08-09 14:30:00');
+
+        $app = App::i();
+        $app->disableAccessControl();
+        $review->save(true);
+        $app->enableAccessControl();
+
+        $this->assertNotNull($review->id, 'O ID da revisão de recurso deve ser gerado.');
+
+        $retrieved = $app->repo('OpportunityAppealPhase\Entities\RegistrationAppealReview')->find($review->id);
+
+        $this->assertInstanceOf(RegistrationAppealReview::class, $retrieved);
+        $this->assertEquals($original_evaluation->id, $retrieved->originalEvaluation->id);
+        $this->assertEquals($registration->id, $retrieved->registration->id);
+        $this->assertEquals($appeal_phase->id, $retrieved->appealPhase->id);
+        $this->assertEquals($slot_owner->id, $retrieved->slotOwnerUser->id);
+        $this->assertEquals($corrector->id, $retrieved->correctorUser->id);
+        $this->assertEquals(RegistrationAppealReview::STATUS_DRAFT, $retrieved->status);
+        $this->assertEquals(RegistrationAppealReview::CORRECTION_TYPE_OFFICIAL, $retrieved->correctionType);
+        $this->assertEquals(['fields' => ['field1', 'field2']], (array) $retrieved->releasedScope);
+        $this->assertEquals($starts_at->format('Y-m-d H:i:s'), $retrieved->startsAt->format('Y-m-d H:i:s'));
+        $this->assertEquals($ends_at->format('Y-m-d H:i:s'), $retrieved->endsAt->format('Y-m-d H:i:s'));
+        $this->assertEquals(['score' => 5.0, 'result' => 'approved'], (array) $retrieved->originalValue);
+        $this->assertEquals(['score' => 7.5, 'result' => 'approved'], (array) $retrieved->correctedValue);
+        $this->assertEqualsWithDelta(5.0, $retrieved->originalScore, 0.001);
+        $this->assertEqualsWithDelta(7.5, $retrieved->correctedScore, 0.001);
+        $this->assertNotNull($retrieved->createTimestamp, 'createTimestamp deve ser preenchido automaticamente.');
+        $this->assertEquals('2026-08-09 14:30:00', $retrieved->sentTimestamp->format('Y-m-d H:i:s'));
+        $this->assertNotNull($retrieved->updateTimestamp, 'updateTimestamp deve ser preenchido automaticamente.');
+    }
+
+    function testActiveSlotUniqueIndexPreventsDuplicateActiveDesignations(): void
+    {
+        $admin = $this->userDirector->createUser('admin');
+
+        [
+            $opportunity,
+            $registration,
+            $original_evaluation,
+            $appeal_phase,
+            $slot_owner,
+            $corrector,
+        ] = $this->createAppealReviewScenario($admin);
+
+        $app = App::i();
+        $app->disableAccessControl();
+
+        $review1 = new RegistrationAppealReview();
+        $review1->originalEvaluation = $original_evaluation;
+        $review1->registration = $registration;
+        $review1->appealPhase = $appeal_phase;
+        $review1->slotOwnerUser = $slot_owner;
+        $review1->correctorUser = $corrector;
+        $review1->status = RegistrationAppealReview::STATUS_DESIGNATED;
+        $review1->correctionType = RegistrationAppealReview::CORRECTION_TYPE_RECORD;
+        $review1->save(true);
+
+        $review2 = new RegistrationAppealReview();
+        $review2->originalEvaluation = $original_evaluation;
+        $review2->registration = $registration;
+        $review2->appealPhase = $appeal_phase;
+        $review2->slotOwnerUser = $slot_owner;
+        $review2->correctorUser = $corrector;
+        $review2->status = RegistrationAppealReview::STATUS_DRAFT;
+        $review2->correctionType = RegistrationAppealReview::CORRECTION_TYPE_RECORD;
+
+        $this->expectException(\Doctrine\DBAL\Exception\UniqueConstraintViolationException::class);
+        $review2->save(true);
+    }
+
+    function testSentSlotAllowsNewDesignation(): void
+    {
+        $admin = $this->userDirector->createUser('admin');
+
+        [
+            $opportunity,
+            $registration,
+            $original_evaluation,
+            $appeal_phase,
+            $slot_owner,
+            $corrector,
+        ] = $this->createAppealReviewScenario($admin);
+
+        $app = App::i();
+        $app->disableAccessControl();
+
+        $review1 = new RegistrationAppealReview();
+        $review1->originalEvaluation = $original_evaluation;
+        $review1->registration = $registration;
+        $review1->appealPhase = $appeal_phase;
+        $review1->slotOwnerUser = $slot_owner;
+        $review1->correctorUser = $corrector;
+        $review1->status = RegistrationAppealReview::STATUS_SENT;
+        $review1->correctionType = RegistrationAppealReview::CORRECTION_TYPE_RECORD;
+        $review1->save(true);
+
+        $review2 = new RegistrationAppealReview();
+        $review2->originalEvaluation = $original_evaluation;
+        $review2->registration = $registration;
+        $review2->appealPhase = $appeal_phase;
+        $review2->slotOwnerUser = $slot_owner;
+        $review2->correctorUser = $corrector;
+        $review2->status = RegistrationAppealReview::STATUS_DESIGNATED;
+        $review2->correctionType = RegistrationAppealReview::CORRECTION_TYPE_RECORD;
+        $review2->save(true);
+
+        $this->assertNotNull($review2->id, 'Uma nova designação deve ser permitida quando o slot anterior já foi enviado.');
+    }
+}


### PR DESCRIPTION
## Contexto

Parte do épico #7 (tarefa #14). A API genérica de avaliação não isola slots dentro da mesma inscrição; este endpoint dedicado expõe ao corretor designado **apenas** o seu slot, filtrado por `released_scope`.

## O que faz

- `GET /appealCorrector/environment/{assignmentId}` (`AppealCorrector::GET_environment`)
- `CorrectorEnvironment` monta o payload read-only:
  - `originalEvaluation` e `draft` filtrados pelos critérios liberados em `released_scope`
  - `committeeOpinion` incluído **somente** se `showAppealOpinion=true` (parecer da fase de recurso, casado por `number`)
- Gates: `requireAuthentication` + flag `APPEAL_SCORE_CORRECTION` + designação **ativa** + usuário logado = `correctorUser` + dentro do prazo (`startsAt`/`endsAt`)

## Contrato

```jsonc
{
  "assignmentId": 123,
  "targetEvaluatorName": "Ana",
  "deadline": "2026-09-01T23:59:59+00:00",
  "status": "draft",
  "correctionType": "official",
  "originalEvaluation": { "c-1": 4 },
  "draft": { "c-1": 7 },
  "committeeOpinion": { "registrationId": 456, "evaluations": ["..."] }
}
```

## Testes

- `AppealCorrectorEnvironmentTest`: **7/7 OK** (24 assertions) — cobre os 4 critérios de aceitação da #14 + happy path HTTP + 403 p/ outsider + rejeição de designação enviada
- Suíte completa: 703 testes, 30 erros **pré-existentes e idênticos no `develop`** (verificados por comparação direta `--filter 'RoutesTest|EventsFilterConfigTest'`: 17/25 no develop, 17/25 na base feature/13, 17/25 nesta branch). Nenhuma regressão introduzida.

## Stack de merges

Baseada em `feature/13-pr4-appeal-apply-correction` (#37). Ordem: **#27 → #37 → este**.

Refs #14 (épica #7)