### PR TITLE
PR5 — Notificações e e-mails de designação e correção

### DIFF
--- a/src/modules/OpportunityAppealPhase/AppealReview/Notifier.php
+++ b/src/modules/OpportunityAppealPhase/AppealReview/Notifier.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace OpportunityAppealPhase\AppealReview;
+
+use MapasCulturais\App;
+use MapasCulturais\Entities\Notification;
+use MapasCulturais\i;
+use OpportunityAppealPhase\Entities\RegistrationAppealReview;
+use OpportunityAppealPhase\Module;
+
+/**
+ * Notificações internas e e-mails da correção de notas pós-recurso.
+ *
+ * Spec: PR5 / issue #15.
+ * - Designação: corretor recebe notificação interna + e-mail.
+ * - Envio definitivo: corretor recebe confirmação; gestores (group-admin)
+ *   da oportunidade de origem são notificados.
+ * - Tudo gated por APPEAL_SCORE_CORRECTION; e-mails additionally gated pela
+ *   config sendMailNotification.opportunityAppealPhase (padrão do módulo).
+ */
+class Notifier
+{
+    public static function notifyDesignation(RegistrationAppealReview $review): void
+    {
+        if (!self::isScoreCorrectionEnabled()) {
+            return;
+        }
+
+        $corrector = $review->correctorUser;
+        if (!$corrector) {
+            return;
+        }
+
+        $registration = $review->registration;
+        $opportunity = $registration->opportunity;
+        $deadline = $review->endsAt
+            ? $review->endsAt->format('d/m/Y H:i')
+            : i::__('sem prazo definido');
+
+        $message = sprintf(
+            i::__('Você foi designado(a) corretor(a) da avaliação da inscrição %s em %s. Prazo para correção: %s.'),
+            $registration->number,
+            $opportunity->name,
+            $deadline
+        );
+
+        self::sendNotification($corrector, $message);
+        self::sendEmail($corrector, $review, true, $message);
+    }
+
+    public static function notifyCorrectionSent(RegistrationAppealReview $review): void
+    {
+        if (!self::isScoreCorrectionEnabled()) {
+            return;
+        }
+
+        $corrector = $review->correctorUser;
+        $registration = $review->registration;
+        $opportunity = $registration->opportunity;
+
+        $corrector_name = '';
+        if ($corrector) {
+            $corrector_name = $corrector->profile
+                ? (string) $corrector->profile->name
+                : (string) $corrector->email;
+        }
+
+        if ($corrector) {
+            $message = sprintf(
+                i::__('Sua correção da avaliação da inscrição %s em %s foi aplicada e enviada.'),
+                $registration->number,
+                $opportunity->name
+            );
+
+            self::sendNotification($corrector, $message);
+            self::sendEmail($corrector, $review, false, $message);
+        }
+
+        foreach (self::managerRelations($opportunity) as $relation) {
+            if ($relation->group !== 'group-admin' || !$relation->agent || !$relation->agent->ownerUser) {
+                continue;
+            }
+
+            $manager = $relation->agent->ownerUser;
+            if ($corrector && $manager->equals($corrector)) {
+                continue;
+            }
+
+            $message = sprintf(
+                i::__('A correção da avaliação da inscrição %s em %s foi enviada pelo corretor %s.'),
+                $registration->number,
+                $opportunity->name,
+                $corrector_name
+            );
+
+            self::sendNotification($manager, $message);
+            self::sendEmail($manager, $review, false, $message);
+        }
+    }
+
+    /**
+     * Relações group-admin ativas, consultadas direto no repositório para
+     * não depender do cache __agentRelations da entidade oportunidade.
+     *
+     * @param \MapasCulturais\Entities\Opportunity $opportunity
+     * @return \MapasCulturais\Entities\OpportunityAgentRelation[]
+     */
+    private static function managerRelations($opportunity): array
+    {
+        $app = App::i();
+        $relations = $app->repo(\MapasCulturais\Entities\OpportunityAgentRelation::class)
+            ->findBy(['owner' => $opportunity]);
+
+        $agent_statuses = [
+            \MapasCulturais\Entities\Agent::STATUS_ENABLED,
+            \MapasCulturais\Entities\Agent::STATUS_INVITED,
+            \MapasCulturais\Entities\Agent::STATUS_RELATED,
+        ];
+
+        return array_values(array_filter(
+            $relations,
+            fn ($relation) => $relation->status > 0
+                && $relation->agent
+                && in_array($relation->agent->status, $agent_statuses, true)
+        ));
+    }
+
+    private static function isScoreCorrectionEnabled(): bool
+    {
+        $module = App::i()->modules['OpportunityAppealPhase'] ?? null;
+        $default = false;
+        if ($module instanceof Module) {
+            $default = (bool) ($module->config['featureFlag.appealScoreCorrection'] ?? false);
+        }
+
+        return (bool) env('APPEAL_SCORE_CORRECTION', $default);
+    }
+
+    private static function isMailEnabled(): bool
+    {
+        $module = App::i()->modules['OpportunityAppealPhase'] ?? null;
+        $default = false;
+        if ($module instanceof Module) {
+            $default = (bool) ($module->config['sendMailNotification.opportunityAppealPhase'] ?? false);
+        }
+
+        return (bool) env('SEND_MAIL_OPPORTUNITY_APPEAL_PHASE', $default);
+    }
+
+    private static function sendNotification($user, string $message): void
+    {
+        $notification = new Notification;
+        $notification->user = $user;
+        $notification->message = $message;
+        $notification->save(true);
+    }
+
+    private static function sendEmail($user, RegistrationAppealReview $review, bool $is_designation, string $message): void
+    {
+        if (!self::isMailEnabled()) {
+            return;
+        }
+
+        $app = App::i();
+
+        $email = null;
+        if ($user->profile) {
+            $email = $user->profile->emailPrivado ?? $user->profile->emailPublico ?? null;
+        }
+        $email = $email ?? $user->email;
+
+        if (!$email) {
+            return;
+        }
+
+        $registration = $review->registration;
+        $original_opportunity = $registration->opportunity;
+        $appeal_phase = $review->appealPhase;
+
+        $subject = $is_designation
+            ? sprintf(i::__('Você foi designado(a) corretor(a) em %s'), $original_opportunity->name)
+            : sprintf(i::__('Correção de avaliação enviada em %s'), $original_opportunity->name);
+
+        $params = [
+            'siteName' => $app->siteName,
+            'message' => $message,
+            'isDesignation' => $is_designation,
+            'isCorrectionSent' => !$is_designation,
+            'opportunityName' => $original_opportunity->name,
+            'opportunityUrl' => $original_opportunity->singleUrl,
+            'phaseName' => $appeal_phase ? $appeal_phase->name : null,
+            'phaseUrl' => $appeal_phase ? $appeal_phase->singleUrl : null,
+            'registrationNumber' => $registration->number,
+            'registrationUrl' => $registration->singleUrl,
+            'deadline' => $review->endsAt ? $review->endsAt->format('d/m/Y H:i') : null,
+        ];
+
+        $template = $is_designation
+            ? 'opportunityappealphase/correction-designation.html'
+            : 'opportunityappealphase/correction-sent.html';
+
+        $app->createAndSendMailMessage([
+            'from' => $app->config['mailer.from'],
+            'to' => $email,
+            'subject' => $subject,
+            'body' => $app->renderMustacheTemplate($template, $params),
+        ]);
+    }
+}

--- a/src/modules/OpportunityAppealPhase/AppealReview/Service.php
+++ b/src/modules/OpportunityAppealPhase/AppealReview/Service.php
@@ -105,6 +105,9 @@ class Service
             throw $e;
         }
 
+        // PR5 (issue #15): notifica correção enviada — somente após o commit
+        Notifier::notifyCorrectionSent($review);
+
         return $review;
     }
 

--- a/src/modules/OpportunityAppealPhase/Module.php
+++ b/src/modules/OpportunityAppealPhase/Module.php
@@ -11,6 +11,7 @@ use MapasCulturais\Entities\Registration;
 use MapasCulturais\Entities\RegistrationEvaluation;
 use MapasCulturais\Entities\RegistrationStep;
 use MapasCulturais\i;
+use OpportunityAppealPhase\AppealReview\Notifier;
 use OpportunityAppealPhase\Entities\RegistrationAppealReview;
 
 class Module extends \MapasCulturais\Module {
@@ -46,6 +47,12 @@ class Module extends \MapasCulturais\Module {
             }
 
             $result = $self->canDesignatedCorrectorAccessSlot($this, $user);
+        });
+
+        // PR5 (issue #15): notifica corretor designado quando a designação é criada
+        $app->hook('entity(OpportunityAppealPhase.Entities.RegistrationAppealReview).insert:after', function () {
+            /** @var RegistrationAppealReview $this */
+            Notifier::notifyDesignation($this);
         });
 
         /* Endpoint de criação de fase de recurso na oportunidade */

--- a/src/modules/OpportunityAppealPhase/templates/es_ES/opportunityappealphase/correction-designation.html
+++ b/src/modules/OpportunityAppealPhase/templates/es_ES/opportunityappealphase/correction-designation.html
@@ -1,0 +1,33 @@
+{{{_header}}}
+<table role="presentation" class="main">
+    <tr>
+        <td class="wrapper">
+            <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                <tr>
+                    <td>
+                        <p>{{message}}</p>
+
+                        {{#isDesignation}}
+                            <p>Ha sido designado(a) para corregir la evaluación de esta inscripción tras la deferencia de un recurso.</p>
+                        {{/isDesignation}}
+
+                        <p>
+                            <strong>Oportunidad: </strong> <a href="{{opportunityUrl}}" rel="noopener noreferrer">{{opportunityName}}</a><br>
+                            {{#phaseUrl}}<strong>Fase de recurso: </strong> <a href="{{phaseUrl}}" rel="noopener noreferrer">{{phaseName}}</a><br>{{/phaseUrl}}
+                            <strong>Inscripción: </strong> <a href="{{registrationUrl}}" rel="noopener noreferrer">{{registrationNumber}}</a><br>
+                            {{#deadline}}<strong>Plazo para corrección: </strong> {{deadline}}{{/deadline}}
+                        </p>
+
+                        <br>
+                        <a href="{{registrationUrl}}" rel="noopener noreferrer">
+                            <div class="status-card status-card--primary">
+                                <h2 class="status-card--title">Acceder a la inscripción</h2>
+                            </div>
+                        </a>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+{{{_footer}}}

--- a/src/modules/OpportunityAppealPhase/templates/es_ES/opportunityappealphase/correction-sent.html
+++ b/src/modules/OpportunityAppealPhase/templates/es_ES/opportunityappealphase/correction-sent.html
@@ -1,0 +1,33 @@
+{{{_header}}}
+<table role="presentation" class="main">
+    <tr>
+        <td class="wrapper">
+            <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                <tr>
+                    <td>
+                        <p>{{message}}</p>
+
+                        {{#isCorrectionSent}}
+                            <p>La corrección de la evaluación de esta inscripción ha sido aplicada y enviada.</p>
+                        {{/isCorrectionSent}}
+
+                        <p>
+                            <strong>Oportunidad: </strong> <a href="{{opportunityUrl}}" rel="noopener noreferrer">{{opportunityName}}</a><br>
+                            {{#phaseUrl}}<strong>Fase de recurso: </strong> <a href="{{phaseUrl}}" rel="noopener noreferrer">{{phaseName}}</a><br>{{/phaseUrl}}
+                            <strong>Inscripción: </strong> <a href="{{registrationUrl}}" rel="noopener noreferrer">{{registrationNumber}}</a><br>
+                            {{#deadline}}<strong>Plazo: </strong> {{deadline}}{{/deadline}}
+                        </p>
+
+                        <br>
+                        <a href="{{registrationUrl}}" rel="noopener noreferrer">
+                            <div class="status-card status-card--primary">
+                                <h2 class="status-card--title">Acceder a la inscripción</h2>
+                            </div>
+                        </a>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+{{{_footer}}}

--- a/src/modules/OpportunityAppealPhase/templates/pt_BR/opportunityappealphase/correction-designation.html
+++ b/src/modules/OpportunityAppealPhase/templates/pt_BR/opportunityappealphase/correction-designation.html
@@ -1,0 +1,33 @@
+{{{_header}}}
+<table role="presentation" class="main">
+    <tr>
+        <td class="wrapper">
+            <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                <tr>
+                    <td>
+                        <p>{{message}}</p>
+
+                        {{#isDesignation}}
+                            <p>Você foi designado(a) para corrigir a avaliação desta inscrição após deferimento de recurso.</p>
+                        {{/isDesignation}}
+
+                        <p>
+                            <strong>Oportunidade: </strong> <a href="{{opportunityUrl}}" rel="noopener noreferrer">{{opportunityName}}</a><br>
+                            {{#phaseUrl}}<strong>Fase de recurso: </strong> <a href="{{phaseUrl}}" rel="noopener noreferrer">{{phaseName}}</a><br>{{/phaseUrl}}
+                            <strong>Inscrição: </strong> <a href="{{registrationUrl}}" rel="noopener noreferrer">{{registrationNumber}}</a><br>
+                            {{#deadline}}<strong>Prazo para correção: </strong> {{deadline}}{{/deadline}}
+                        </p>
+
+                        <br>
+                        <a href="{{registrationUrl}}" rel="noopener noreferrer">
+                            <div class="status-card status-card--primary">
+                                <h2 class="status-card--title">Acessar inscrição</h2>
+                            </div>
+                        </a>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+{{{_footer}}}

--- a/src/modules/OpportunityAppealPhase/templates/pt_BR/opportunityappealphase/correction-sent.html
+++ b/src/modules/OpportunityAppealPhase/templates/pt_BR/opportunityappealphase/correction-sent.html
@@ -1,0 +1,33 @@
+{{{_header}}}
+<table role="presentation" class="main">
+    <tr>
+        <td class="wrapper">
+            <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                <tr>
+                    <td>
+                        <p>{{message}}</p>
+
+                        {{#isCorrectionSent}}
+                            <p>A correção da avaliação desta inscrição foi aplicada e enviada.</p>
+                        {{/isCorrectionSent}}
+
+                        <p>
+                            <strong>Oportunidade: </strong> <a href="{{opportunityUrl}}" rel="noopener noreferrer">{{opportunityName}}</a><br>
+                            {{#phaseUrl}}<strong>Fase de recurso: </strong> <a href="{{phaseUrl}}" rel="noopener noreferrer">{{phaseName}}</a><br>{{/phaseUrl}}
+                            <strong>Inscrição: </strong> <a href="{{registrationUrl}}" rel="noopener noreferrer">{{registrationNumber}}</a><br>
+                            {{#deadline}}<strong>Prazo: </strong> {{deadline}}{{/deadline}}
+                        </p>
+
+                        <br>
+                        <a href="{{registrationUrl}}" rel="noopener noreferrer">
+                            <div class="status-card status-card--primary">
+                                <h2 class="status-card--title">Acessar inscrição</h2>
+                            </div>
+                        </a>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+{{{_footer}}}

--- a/tests/src/AppealCorrectionNotificationsTest.php
+++ b/tests/src/AppealCorrectionNotificationsTest.php
@@ -1,0 +1,315 @@
+<?php
+
+namespace Tests;
+
+use DateTime;
+use MapasCulturais\App;
+use MapasCulturais\Entities\Notification;
+use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\Entities\OpportunityAgentRelation;
+use MapasCulturais\Entities\Registration;
+use MapasCulturais\Entities\RegistrationEvaluation;
+use MapasCulturais\Entities\User;
+use OpportunityAppealPhase\AppealReview\Notifier;
+use OpportunityAppealPhase\AppealReview\Service;
+use OpportunityAppealPhase\Entities\RegistrationAppealReview;
+use Symfony\Component\Mime\Email;
+use Tests\Abstract\TestCase;
+use Tests\Builders\PhasePeriods\ConcurrentEndingAfter;
+use Tests\Builders\PhasePeriods\Open;
+use Tests\Enums\EvaluationMethods;
+use Tests\Mailer\TestTransport;
+use Tests\Traits\OpportunityBuilder;
+use Tests\Traits\RegistrationDirector;
+use Tests\Traits\UserDirector;
+
+/**
+ * PR5 (issue #15): notificações internas e e-mails de designação e correção.
+ */
+class AppealCorrectionNotificationsTest extends TestCase
+{
+    use OpportunityBuilder,
+        RegistrationDirector,
+        UserDirector;
+
+    private User $manager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $app = App::i();
+        $app->clearHooks('mailer.transport');
+        $app->hook('mailer.transport', function (&$transport) {
+            $transport = new TestTransport;
+        });
+        $app->config['mailer.from'] = 'test@mapasculturais.org';
+        $_ENV['SEND_MAIL_OPPORTUNITY_APPEAL_PHASE'] = 'true';
+        TestTransport::reset();
+    }
+
+    private function enableFlag(): void
+    {
+        $_ENV['APPEAL_SCORE_CORRECTION'] = 'true';
+    }
+
+    private function countNotifications(User $user): int
+    {
+        return count(App::i()->repo(Notification::class)->findBy(['user' => $user]));
+    }
+
+    /**
+     * @return array{corrector: User, manager: User, review: RegistrationAppealReview, registration: Registration}
+     */
+    private function createScenario(): array
+    {
+        $this->enableFlag();
+
+        $admin = $this->userDirector->createUser('admin');
+        $slot_owner = $this->userDirector->createUser();
+        $corrector = $this->userDirector->createUser();
+        $this->manager = $this->userDirector->createUser();
+        $this->login($admin);
+
+        $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase(EvaluationMethods::technical)
+                ->fillRequiredProperties()
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->save()
+                ->config()
+                    ->addSection('sec-1', 'Seção 1')
+                    ->addCriterion('c-1', 'sec-1', 'Critério 1', 0, 10, 1)
+                    ->done()
+                ->save()
+                ->addValuer('Comissão', 'Avaliador', $slot_owner->profile)
+                    ->done()
+                ->done()
+            ->save();
+
+        $opportunity = $this->opportunityBuilder->getInstance();
+        $registration = $this->registrationDirector->createSentRegistration($opportunity, data: []);
+
+        $app = App::i();
+        $app->disableAccessControl();
+
+        $slot = new RegistrationEvaluation();
+        $slot->registration = $registration;
+        $slot->user = $slot_owner;
+        $slot->setEvaluationData((object) ['c-1' => 4]);
+        $slot->status = RegistrationEvaluation::STATUS_SENT;
+        $slot->sentTimestamp = new DateTime();
+        $slot->save(true);
+
+        // gestor (group-admin) da oportunidade — destinatário da notificação de correção enviada
+        $manager_relation = new OpportunityAgentRelation();
+        $manager_relation->owner = $opportunity;
+        $manager_relation->group = 'group-admin';
+        $manager_relation->agent = $this->manager->profile;
+        $manager_relation->hasControl = true;
+        $manager_relation->save(true);
+
+        $appeal_phase_class = $opportunity->getSpecializedClassName();
+        /** @var Opportunity $appeal_phase */
+        $appeal_phase = new $appeal_phase_class();
+        $appeal_phase->parent = $opportunity;
+        $appeal_phase->status = Opportunity::STATUS_APPEAL_PHASE;
+        $appeal_phase->name = 'Recurso técnico';
+        $appeal_phase->ownerEntity = $opportunity->ownerEntity;
+        $appeal_phase->owner = $opportunity->owner;
+        $appeal_phase->isDataCollection = true;
+        $appeal_phase->isAppealPhase = true;
+        $appeal_phase->registrationFrom = new DateTime('-1 day');
+        $appeal_phase->registrationTo = new DateTime('+1 day');
+        $appeal_phase->save(true);
+
+        $opportunity->appealPhase = $appeal_phase;
+        $opportunity->save(true);
+
+        $app->enableAccessControl();
+
+        return [
+            'corrector' => $corrector,
+            'manager' => $this->manager,
+            'registration' => $registration,
+            'slot' => $slot,
+            'appealPhase' => $appeal_phase,
+            'opportunity' => $opportunity,
+        ];
+    }
+
+    private function createReview(array $scenario): RegistrationAppealReview
+    {
+        $app = App::i();
+        $app->disableAccessControl();
+
+        $review = new RegistrationAppealReview();
+        $review->originalEvaluation = $scenario['slot'];
+        $review->registration = $scenario['registration'];
+        $review->appealPhase = $scenario['appealPhase'];
+        $review->slotOwnerUser = $scenario['slot']->user;
+        $review->correctorUser = $scenario['corrector'];
+        $review->status = RegistrationAppealReview::STATUS_DESIGNATED;
+        $review->correctionType = RegistrationAppealReview::CORRECTION_TYPE_OFFICIAL;
+        $review->releasedScope = (object) ['criteria' => ['c-1'], 'showAppealOpinion' => false];
+        $review->startsAt = new DateTime('-1 hour');
+        $review->endsAt = new DateTime('+1 day');
+        $review->originalValue = $scenario['slot']->getEvaluationData();
+        $review->originalScore = (float) $scenario['slot']->result;
+        $review->save(true);
+
+        $app->enableAccessControl();
+
+        return $review;
+    }
+
+    function testDesignatedCorrectorReceivesInternalNotification(): void
+    {
+        $scenario = $this->createScenario();
+        TestTransport::reset();
+        $before = $this->countNotifications($scenario['corrector']);
+
+        $review = $this->createReview($scenario);
+
+        $after = $this->countNotifications($scenario['corrector']);
+        $this->assertSame($before + 1, $after, 'Corretor designado deveria receber exatamente 1 notificação interna');
+
+        $last = App::i()->repo(Notification::class)->findOneBy(['user' => $scenario['corrector']], ['id' => 'DESC']);
+        $this->assertStringContainsString('designado', $last->message);
+        $this->assertStringContainsString($scenario['registration']->number, $last->message);
+        $this->assertNotNull($review->id);
+    }
+
+    function testDesignatedCorrectorReceivesEmail(): void
+    {
+        $scenario = $this->createScenario();
+        TestTransport::reset();
+
+        $this->createReview($scenario);
+
+        $this->assertGreaterThan(0, TestTransport::getMessagesCount(), 'Deveria disparar e-mail na designação');
+
+        $found = false;
+        foreach (TestTransport::getSentMessages() as $sent) {
+            $original = $sent->getOriginalMessage();
+            if (!$original instanceof Email) {
+                continue;
+            }
+            foreach ($original->getTo() as $address) {
+                if ($address->getAddress() === $scenario['corrector']->email) {
+                    $this->assertStringContainsString('designado', $original->getSubject());
+                    $this->assertStringContainsString($scenario['registration']->number, (string) $original->getHtmlBody());
+                    $found = true;
+                }
+            }
+        }
+        $this->assertTrue($found, 'E-mail de designação deveria ir para o e-mail do corretor');
+    }
+
+    function testManagerNotifiedWhenCorrectionSent(): void
+    {
+        $scenario = $this->createScenario();
+        $review = $this->createReview($scenario);
+
+        $manager_before = $this->countNotifications($scenario['manager']);
+        $corrector_before = $this->countNotifications($scenario['corrector']);
+        TestTransport::reset();
+
+        $this->login($scenario['corrector']);
+        (new Service())->applyCorrection($review, ['c-1' => 9]);
+
+        $this->assertSame($manager_before + 1, $this->countNotifications($scenario['manager']),
+            'Gestor (group-admin) deveria ser notificado do envio da correção');
+        $this->assertSame($corrector_before + 1, $this->countNotifications($scenario['corrector']),
+            'Corretor deveria receber confirmação do envio');
+
+        $last = App::i()->repo(Notification::class)->findOneBy(['user' => $scenario['manager']], ['id' => 'DESC']);
+        $this->assertStringContainsString('enviada pelo corretor', $last->message);
+    }
+
+    function testCorrectionSentEmailsToCorrectorAndManager(): void
+    {
+        $scenario = $this->createScenario();
+        $review = $this->createReview($scenario);
+        TestTransport::reset();
+
+        $this->login($scenario['corrector']);
+        (new Service())->applyCorrection($review, ['c-1' => 9]);
+
+        $recipients = [];
+        foreach (TestTransport::getSentMessages() as $sent) {
+            $original = $sent->getOriginalMessage();
+            if ($original instanceof Email) {
+                foreach ($original->getTo() as $address) {
+                    $recipients[] = $address->getAddress();
+                }
+            }
+        }
+
+        $this->assertContains($scenario['corrector']->email, $recipients, 'Corretor deveria receber e-mail de confirmação');
+        $this->assertContains($scenario['manager']->email, $recipients, 'Gestor deveria receber e-mail de correção enviada');
+    }
+
+    function testNoNotificationWhenFlagDisabled(): void
+    {
+        $scenario = $this->createScenario();
+        $_ENV['APPEAL_SCORE_CORRECTION'] = 'false';
+        TestTransport::reset();
+        $before = $this->countNotifications($scenario['corrector']);
+
+        $this->createReview($scenario);
+
+        $this->assertSame($before, $this->countNotifications($scenario['corrector']),
+            'Flag desligada não deve gerar notificação de designação');
+        $this->assertSame(0, TestTransport::getMessagesCount(),
+            'Flag desligada não deve disparar e-mails');
+    }
+
+    function testTemplatesRenderWithExpectedContent(): void
+    {
+        $app = App::i();
+        $params = [
+            'siteName' => $app->siteName,
+            'message' => 'mensagem de teste',
+            'isDesignation' => true,
+            'isCorrectionSent' => false,
+            'opportunityName' => 'Edital Teste',
+            'opportunityUrl' => 'https://example.org/opportunity',
+            'phaseName' => 'Recurso',
+            'phaseUrl' => 'https://example.org/recurso',
+            'registrationNumber' => '1234',
+            'registrationUrl' => 'https://example.org/inscricao',
+            'deadline' => '05/09/2026 23:59',
+        ];
+
+        $designation = $app->renderMustacheTemplate('opportunityappealphase/correction-designation.html', $params);
+        $this->assertStringContainsString('designado', $designation);
+        $this->assertStringContainsString('Prazo para correção', $designation);
+        $this->assertStringContainsString('1234', $designation);
+
+        $params['isDesignation'] = false;
+        $params['isCorrectionSent'] = true;
+        $sent = $app->renderMustacheTemplate('opportunityappealphase/correction-sent.html', $params);
+        $this->assertStringContainsString('foi aplicada e enviada', $sent);
+        $this->assertStringContainsString('Edital Teste', $sent);
+    }
+
+    function testNotifierRespectsMailConfigDisabled(): void
+    {
+        $scenario = $this->createScenario();
+        $_ENV['SEND_MAIL_OPPORTUNITY_APPEAL_PHASE'] = 'false';
+        TestTransport::reset();
+        $before = $this->countNotifications($scenario['corrector']);
+
+        $this->createReview($scenario);
+
+        // notificação interna sempre; e-mail só com mail habilitado
+        $this->assertSame($before + 1, $this->countNotifications($scenario['corrector']));
+        $this->assertSame(0, TestTransport::getMessagesCount());
+    }
+}


### PR DESCRIPTION
## Contexto

Épica #7, tarefa #15. Corretor designado precisa saber que foi designado; gestores precisam saber quando a correção foi enviada.

## O que faz

**Na designação** (hook `entity(OpportunityAppealPhase.Entities.RegistrationAppealReview).insert:after`):
- Notificação interna + e-mail ao corretor designado (template `correction-designation`, pt_BR + es_ES)

**No envio definitivo** (`Service::applyCorrection`, **após o commit** — nunca para correção revertida):
- Confirmação (notificação + e-mail) ao corretor
- Notificação + e-mail aos gestores `group-admin` da oportunidade (template `correction-sent`)

**Gates:** `APPEAL_SCORE_CORRECTION` controla tudo; e-mails adicionalmente exigem `SEND_MAIL_OPPORTUNITY_APPEAL_PHASE` (ou config do módulo). Mensagens/assuntos via `i::__()`; templates por locale — padrão do módulo.

## Detalhes técnicos que valem registro

- Hook de entidade de módulo exige **caminho pontuado** (`Modulo.Entities.Entidade`) — nome curto nunca dispara (getHookClassPath só remove o prefixo MapasCulturais.Entities)
- Gestores consultados via repo direto com filtros de status — imune ao cache `__agentRelations` stale da entidade
- `SEND_MAIL_OPPORTUNITY_APPEAL_PHASE` agora consultado em runtime (env > config), consistente com as demais flags

## Testes

- `AppealCorrectionNotificationsTest`: **7/7 OK** (22 assertions) — notificação interna do corretor, e-mail de designação, notificação+e-mail do gestor no envio, confirmação do corretor, flag desligada silencia tudo, mail desabilitado silencia só e-mail, templates renderizam
- Regressão (suítes de appeal no estado integrado): **29/29 OK** (106 assertions)

Closes #15 (épica #7)
