### PR TITLE
F2 — Modal de designação de corretores por slot (#18)

### DIFF
--- a/docs/rounds/R01-2026-08-correcao-notas-recurso/deviations.md
+++ b/docs/rounds/R01-2026-08-correcao-notas-recurso/deviations.md
@@ -1,0 +1,3 @@
+# Deviations — R01 (Correção de notas após deferimento de recurso)
+
+Nenhum desvio nesta rodada.

--- a/docs/rounds/R01-2026-08-correcao-notas-recurso/scope.md
+++ b/docs/rounds/R01-2026-08-correcao-notas-recurso/scope.md
@@ -1,0 +1,12 @@
+# R01 — Correção de notas após deferimento de recurso
+
+> Registro da rodada (record) — imutável após o fechamento.
+> Pasta criada retroativamente em 2026-09-04: a rodada começou sem registro; criação combinada na inicialização de F1/F2.
+
+## Escopo (reconstruído da épica #7, do PRD vivo e da onda de tarefas)
+
+**Demanda:** permitir que gestores designem corretores para ajustar notas individuais de avaliadores (slots) em inscrições com recurso deferido, sem reabrir a fase avaliativa.
+
+- Épica: #7 (variante Condensed; override Full→Condensed registrado em 2026-08-21 por @cesardelucca)
+- PRD vivo: docs/reference/prd.md (RF-A15; CA-1..CA-13) — fonte dos requisitos
+- Onda de execução: PR1 #10, PR2 #11, PR3 #12, PR4 #13, PR4.5 #14 (backend — entregues no develop); F1 #17, F2 #18, F3 #19, F4 #20, PR5 #15 (interface — em curso)

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/README.md
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/README.md
@@ -45,8 +45,8 @@ window.dispatchEvent(new CustomEvent(
 
 | Dado | Fonte | Observação |
 |------|-------|------------|
-| Slots da inscrição | `GET /api/registrationevaluation/find` (`registration=EQ(id)`) | API filtra por permissão de visão |
-| Comissão de Recursos + fase de recurso | Injeção do `init.php` (`$MAPAS.config.appealCorrectionAssignment`) | Espelha os gates de `eligibleCorrectors()`; exige `@control` |
+| Slots da inscrição | `GET /api/registrationevaluation/find` (`registration=EQ(id)`) | API filtra por permissão de visão; leitura **raw** obrigatória (`raw: true` — `rawProcessor` sozinho não ativa o modo raw e o `populate` do SDK descarta relações escalares); a relação `user` volta sempre ESCALAR (não expande) |
+| Comissão de Recursos (`committees`) + avaliadores da fase principal (`evaluators`, mapa `{userId: name}`) + fase de recurso (`appealPhases`) | Injeção do `init.php` (`$MAPAS.config.appealCorrectionAssignment`) | Espelha os gates de `eligibleCorrectors()`; exige `@control`; `evaluators` é a fonte dos nomes dos donos de slot (a API de avaliação não expõe nome) |
 | Criação/leitura de designações | API canônica de `registrationappealreview` | **Disponível somente quando `endpointAvailable`** — requer controller registrado para a entidade no backend |
 
 ### Estado bloqueado (`endpointAvailable = false`)

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/README.md
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/README.md
@@ -1,0 +1,66 @@
+# Componente `<opportunity-appeal-correction-assignment>`
+
+Modal de designação de corretores por slot (F2 / issue #18, épica #7 — RF-A30).
+Lista as avaliações da fase principal de uma inscrição com recurso deferido,
+uma por avaliador, e permite ao gestor marcar quais notas serão corrigidas e
+designar **1 corretor por slot** — restrito ao dono do slot e aos membros da
+Comissão de Recursos (mesma composição de `RegistrationAppealReview::eligibleCorrectors()`).
+
+Também exibe o acompanhamento por slot (designado / rascunho / enviado /
+reaberto, prazo e data de envio), somente leitura. Substituição de corretor e
+reabertura não fazem parte do componente.
+
+## Uso
+
+Não recebe props: é aberto programaticamente por evento global (interface
+pública consumida pelo F1). A view só precisa importá-lo e renderizá-lo uma
+única vez:
+
+```php
+<?php $this->import('opportunity-appeal-correction-assignment'); ?>
+<opportunity-appeal-correction-assignment></opportunity-appeal-correction-assignment>
+```
+
+Abertura (assinatura documentada também no `init.php`):
+
+```js
+window.dispatchEvent(new CustomEvent(
+    'opportunity-appeal-correction-assignment:open',
+    {
+        detail: {
+            opportunity: Entity|{id},   // fase principal (avaliativa) da inscrição
+            registration: Entity|{id, number?}, // inscrição da fase principal (não a da fase de recurso)
+        }
+    }
+));
+```
+
+## Eventos emitidos
+
+| Evento   | Payload | Quando |
+|----------|---------|--------|
+| `saved`  | `{registrationId}` | Após criar todas as designações marcadas com sucesso |
+
+## Fontes de dados (somente endpoints existentes)
+
+| Dado | Fonte | Observação |
+|------|-------|------------|
+| Slots da inscrição | `GET /api/registrationevaluation/find` (`registration=EQ(id)`) | API filtra por permissão de visão |
+| Comissão de Recursos + fase de recurso | Injeção do `init.php` (`$MAPAS.config.appealCorrectionAssignment`) | Espelha os gates de `eligibleCorrectors()`; exige `@control` |
+| Criação/leitura de designações | API canônica de `registrationappealreview` | **Disponível somente quando `endpointAvailable`** — requer controller registrado para a entidade no backend |
+
+### Estado bloqueado (`endpointAvailable = false`)
+
+Enquanto a entidade `RegistrationAppealReview` não tiver controller registrado
+no backend (criação é backend de out of scope da F2), salvar e acompanhar
+ficam desabilitados: o modal exibe aviso explícito e o botão de salvar fica
+inativo. O restante da interface (lista de slots e opções de corretor) opera
+normalmente. Quando o controller existir, os fluxos ativam-se sem alteração
+neste componente.
+
+## Defaults de criação
+
+Por linha marcada cria-se: `status=DESIGNATED`, `correctionType=official`
+(correção oficial), prazo e escopo de critérios livres (`null`). A
+parametrização completa (prazo, escopo, `record`, visibilidade do parecer) é
+tratada em outra onda da épica (CA-4).

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/README.md
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/README.md
@@ -58,6 +58,14 @@ inativo. O restante da interface (lista de slots e opções de corretor) opera
 normalmente. Quando o controller existir, os fluxos ativam-se sem alteração
 neste componente.
 
+## Estilo
+
+A estrutura do diálogo vem do `mc-modal` (`.modal-content`/`.modal__*` + botões
+`.button--primary`/`.button--text`, responsivo). O conteúdo interno usa classes
+utilitárias do tema (`.semibold`, `.{primary|success|warning|danger}__color`,
+`.warning__background`) e o `style.css` local do componente (auto-enfileirado,
+sem passo de build — mesmo padrão do `mc-modal`), com tokens `--mc-*`.
+
 ## Defaults de criação
 
 Por linha marcada cria-se: `status=DESIGNATED`, `correctionType=official`

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/init.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/init.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Componente: opportunity-appeal-correction-assignment (F2 / issue #18).
+ *
+ * Interface pública para abrir o modal de designação de corretores por slot
+ * (consumida pelo F1 — botão na lista de inscritos — e por qualquer outra
+ * integração):
+ *
+ *     window.dispatchEvent(new CustomEvent(
+ *         'opportunity-appeal-correction-assignment:open',
+ *         {
+ *             detail: {
+ *                 // fase principal (avaliativa) da inscrição.
+ *                 // Entity do SDK ou objeto com ao menos {id}.
+ *                 opportunity: Entity|{id},
+ *
+ *                 // inscrição da fase principal com recurso deferido
+ *                 // (NÃO a inscrição da fase de recurso).
+ *                 // Entity do SDK ou objeto com ao menos {id, number?}.
+ *                 registration: Entity|{id, number?},
+ *             }
+ *         }
+ *     ));
+ *
+ * Requisitos:
+ * - A view deve importar e renderizar o componente uma única vez:
+ *   `$this->import('opportunity-appeal-correction-assignment');`
+ *   seguido de `<opportunity-appeal-correction-assignment></opportunity-appeal-correction-assignment>`
+ *   (o listener do evento é registrado no mounted() do Vue).
+ * - A designação só fica habilitada quando a oportunidade em contexto é uma
+ *   fase técnica com fase de recurso ativa e o usuário tem `@control`.
+ *
+ * Fontes de dados (somente endpoints existentes):
+ * - Slots: GET /api/registrationevaluation/find (uma avaliação por avaliador).
+ * - Comissão de Recursos: injetada aqui (mesma origem de
+ *   RegistrationAppealReview::eligibleCorrectors()).
+ * - Criação/leitura de RegistrationAppealReview: API canônica da entidade,
+ *   disponível somente quando houver controller registrado para ela
+ *   (`endpointAvailable` abaixo). Sem controller, salvar e acompanhar ficam
+ *   desabilitados na interface — backend é out of scope da F2.
+ *
+ * @var MapasCulturais\App $app
+ * @var MapasCulturais\Themes\BaseV2\Theme $this
+ */
+
+use MapasCulturais\Entities\Opportunity;
+use OpportunityAppealPhase\Entities\RegistrationAppealReview;
+
+$config = [
+    // Verdadeiro somente quando a entidade possui controller registrado
+    // (sem controller não existe /api/registrationappealreview).
+    'endpointAvailable' => (bool) $app->getControllerIdByEntity(RegistrationAppealReview::class),
+
+    // Defaults de criação derivados da entidade/PRD (CA-4 é tratado em outra
+    // onda; F2 usa correção oficial e janela/escopo livres).
+    'statusDesignated' => RegistrationAppealReview::STATUS_DESIGNATED,
+    'statusSent' => RegistrationAppealReview::STATUS_SENT,
+    'correctionTypeDefault' => RegistrationAppealReview::CORRECTION_TYPE_OFFICIAL,
+    'activeStatuses' => RegistrationAppealReview::getActiveStatuses(),
+
+    // opportunityId (fase principal) => id da fase de recurso.
+    'appealPhases' => new stdClass(),
+
+    // opportunityId (fase principal) => membros da Comissão de Recursos:
+    // [{userId, name}]. Presente somente em contexto elegível.
+    'committees' => new stdClass(),
+];
+
+$requested_entity = $this->controller->requestedEntity ?? null;
+$opportunity = $requested_entity ? $this->getOpportunityFromEntity($requested_entity) : null;
+
+if ($opportunity instanceof Opportunity && $opportunity->canUser('@control')) {
+    $appeal_phase = $opportunity->appealPhase ?? null;
+    $main_emc = $opportunity->evaluationMethodConfiguration;
+
+    // Espelha os gates de RegistrationAppealReview::eligibleCorrectors():
+    // fase principal com método técnico + fase de recurso ativa com EMC.
+    $is_eligible_context = $appeal_phase
+        && $appeal_phase->status === Opportunity::STATUS_APPEAL_PHASE
+        && $appeal_phase->evaluationMethodConfiguration
+        && $main_emc
+        && $main_emc->type->id === 'technical';
+
+    if ($is_eligible_context) {
+        $committee = [];
+
+        foreach ($appeal_phase->evaluationMethodConfiguration->getCommittee(false) as $agent) {
+            $user = $agent->user ?? null;
+            if (!$user) {
+                continue;
+            }
+
+            $committee[$user->id] = [
+                'userId' => (int) $user->id,
+                'name' => (string) $agent->name,
+            ];
+        }
+
+        $opportunity_id = (int) $opportunity->id;
+        $config['appealPhases']->{$opportunity_id} = (int) $appeal_phase->id;
+        $config['committees']->{$opportunity_id} = array_values($committee);
+    }
+}
+
+$app->applyHook('component(opportunity-appeal-correction-assignment).config', [&$config]);
+
+$this->jsObject['config']['appealCorrectionAssignment'] = $config;

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/init.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/init.php
@@ -31,9 +31,12 @@
  *   fase técnica com fase de recurso ativa e o usuário tem `@control`.
  *
  * Fontes de dados (somente endpoints existentes):
- * - Slots: GET /api/registrationevaluation/find (uma avaliação por avaliador).
- * - Comissão de Recursos: injetada aqui (mesma origem de
- *   RegistrationAppealReview::eligibleCorrectors()).
+ * - Slots: GET /api/registrationevaluation/find (uma avaliação por avaliador;
+ *   a relação `user` volta ESCALAR — o nome do avaliador não vem da API).
+ * - Comissão de Recursos (`committees`) e avaliadores da fase principal
+ *   (`evaluators`, mapa {userId: name}): injetados aqui a partir dos comitês
+ *   das EMCs (mesma origem de RegistrationAppealReview::eligibleCorrectors()
+ *   e da lista de avaliações da oportunidade).
  * - Criação/leitura de RegistrationAppealReview: API canônica da entidade,
  *   disponível somente quando houver controller registrado para ela
  *   (`endpointAvailable` abaixo). Sem controller, salvar e acompanhar ficam
@@ -64,6 +67,12 @@ $config = [
     // opportunityId (fase principal) => membros da Comissão de Recursos:
     // [{userId, name}]. Presente somente em contexto elegível.
     'committees' => new stdClass(),
+
+    // opportunityId (fase principal) => {userId: name} dos avaliadores da
+    // fase principal (comitê do EMC principal). Necessário porque a API de
+    // RegistrationEvaluation não expõe o nome do avaliador (a relação user
+    // não expande no @select — volta sempre escalar).
+    'evaluators' => new stdClass(),
 ];
 
 $requested_entity = $this->controller->requestedEntity ?? null;
@@ -83,6 +92,7 @@ if ($opportunity instanceof Opportunity && $opportunity->canUser('@control')) {
 
     if ($is_eligible_context) {
         $committee = [];
+        $evaluators = new stdClass();
 
         foreach ($appeal_phase->evaluationMethodConfiguration->getCommittee(false) as $agent) {
             $user = $agent->user ?? null;
@@ -96,9 +106,21 @@ if ($opportunity instanceof Opportunity && $opportunity->canUser('@control')) {
             ];
         }
 
+        // Avaliadores da fase principal (donos de slot): comitê do EMC principal.
+        // Mesma fonte de nomes usada pela lista de avaliações da oportunidade.
+        foreach ($main_emc->getCommittee(false) as $agent) {
+            $user = $agent->user ?? null;
+            if (!$user) {
+                continue;
+            }
+
+            $evaluators->{$user->id} = (string) $agent->name;
+        }
+
         $opportunity_id = (int) $opportunity->id;
         $config['appealPhases']->{$opportunity_id} = (int) $appeal_phase->id;
         $config['committees']->{$opportunity_id} = array_values($committee);
+        $config['evaluators']->{$opportunity_id} = $evaluators;
     }
 }
 

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/script.js
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/script.js
@@ -356,10 +356,11 @@ app.component('opportunity-appeal-correction-assignment', {
         },
 
         /**
-         * Nome do avaliador pelo mapa `evaluators` ({userId: name}) injetado
-         * no init.php (comitê do EMC da fase principal) — a API de avaliação
-         * não expõe nome (relação user não expande). Fallback: Comissão de
-         * Recursos da fase de recurso (config.committees).
+         * Nome do avaliador pelo mapa `evaluators` injetado no init.php —
+         * chaveado por opportunityId (mesma estrutura de `committees`):
+         * {opportunityId: {userId: name}}. A API de avaliação não expõe
+         * nome (relação user não expande). Fallback: Comissão de Recursos
+         * da fase de recurso (config.committees, também por oportunidade).
          */
         evaluatorName(userId) {
             if (userId == null) {
@@ -367,8 +368,12 @@ app.component('opportunity-appeal-correction-assignment', {
             }
 
             const evaluators = this.config.evaluators || {};
-            if (evaluators[userId]) {
-                return evaluators[userId];
+            const name = this.opportunityId != null
+                ? evaluators[this.opportunityId]?.[userId] ?? null
+                : null;
+
+            if (name) {
+                return name;
             }
 
             const committee_member = (this.committee || []).find(member => member.userId === userId);

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/script.js
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/script.js
@@ -163,21 +163,24 @@ app.component('opportunity-appeal-correction-assignment', {
         /**
          * Lista as N avaliações da fase principal da inscrição (uma por avaliador),
          * via API de RegistrationEvaluation (a API filtra por permissão de visão).
-         * Usa leitura raw. Shapes reais da ApiQuery (validados no ambiente):
-         * - `user.{id,profile.name}` volta objeto (subselect ≠ pk): {id, profile:{name}};
-         * - relações selecionadas só como `.id` são ACHATADAS para escalar
-         *   (ex.: user.id → user:35) — por isso todo id é normalizado com
-         *   normalizeId(), que aceita escalar OU objeto.
-         * - `agent` é campo computado do jsonSerialize, não relação: não
-         *   responde a @select — mantido apenas como fallback de leitura.
+         *
+         * LEITURA RAW OBRIGATÓRIA: `fetch()` só ativa o modo raw com `raw: true`
+         * nas options (rawProcessor sozinho é ignorado) — sem isso o payload
+         * passa por Entity.populate(), que DESCARTA relações escalares
+         * (user:35 vira undefined) e campos computados (resultString).
+         *
+         * Shapes reais da ApiQuery (evidência de rede): `user` volta ESCALAR
+         * mesmo com select aninhado (expansão não suportada nesta entidade);
+         * `registration` expande como objeto. Nomes de avaliadores vêm do mapa
+         * `evaluators` injetado no init.php, não deste select.
          */
         async fetchSlots() {
             const api = new API('registrationevaluation');
             const evaluations = await api.fetch('find', {
-                '@select': 'id,user.{id,profile.name},status,result,resultString,registration.{id,number}',
+                '@select': 'id,user,status,result,resultString,registration.{id,number}',
                 'registration': `EQ(${this.registrationId})`,
                 '@order': 'id ASC',
-            }, { rawProcessor: data => data });
+            }, { raw: true, rawProcessor: data => data });
 
             this.slots = (evaluations || []).map(evaluation => ({
                 id: this.normalizeId(evaluation.id),
@@ -197,6 +200,9 @@ app.component('opportunity-appeal-correction-assignment', {
         /**
          * Acompanhamento: designações existentes da inscrição. Disponível
          * somente quando a API da entidade existe (endpointAvailable).
+         * Leitura raw pelo mesmo motivo de fetchSlots: `originalEvaluation`
+         * vem ACHATADO para escalar pela ApiQuery (evidência:
+         * {"originalEvaluation":1}) e o populate do SDK o descartaria.
          */
         async fetchReviews() {
             if (!this.endpointAvailable) {
@@ -208,11 +214,10 @@ app.component('opportunity-appeal-correction-assignment', {
                 '@select': 'id,originalEvaluation.id,status,correctionType,endsAt,sentTimestamp',
                 'registration': `EQ(${this.registrationId})`,
                 '@order': 'id ASC',
-            }, { rawProcessor: data => data });
+            }, { raw: true, rawProcessor: data => data });
 
-            // `originalEvaluation` vem ACHATADO para escalar pela ApiQuery
-            // (evidência: {"originalEvaluation":1}); normalizeId aceita os
-            // dois shapes para o join com os slots.
+            // normalizeId aceita escalar OU objeto — o join com os slots
+            // compara ids normalizados nos dois lados.
             this.reviews = (reviews || []).map(review => ({
                 id: this.normalizeId(review.id),
                 originalEvaluationId: this.normalizeId(review.originalEvaluation),
@@ -350,10 +355,29 @@ app.component('opportunity-appeal-correction-assignment', {
             return slot?.userId ?? this.normalizeId(slot?.user);
         },
 
+        /**
+         * Nome do avaliador pelo mapa `evaluators` ({userId: name}) injetado
+         * no init.php (comitê do EMC da fase principal) — a API de avaliação
+         * não expõe nome (relação user não expande). Fallback: Comissão de
+         * Recursos da fase de recurso (config.committees).
+         */
+        evaluatorName(userId) {
+            if (userId == null) {
+                return null;
+            }
+
+            const evaluators = this.config.evaluators || {};
+            if (evaluators[userId]) {
+                return evaluators[userId];
+            }
+
+            const committee_member = (this.committee || []).find(member => member.userId === userId);
+            return committee_member?.name || null;
+        },
+
         slotAgentName(slot) {
-            // @select atual traz user.{id,profile.name}; os demais caminhos
-            // são fallbacks defensivos para shapes alternativos da ApiQuery.
-            return slot?.agent?.name
+            return this.evaluatorName(this.slotUserId(slot))
+                || slot?.agent?.name
                 || slot?.user?.profile?.name
                 || slot?.user?.name
                 || slot?.agent?.email

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/script.js
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/script.js
@@ -292,12 +292,19 @@ app.component('opportunity-appeal-correction-assignment', {
             return status_key ? this.text(status_key) : String(review?.status ?? '');
         },
 
+        /**
+         * Classes utilitárias de cor do tema (0.settings/_atoms.scss) para o
+         * rótulo e o ícone de status — mesmo padrão do appeal-phase-chat
+         * (mc-icon "circle" + .{primary|success|warning|danger}__color):
+         * designado=pendente (primary), rascunho=em andamento (warning),
+         * enviado=concluído (success), reaberto=exige ação (danger).
+         */
         statusClass(review) {
             return {
-                0: 'opportunity-appeal-correction-assignment__status-label--designated',
-                1: 'opportunity-appeal-correction-assignment__status-label--draft',
-                2: 'opportunity-appeal-correction-assignment__status-label--sent',
-                3: 'opportunity-appeal-correction-assignment__status-label--reopened',
+                0: 'primary__color',
+                1: 'warning__color',
+                2: 'success__color',
+                3: 'danger__color',
             }[this.statusNumber(review)] || '';
         },
 

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/script.js
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/script.js
@@ -163,21 +163,26 @@ app.component('opportunity-appeal-correction-assignment', {
         /**
          * Lista as N avaliações da fase principal da inscrição (uma por avaliador),
          * via API de RegistrationEvaluation (a API filtra por permissão de visão).
-         * Usa leitura raw: os campos escalarizados pelo jsonSerialize (user, agent)
-         * chegam sem transformação do SDK.
+         * Usa leitura raw. Shapes reais da ApiQuery (validados no ambiente):
+         * - `user.{id,profile.name}` volta objeto (subselect ≠ pk): {id, profile:{name}};
+         * - relações selecionadas só como `.id` são ACHATADAS para escalar
+         *   (ex.: user.id → user:35) — por isso todo id é normalizado com
+         *   normalizeId(), que aceita escalar OU objeto.
+         * - `agent` é campo computado do jsonSerialize, não relação: não
+         *   responde a @select — mantido apenas como fallback de leitura.
          */
         async fetchSlots() {
             const api = new API('registrationevaluation');
             const evaluations = await api.fetch('find', {
-                '@select': 'id,user.id,status,result,resultString,registration.{id,number},agent.{id,name}',
+                '@select': 'id,user.{id,profile.name},status,result,resultString,registration.{id,number}',
                 'registration': `EQ(${this.registrationId})`,
                 '@order': 'id ASC',
             }, { rawProcessor: data => data });
 
             this.slots = (evaluations || []).map(evaluation => ({
-                id: evaluation.id,
+                id: this.normalizeId(evaluation.id),
                 user: evaluation.user,
-                agent: evaluation.agent,
+                userId: this.normalizeId(evaluation.user),
                 status: evaluation.status,
                 result: evaluation.result,
                 resultString: evaluation.resultString,
@@ -205,8 +210,11 @@ app.component('opportunity-appeal-correction-assignment', {
                 '@order': 'id ASC',
             }, { rawProcessor: data => data });
 
+            // `originalEvaluation` vem ACHATADO para escalar pela ApiQuery
+            // (evidência: {"originalEvaluation":1}); normalizeId aceita os
+            // dois shapes para o join com os slots.
             this.reviews = (reviews || []).map(review => ({
-                id: review.id,
+                id: this.normalizeId(review.id),
                 originalEvaluationId: this.normalizeId(review.originalEvaluation),
                 status: review.status,
                 correctionType: review.correctionType,
@@ -268,13 +276,17 @@ app.component('opportunity-appeal-correction-assignment', {
         activeReviewForSlot(slot) {
             const active_statuses = this.config.activeStatuses || [0, 1, 3];
             return this.reviews.find(review =>
-                review.originalEvaluationId === slot.id
+                review.originalEvaluationId != null
+                && review.originalEvaluationId === this.normalizeId(slot.id)
                 && active_statuses.includes(this.statusNumber(review))
             ) || null;
         },
 
         reviewForSlot(slot) {
-            return this.reviews.find(review => review.originalEvaluationId === slot.id) || null;
+            return this.reviews.find(review =>
+                review.originalEvaluationId != null
+                && review.originalEvaluationId === this.normalizeId(slot.id)
+            ) || null;
         },
 
         statusNumber(review) {
@@ -335,11 +347,18 @@ app.component('opportunity-appeal-correction-assignment', {
         },
 
         slotUserId(slot) {
-            return this.normalizeId(slot?.user);
+            return slot?.userId ?? this.normalizeId(slot?.user);
         },
 
         slotAgentName(slot) {
-            return slot?.agent?.name || slot?.agent?.email || this.text('slot owner tag');
+            // @select atual traz user.{id,profile.name}; os demais caminhos
+            // são fallbacks defensivos para shapes alternativos da ApiQuery.
+            return slot?.agent?.name
+                || slot?.user?.profile?.name
+                || slot?.user?.name
+                || slot?.agent?.email
+                || slot?.user?.profile?.email
+                || this.text('slot owner tag');
         },
 
         /**
@@ -376,10 +395,45 @@ app.component('opportunity-appeal-correction-assignment', {
                 close();
             } catch (error) {
                 console.error('opportunity-appeal-correction-assignment:saveDesignations', error);
-                messages.error(this.text('save error'));
+                messages.error(this.backendErrorMessage(error) || this.text('save error'));
             } finally {
                 this.saving = false;
             }
+        },
+
+        /**
+         * Extrai a mensagem de erro devolvida pelo backend para exibição.
+         *
+         * Shapes reais: Controller::errorJson responde
+         * {error: true, data: "mensagem"} ou {error: true, data: {campo: msg}}
+         * (validação); aceita também {error: "mensagem"} por defesa.
+         * Retorna null quando não há texto utilizável (caller usa o genérico).
+         */
+        backendErrorMessage(error) {
+            const candidates = [
+                error?.data,
+                error?.error,
+                error?.data?.error,
+            ];
+
+            for (const candidate of candidates) {
+                if (typeof candidate === 'string' && candidate.trim()) {
+                    return candidate.trim();
+                }
+
+                if (candidate && typeof candidate === 'object') {
+                    const messages = Object.values(candidate)
+                        .flat()
+                        .map(value => (typeof value === 'string' ? value.trim() : ''))
+                        .filter(Boolean);
+
+                    if (messages.length) {
+                        return messages.join(' ');
+                    }
+                }
+            }
+
+            return null;
         },
 
         /**

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/script.js
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/script.js
@@ -1,0 +1,409 @@
+/**
+ * opportunity-appeal-correction-assignment (F2 / issue #18)
+ *
+ * Modal de designação de corretores por slot: lista as avaliações da fase
+ * principal da inscrição (uma por avaliador), permite marcar quais notas serão
+ * corrigidas e designar 1 corretor por slot marcado (dono do slot ou membro
+ * da Comissão de Recursos — mesma regra de
+ * RegistrationAppealReview::eligibleCorrectors()).
+ *
+ * Abertura: ver docblock do init.php deste componente (evento global
+ * 'opportunity-appeal-correction-assignment:open' com {opportunity, registration}).
+ *
+ * Backend consumido (somente endpoints existentes):
+ * - GET /api/registrationevaluation/find  → slots da inscrição.
+ * - /registrationappealreview (API canônica da entidade) → criação e
+ *   acompanhamento; habilitada somente quando 'endpointAvailable' (controller
+ *   da entidade registrado no backend).
+ */
+
+app.component('opportunity-appeal-correction-assignment', {
+    template: $TEMPLATES['opportunity-appeal-correction-assignment'],
+
+    emits: ['saved'],
+
+    setup() {
+        // os textos estão localizados no arquivo texts.php deste componente
+        const text = Utils.getTexts('opportunity-appeal-correction-assignment');
+        return { text };
+    },
+
+    data() {
+        return {
+            opportunityId: null,
+            registrationId: null,
+            registrationNumber: null,
+            slots: [],
+            reviews: [],
+            loading: false,
+            saving: false,
+        };
+    },
+
+    computed: {
+        config() {
+            return $MAPAS.config.appealCorrectionAssignment || {};
+        },
+
+        endpointAvailable() {
+            return this.config.endpointAvailable === true;
+        },
+
+        /**
+         * Contexto elegível: fase técnica com fase de recurso ativa e Comissão
+         * de Recursos injetada para a oportunidade recebida (espelha os gates
+         * de RegistrationAppealReview::eligibleCorrectors()).
+         */
+        correctionEligible() {
+            return this.appealPhaseId != null && Array.isArray(this.committee);
+        },
+
+        appealPhaseId() {
+            const appeal_phases = this.config.appealPhases || {};
+            return this.opportunityId != null
+                ? appeal_phases[this.opportunityId] ?? null
+                : null;
+        },
+
+        committee() {
+            const committees = this.config.committees || {};
+            return this.opportunityId != null
+                ? committees[this.opportunityId] ?? null
+                : null;
+        },
+
+        markedSlots() {
+            return this.slots.filter(slot => slot.checked);
+        },
+
+        hasInvalidSelection() {
+            return this.markedSlots.some(slot => !this.normalizeId(slot.correctorUserId));
+        },
+
+        canSave() {
+            return this.endpointAvailable
+                && this.correctionEligible
+                && !this.loading
+                && !this.saving
+                && this.markedSlots.length > 0
+                && !this.hasInvalidSelection;
+        },
+
+        designatedCount() {
+            return this.slots.filter(slot => this.reviewForSlot(slot) != null).length;
+        },
+
+        sentCount() {
+            const sent_status = this.config.statusSent ?? 2;
+            return this.reviews.filter(review => this.statusNumber(review) === sent_status).length;
+        },
+
+        progressSummary() {
+            return this.text('progress summary')
+                .replace('%s', this.designatedCount)
+                .replace('%s', this.slots.length)
+                .replace('%s', this.sentCount);
+        },
+
+        subtitle() {
+            const number = this.registrationNumber || this.slots[0]?.registration?.number || null;
+            return number ? `${this.text('registration')} ${number}` : '';
+        },
+    },
+
+    mounted() {
+        window.addEventListener('opportunity-appeal-correction-assignment:open', this.handleOpenEvent);
+    },
+
+    beforeUnmount() {
+        window.removeEventListener('opportunity-appeal-correction-assignment:open', this.handleOpenEvent);
+    },
+
+    methods: {
+        /**
+         * Interface pública (F1): detail = {opportunity, registration}.
+         * Aceita instâncias Entity do SDK ou objetos com ao menos {id}.
+         */
+        handleOpenEvent(event) {
+            const { opportunity, registration } = event?.detail || {};
+
+            const opportunity_id = this.normalizeId(opportunity);
+            const registration_id = this.normalizeId(registration);
+
+            if (!opportunity_id || !registration_id) {
+                console.error('opportunity-appeal-correction-assignment: evento requer {opportunity, registration} com id válido');
+                return;
+            }
+
+            this.opportunityId = opportunity_id;
+            this.registrationId = registration_id;
+            this.registrationNumber = registration?.number || null;
+            this.slots = [];
+            this.reviews = [];
+
+            this.$refs.modal?.open();
+            this.loadData();
+        },
+
+        async loadData() {
+            this.loading = true;
+
+            try {
+                await Promise.all([
+                    this.fetchSlots(),
+                    this.endpointAvailable ? this.fetchReviews() : Promise.resolve(),
+                ]);
+            } catch (error) {
+                console.error('opportunity-appeal-correction-assignment:', error);
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        /**
+         * Lista as N avaliações da fase principal da inscrição (uma por avaliador),
+         * via API de RegistrationEvaluation (a API filtra por permissão de visão).
+         * Usa leitura raw: os campos escalarizados pelo jsonSerialize (user, agent)
+         * chegam sem transformação do SDK.
+         */
+        async fetchSlots() {
+            const api = new API('registrationevaluation');
+            const evaluations = await api.fetch('find', {
+                '@select': 'id,user.id,status,result,resultString,registration.{id,number},agent.{id,name}',
+                'registration': `EQ(${this.registrationId})`,
+                '@order': 'id ASC',
+            }, { rawProcessor: data => data });
+
+            this.slots = (evaluations || []).map(evaluation => ({
+                id: evaluation.id,
+                user: evaluation.user,
+                agent: evaluation.agent,
+                status: evaluation.status,
+                result: evaluation.result,
+                resultString: evaluation.resultString,
+                registration: evaluation.registration,
+                checked: false,
+                correctorUserId: null,
+            }));
+
+            this.preSelectCorrectors();
+        },
+
+        /**
+         * Acompanhamento: designações existentes da inscrição. Disponível
+         * somente quando a API da entidade existe (endpointAvailable).
+         */
+        async fetchReviews() {
+            if (!this.endpointAvailable) {
+                return;
+            }
+
+            const api = new API('registrationappealreview');
+            const reviews = await api.fetch('find', {
+                '@select': 'id,originalEvaluation.id,status,correctionType,endsAt,sentTimestamp',
+                'registration': `EQ(${this.registrationId})`,
+                '@order': 'id ASC',
+            }, { rawProcessor: data => data });
+
+            this.reviews = (reviews || []).map(review => ({
+                id: review.id,
+                originalEvaluationId: this.normalizeId(review.originalEvaluation),
+                status: review.status,
+                correctionType: review.correctionType,
+                endsAt: review.endsAt,
+                sentTimestamp: review.sentTimestamp,
+            }));
+        },
+
+        /**
+         * Opções de corretor do slot: dono do slot + Comissão de Recursos,
+         * sem duplicatas (mesma composição de eligibleCorrectors()).
+         */
+        correctorOptions(slot) {
+            if (!this.correctionEligible) {
+                return [];
+            }
+
+            const options = [];
+            const seen = new Set();
+
+            const owner_id = this.slotUserId(slot);
+            if (owner_id != null) {
+                options.push({
+                    value: owner_id,
+                    label: `${this.slotAgentName(slot)} (${this.text('slot owner tag')})`,
+                });
+                seen.add(owner_id);
+            }
+
+            for (const member of this.committee) {
+                if (seen.has(member.userId)) {
+                    continue;
+                }
+
+                options.push({
+                    value: member.userId,
+                    label: `${member.name} (${this.text('committee tag')})`,
+                });
+                seen.add(member.userId);
+            }
+
+            return options;
+        },
+
+        /**
+         * Slot pode ser marcado: contexto elegível, sem designação ativa
+         * (o índice único de slots ativos impõe a mesma regra no backend).
+         */
+        slotSelectable(slot) {
+            return this.correctionEligible && !this.activeReviewForSlot(slot);
+        },
+
+        preSelectCorrectors() {
+            for (const slot of this.slots) {
+                slot.correctorUserId = this.slotUserId(slot);
+            }
+        },
+
+        activeReviewForSlot(slot) {
+            const active_statuses = this.config.activeStatuses || [0, 1, 3];
+            return this.reviews.find(review =>
+                review.originalEvaluationId === slot.id
+                && active_statuses.includes(this.statusNumber(review))
+            ) || null;
+        },
+
+        reviewForSlot(slot) {
+            return this.reviews.find(review => review.originalEvaluationId === slot.id) || null;
+        },
+
+        statusNumber(review) {
+            return parseInt(review?.status, 10);
+        },
+
+        statusLabel(review) {
+            const status_key = {
+                0: 'status designated',
+                1: 'status draft',
+                2: 'status sent',
+                3: 'status reopened',
+            }[this.statusNumber(review)];
+
+            return status_key ? this.text(status_key) : String(review?.status ?? '');
+        },
+
+        statusClass(review) {
+            return {
+                0: 'opportunity-appeal-correction-assignment__status-label--designated',
+                1: 'opportunity-appeal-correction-assignment__status-label--draft',
+                2: 'opportunity-appeal-correction-assignment__status-label--sent',
+                3: 'opportunity-appeal-correction-assignment__status-label--reopened',
+            }[this.statusNumber(review)] || '';
+        },
+
+        reviewDeadline(review) {
+            return this.formatDate(review?.endsAt);
+        },
+
+        reviewSentAt(review) {
+            return this.formatDate(review?.sentTimestamp);
+        },
+
+        formatDate(value) {
+            if (!value) {
+                return '';
+            }
+
+            const raw = typeof value === 'object' ? (value.date ?? null) : value;
+            if (!raw) {
+                return '';
+            }
+
+            try {
+                const mcdate = new McDate(new Date(raw));
+                return `${mcdate.date('2-digit year')} ${mcdate.time()}`;
+            } catch (error) {
+                return String(raw).slice(0, 16).replace('T', ' ');
+            }
+        },
+
+        slotUserId(slot) {
+            return this.normalizeId(slot?.user);
+        },
+
+        slotAgentName(slot) {
+            return slot?.agent?.name || slot?.agent?.email || this.text('slot owner tag');
+        },
+
+        /**
+         * Cria 1 RegistrationAppealReview por nota marcada, via API canônica
+         * da entidade. Defaults: status=DESIGNATED, correction_type=official,
+         * prazo e escopo livres (CA-4 fica para a onda de parametrização).
+         */
+        async saveDesignations(close) {
+            if (!this.canSave) {
+                return;
+            }
+
+            const messages = useMessages();
+            this.saving = true;
+
+            const api = new API('registrationappealreview');
+            const url = api.createUrl('index');
+
+            try {
+                for (const slot of this.markedSlots) {
+                    const response = await api.POST(url, this.buildAssignmentPayload(slot));
+
+                    if (!response.ok) {
+                        const error = await response.json().catch(() => ({}));
+                        throw error;
+                    }
+                }
+
+                messages.success(this.text('saved'));
+                this.$emit('saved', { registrationId: this.registrationId });
+
+                await this.fetchReviews();
+
+                close();
+            } catch (error) {
+                console.error('opportunity-appeal-correction-assignment:saveDesignations', error);
+                messages.error(this.text('save error'));
+            } finally {
+                this.saving = false;
+            }
+        },
+
+        /**
+         * Payload de criação de 1 designação (RegistrationAppealReview) para o
+         * slot informado. Defaults: status=DESIGNATED, correction_type=official,
+         * prazo e escopo livres (CA-4 fica para a onda de parametrização).
+         */
+        buildAssignmentPayload(slot) {
+            return {
+                originalEvaluation: slot.id,
+                registration: this.registrationId,
+                appealPhase: this.appealPhaseId,
+                slotOwnerUser: this.slotUserId(slot),
+                correctorUser: this.normalizeId(slot.correctorUserId),
+                status: this.config.statusDesignated ?? 0,
+                correctionType: this.config.correctionTypeDefault || 'official',
+            };
+        },
+
+        normalizeId(value) {
+            if (value == null) {
+                return null;
+            }
+
+            const raw_id = typeof value === 'object' ? (value.id ?? null) : value;
+            if (raw_id == null) {
+                return null;
+            }
+
+            const parsed = parseInt(raw_id, 10);
+            return Number.isNaN(parsed) ? null : parsed;
+        },
+    },
+});

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/style.css
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/style.css
@@ -1,0 +1,158 @@
+/*
+ * opportunity-appeal-correction-assignment (F2 / issue #18)
+ *
+ * Estilo local no padrão do mc-modal (style.css do componente é enfileirado
+ * automaticamente pelo AssetManager — sem passo de build). Estrutura visual:
+ * estrutura do diálogo vem do mc-modal (.modal-content/.modal__*); aqui só o
+ * conteúdo interno — linhas de slot, badges e estados — usando tokens e
+ * classes utilitárias do tema BaseV2 (--mc-*, .semibold, .warning__background,
+ * .primary__color, .success__color, .warning__color, .danger__color).
+ */
+
+.opportunity-appeal-correction-assignment .modal-content {
+    min-width: 0;
+}
+
+@media (min-width: 801px) {
+    .opportunity-appeal-correction-assignment .modal-content {
+        min-width: 45rem;
+        max-width: 45rem;
+    }
+}
+
+.opportunity-appeal-correction-assignment__content {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding-bottom: .75rem;
+}
+
+.opportunity-appeal-correction-assignment__empty,
+.opportunity-appeal-correction-assignment__progress {
+    align-items: center;
+    display: flex;
+    gap: .5rem;
+}
+
+.opportunity-appeal-correction-assignment__empty {
+    opacity: .7;
+}
+
+.opportunity-appeal-correction-assignment__header {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) minmax(0, 1fr);
+    font-size: .75rem;
+    font-weight: 600;
+    letter-spacing: .02em;
+    opacity: .7;
+    padding: 0 .75rem;
+    text-transform: uppercase;
+}
+
+.opportunity-appeal-correction-assignment__slot {
+    align-items: start;
+    background-color: var(--mc-gray-100);
+    border: 1px solid var(--mc-gray-300);
+    border-radius: var(--mc-border-radius-sm);
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) minmax(0, 1fr);
+    padding: .75rem;
+}
+
+.opportunity-appeal-correction-assignment__slot--disabled {
+    opacity: .5;
+}
+
+.opportunity-appeal-correction-assignment__slot-check {
+    align-items: flex-start;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: .25rem;
+}
+
+.opportunity-appeal-correction-assignment__slot-check input {
+    margin-right: .25rem;
+}
+
+.opportunity-appeal-correction-assignment__slot-valuer {
+    display: block;
+    margin-left: 1.5rem;
+}
+
+.opportunity-appeal-correction-assignment__slot-result {
+    font-size: .875rem;
+    margin: .25rem 0 0 1.5rem;
+    opacity: .7;
+}
+
+.opportunity-appeal-correction-assignment__tag {
+    border-radius: var(--mc-border-radius-pill);
+    display: inline-block;
+    font-size: .75rem;
+    font-weight: 600;
+    line-height: 1;
+    margin: .5rem 0 0 1.5rem;
+    padding: .4rem .75rem;
+}
+
+.opportunity-appeal-correction-assignment__select {
+    background-color: #fff;
+    border: 1px solid var(--mc-low-500);
+    border-radius: var(--mc-border-radius-xs);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: .875rem;
+    min-height: 2.75rem;
+    padding: .5rem .75rem;
+    width: 100%;
+}
+
+.opportunity-appeal-correction-assignment__select:disabled {
+    cursor: default;
+    opacity: .5;
+}
+
+.opportunity-appeal-correction-assignment__slot-hint {
+    font-size: .75rem;
+    margin-top: .25rem;
+}
+
+.opportunity-appeal-correction-assignment__status {
+    align-items: center;
+    display: flex;
+    gap: .5rem;
+}
+
+.opportunity-appeal-correction-assignment__status .iconify,
+.opportunity-appeal-correction-assignment__status-detail .iconify {
+    font-size: .75rem;
+    min-width: .75rem;
+}
+
+.opportunity-appeal-correction-assignment__status-detail {
+    align-items: center;
+    display: flex;
+    font-size: .75rem;
+    gap: .5rem;
+    margin-top: .25rem;
+    opacity: .7;
+}
+
+.opportunity-appeal-correction-assignment__status-detail--empty {
+    font-size: .75rem;
+    opacity: .5;
+}
+
+/* Mesmo breakpoint do mc-modal/.grid-12 (800px): linhas empilham. */
+@media (max-width: 800px) {
+    .opportunity-appeal-correction-assignment__header {
+        display: none;
+    }
+
+    .opportunity-appeal-correction-assignment__slot {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/template.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/template.php
@@ -7,6 +7,7 @@
 use MapasCulturais\i;
 
 $this->import('
+    mc-alert
     mc-icon
     mc-loading
     mc-modal
@@ -15,41 +16,40 @@ $this->import('
 
 <mc-modal ref="modal" classes="opportunity-appeal-correction-assignment" :title="text('title')" :subtitle="subtitle">
     <template #default="{ close }">
-        <div class="opportunity-appeal-correction-assignment">
-            <div v-if="!endpointAvailable" class="opportunity-appeal-correction-assignment__notice field col-12">
-                <mc-icon name="alert"></mc-icon>
-                {{ text('endpoint unavailable') }}
-            </div>
+        <div class="opportunity-appeal-correction-assignment__content">
+            <mc-alert v-if="!endpointAvailable" type="warning">{{ text('endpoint unavailable') }}</mc-alert>
 
-            <div v-if="!correctionEligible" class="opportunity-appeal-correction-assignment__notice field col-12">
-                <mc-icon name="alert"></mc-icon>
-                {{ text('eligible context required') }}
-            </div>
+            <mc-alert v-if="!correctionEligible" type="warning">{{ text('eligible context required') }}</mc-alert>
 
-            <mc-loading :condition="loading"></mc-loading>
+            <mc-loading :condition="loading">{{ text('loading') }}</mc-loading>
 
-            <div v-if="!loading && !slots.length" class="field col-12">
+            <div v-if="!loading && !slots.length" class="opportunity-appeal-correction-assignment__empty">
                 {{ text('empty slots') }}
             </div>
 
-            <div v-if="!loading && slots.length" class="opportunity-appeal-correction-assignment__progress field col-12 semibold">
+            <div v-if="!loading && slots.length" class="opportunity-appeal-correction-assignment__progress semibold">
+                <mc-icon name="circle" class="primary__color"></mc-icon>
                 {{ progressSummary }}
             </div>
 
-            <div v-if="!loading && slots.length" class="opportunity-appeal-correction-assignment__header grid-12">
-                <div class="col-4"><?= i::__('Avaliação (slot)') ?></div>
-                <div class="col-4"><?= i::__('Corretor designado') ?></div>
-                <div class="col-4"><?= i::__('Acompanhamento') ?></div>
+            <div v-if="!loading && slots.length" class="opportunity-appeal-correction-assignment__header">
+                <div><?= i::__('Avaliação (slot)') ?></div>
+                <div><?= i::__('Corretor designado') ?></div>
+                <div><?= i::__('Acompanhamento') ?></div>
             </div>
 
             <div
                 v-for="slot in slots"
                 :key="slot.id"
-                class="opportunity-appeal-correction-assignment__slot grid-12"
+                class="opportunity-appeal-correction-assignment__slot"
                 :class="{ 'opportunity-appeal-correction-assignment__slot--disabled': !slotSelectable(slot) }">
 
-                <div class="opportunity-appeal-correction-assignment__slot-score col-4">
-                    <label class="field" :for="'correct-slot-' + slot.id" :class="{ 'semibold': slot.checked }">
+                <div class="opportunity-appeal-correction-assignment__slot-score">
+                    <label
+                        class="opportunity-appeal-correction-assignment__slot-check"
+                        :class="{ 'semibold': slot.checked }"
+                        :for="'correct-slot-' + slot.id">
+
                         <input
                             type="checkbox"
                             :id="'correct-slot-' + slot.id"
@@ -57,8 +57,10 @@ $this->import('
                             :disabled="!slotSelectable(slot)">
 
                         <span>
-                            {{ text('correct this score') }}
-                            <span class="semibold">{{ slotAgentName(slot) }}</span>
+                            <span class="semibold">{{ text('correct this score') }}</span>
+                            <span class="opportunity-appeal-correction-assignment__slot-valuer">
+                                {{ slotAgentName(slot) }}
+                            </span>
                         </span>
                     </label>
 
@@ -66,14 +68,16 @@ $this->import('
                         {{ slot.resultString }}
                     </div>
 
-                    <div v-if="activeReviewForSlot(slot)" class="opportunity-appeal-correction-assignment__slot-tag">
+                    <span
+                        v-if="activeReviewForSlot(slot)"
+                        class="opportunity-appeal-correction-assignment__tag warning__background">
                         {{ text('already designated') }}
-                    </div>
+                    </span>
                 </div>
 
-                <div class="opportunity-appeal-correction-assignment__slot-corrector col-4">
+                <div class="opportunity-appeal-correction-assignment__slot-corrector">
                     <select
-                        class="field"
+                        class="opportunity-appeal-correction-assignment__select"
                         v-model="slot.correctorUserId"
                         :disabled="!slot.checked || !slotSelectable(slot)">
 
@@ -88,29 +92,33 @@ $this->import('
 
                     <div
                         v-if="slot.checked && !slot.correctorUserId"
-                        class="opportunity-appeal-correction-assignment__slot-hint">
+                        class="opportunity-appeal-correction-assignment__slot-hint danger__color">
                         <?= i::__('Selecione o corretor para salvar esta designação') ?>
                     </div>
                 </div>
 
-                <div class="opportunity-appeal-correction-assignment__slot-status col-4">
+                <div class="opportunity-appeal-correction-assignment__slot-status">
                     <template v-if="reviewForSlot(slot)">
-                        <span
-                            class="opportunity-appeal-correction-assignment__status-label semibold"
+                        <div
+                            class="opportunity-appeal-correction-assignment__status semibold"
                             :class="statusClass(reviewForSlot(slot))">
+
+                            <mc-icon name="circle" :class="statusClass(reviewForSlot(slot))"></mc-icon>
                             {{ statusLabel(reviewForSlot(slot)) }}
-                        </span>
+                        </div>
 
                         <div v-if="reviewDeadline(reviewForSlot(slot))" class="opportunity-appeal-correction-assignment__status-detail">
-                            {{ text('deadline') }}: {{ reviewDeadline(reviewForSlot(slot)) }}
+                            <mc-icon name="clock"></mc-icon>
+                            <span><?= i::__('Prazo') ?>: {{ reviewDeadline(reviewForSlot(slot)) }}</span>
                         </div>
 
                         <div v-if="reviewSentAt(reviewForSlot(slot))" class="opportunity-appeal-correction-assignment__status-detail">
-                            {{ text('sent at') }}: {{ reviewSentAt(reviewForSlot(slot)) }}
+                            <mc-icon name="send"></mc-icon>
+                            <span><?= i::__('Enviada em') ?>: {{ reviewSentAt(reviewForSlot(slot)) }}</span>
                         </div>
                     </template>
 
-                    <span v-else class="opportunity-appeal-correction-assignment__status-label--empty">
+                    <span v-else class="opportunity-appeal-correction-assignment__status-detail--empty">
                         {{ text('no designation') }}
                     </span>
                 </div>
@@ -119,17 +127,17 @@ $this->import('
     </template>
 
     <template #actions="{ close }">
+        <button class="button button--text" @click="close()">
+            <?= i::__('Cancelar') ?>
+        </button>
+
         <button
-            class="button button--primary"
+            class="button button--md button--primary"
             :class="{ 'disabled': !canSave }"
             :disabled="!canSave"
             @click="saveDesignations(close)">
 
             {{ saving ? text('saving') : text('save') }}
-        </button>
-
-        <button class="button button--text" @click="close()">
-            <?= i::__('Cancelar') ?>
         </button>
     </template>
 </mc-modal>

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/template.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/template.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * @var MapasCulturais\App $app
+ * @var MapasCulturais\Themes\BaseV2\Theme $this
+ */
+
+use MapasCulturais\i;
+
+$this->import('
+    mc-icon
+    mc-loading
+    mc-modal
+');
+?>
+
+<mc-modal ref="modal" classes="opportunity-appeal-correction-assignment" :title="text('title')" :subtitle="subtitle">
+    <template #default="{ close }">
+        <div class="opportunity-appeal-correction-assignment">
+            <div v-if="!endpointAvailable" class="opportunity-appeal-correction-assignment__notice field col-12">
+                <mc-icon name="alert"></mc-icon>
+                {{ text('endpoint unavailable') }}
+            </div>
+
+            <div v-if="!correctionEligible" class="opportunity-appeal-correction-assignment__notice field col-12">
+                <mc-icon name="alert"></mc-icon>
+                {{ text('eligible context required') }}
+            </div>
+
+            <mc-loading :condition="loading"></mc-loading>
+
+            <div v-if="!loading && !slots.length" class="field col-12">
+                {{ text('empty slots') }}
+            </div>
+
+            <div v-if="!loading && slots.length" class="opportunity-appeal-correction-assignment__progress field col-12 semibold">
+                {{ progressSummary }}
+            </div>
+
+            <div v-if="!loading && slots.length" class="opportunity-appeal-correction-assignment__header grid-12">
+                <div class="col-4"><?= i::__('Avaliação (slot)') ?></div>
+                <div class="col-4"><?= i::__('Corretor designado') ?></div>
+                <div class="col-4"><?= i::__('Acompanhamento') ?></div>
+            </div>
+
+            <div
+                v-for="slot in slots"
+                :key="slot.id"
+                class="opportunity-appeal-correction-assignment__slot grid-12"
+                :class="{ 'opportunity-appeal-correction-assignment__slot--disabled': !slotSelectable(slot) }">
+
+                <div class="opportunity-appeal-correction-assignment__slot-score col-4">
+                    <label class="field" :for="'correct-slot-' + slot.id" :class="{ 'semibold': slot.checked }">
+                        <input
+                            type="checkbox"
+                            :id="'correct-slot-' + slot.id"
+                            v-model="slot.checked"
+                            :disabled="!slotSelectable(slot)">
+
+                        <span>
+                            {{ text('correct this score') }}
+                            <span class="semibold">{{ slotAgentName(slot) }}</span>
+                        </span>
+                    </label>
+
+                    <div class="opportunity-appeal-correction-assignment__slot-result">
+                        {{ slot.resultString }}
+                    </div>
+
+                    <div v-if="activeReviewForSlot(slot)" class="opportunity-appeal-correction-assignment__slot-tag">
+                        {{ text('already designated') }}
+                    </div>
+                </div>
+
+                <div class="opportunity-appeal-correction-assignment__slot-corrector col-4">
+                    <select
+                        class="field"
+                        v-model="slot.correctorUserId"
+                        :disabled="!slot.checked || !slotSelectable(slot)">
+
+                        <option :value="null" disabled>{{ text('select corrector') }}</option>
+                        <option
+                            v-for="option in correctorOptions(slot)"
+                            :key="option.value"
+                            :value="option.value">
+                            {{ option.label }}
+                        </option>
+                    </select>
+
+                    <div
+                        v-if="slot.checked && !slot.correctorUserId"
+                        class="opportunity-appeal-correction-assignment__slot-hint">
+                        <?= i::__('Selecione o corretor para salvar esta designação') ?>
+                    </div>
+                </div>
+
+                <div class="opportunity-appeal-correction-assignment__slot-status col-4">
+                    <template v-if="reviewForSlot(slot)">
+                        <span
+                            class="opportunity-appeal-correction-assignment__status-label semibold"
+                            :class="statusClass(reviewForSlot(slot))">
+                            {{ statusLabel(reviewForSlot(slot)) }}
+                        </span>
+
+                        <div v-if="reviewDeadline(reviewForSlot(slot))" class="opportunity-appeal-correction-assignment__status-detail">
+                            {{ text('deadline') }}: {{ reviewDeadline(reviewForSlot(slot)) }}
+                        </div>
+
+                        <div v-if="reviewSentAt(reviewForSlot(slot))" class="opportunity-appeal-correction-assignment__status-detail">
+                            {{ text('sent at') }}: {{ reviewSentAt(reviewForSlot(slot)) }}
+                        </div>
+                    </template>
+
+                    <span v-else class="opportunity-appeal-correction-assignment__status-label--empty">
+                        {{ text('no designation') }}
+                    </span>
+                </div>
+            </div>
+        </div>
+    </template>
+
+    <template #actions="{ close }">
+        <button
+            class="button button--primary"
+            :class="{ 'disabled': !canSave }"
+            :disabled="!canSave"
+            @click="saveDesignations(close)">
+
+            {{ saving ? text('saving') : text('save') }}
+        </button>
+
+        <button class="button button--text" @click="close()">
+            <?= i::__('Cancelar') ?>
+        </button>
+    </template>
+</mc-modal>

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/template.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/template.php
@@ -53,6 +53,7 @@ $this->import('
                         <input
                             type="checkbox"
                             :id="'correct-slot-' + slot.id"
+                            :name="'correct-slot-' + slot.id"
                             v-model="slot.checked"
                             :disabled="!slotSelectable(slot)">
 
@@ -78,6 +79,9 @@ $this->import('
                 <div class="opportunity-appeal-correction-assignment__slot-corrector">
                     <select
                         class="opportunity-appeal-correction-assignment__select"
+                        :id="'corrector-select-' + slot.id"
+                        :name="'corrector-select-' + slot.id"
+                        :aria-label="text('select corrector') + ' — ' + slotAgentName(slot)"
                         v-model="slot.correctorUserId"
                         :disabled="!slot.checked || !slotSelectable(slot)">
 

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/texts.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/texts.php
@@ -1,0 +1,42 @@
+<?php
+
+use MapasCulturais\App;
+use MapasCulturais\i;
+
+$app = App::i();
+
+$texts = [
+    // título e cabeçalho
+    'title' => i::__('Designar corretores de nota'),
+    'registration' => i::__('Inscrição'),
+    'empty slots' => i::__('Nenhuma avaliação encontrada para esta inscrição.'),
+
+    // linha por slot
+    'correct this score' => i::__('Corrigir esta nota'),
+    'select corrector' => i::__('Selecione o corretor'),
+    'slot owner tag' => i::__('avaliador do slot'),
+    'committee tag' => i::__('Comissão de Recursos'),
+    'already designated' => i::__('Já designado'),
+    'eligible context required' => i::__('A designação de corretores exige uma fase de avaliação técnica com fase de recurso ativa e comissão configurada.'),
+
+    // acompanhamento
+    'status designated' => i::__('Designado'),
+    'status draft' => i::__('Rascunho'),
+    'status sent' => i::__('Enviado'),
+    'status reopened' => i::__('Reaberto'),
+    'deadline' => i::__('Prazo'),
+    'sent at' => i::__('Enviada em'),
+    'no designation' => i::__('sem designação'),
+    'progress summary' => i::__('%s de %s slots com designação · %s enviadas'),
+
+    // ações e mensagens
+    'save' => i::__('Salvar designações'),
+    'saving' => i::__('Salvando designações...'),
+    'saved' => i::__('Designações criadas com sucesso.'),
+    'save error' => i::__('Não foi possível criar as designações.'),
+    'endpoint unavailable' => i::__('A criação e o acompanhamento de designações estão temporariamente indisponíveis: a API da entidade de designação (RegistrationAppealReview) ainda não está registrada no backend.'),
+];
+
+$app->applyHook('component(opportunity-appeal-correction-assignment).texts', [&$texts]);
+
+return $texts;

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/texts.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/texts.php
@@ -34,6 +34,7 @@ $texts = [
     'saving' => i::__('Salvando designações...'),
     'saved' => i::__('Designações criadas com sucesso.'),
     'save error' => i::__('Não foi possível criar as designações.'),
+    'loading' => i::__('Carregando avaliações...'),
     'endpoint unavailable' => i::__('A criação e o acompanhamento de designações estão temporariamente indisponíveis: a API da entidade de designação (RegistrationAppealReview) ainda não está registrada no backend.'),
 ];
 


### PR DESCRIPTION
Componente `opportunity-appeal-correction-assignment` em `OpportunityAppealPhase/components/`:

- Lista as avaliações da fase principal da inscrição (uma por avaliador) via `GET /api/registrationevaluation/find`.
- Por slot: checkbox "corrigir esta nota" + select de corretor restrito a dono do slot ∪ Comissão de Recursos (espelho dos gates de `eligibleCorrectors()`; validação autoritativa no backend).
- Salvamento e painel de acompanhamento implementados e **dark-launched**: ativam sozinhos quando a API de designação existir (flag `endpointAvailable` no `init.php`, hoje `false`) — tarefa PR6 (#40).
- Interface pública de abertura: evento `opportunity-appeal-correction-assignment:open` com `{opportunity, registration}` (documentada no `init.php`/README) — consumida pelo F1 (#17).
- Registro da rodada: `docs/rounds/R01-2026-08-correcao-notas-recurso/` (scope.md + deviations.md).

**Critérios:** 1 (lista) e 2 (select elegível) implementados; 3 (salvar) e 4 (acompanhamento) implementados, validação E2E pendente do PR6 (#40).

**Verificação:** `php -l` OK; `node --check` OK; `bash tests/run.sh`: suíte vermelha na base (deprecations PHP 8.4 do core, pré-existentes — controle sem estes arquivos dá os mesmos erros; nenhum erro causado por esta mudança).
