### PR TITLE
PR6 — API de designação: criar e listar RegistrationAppealReview (#40)

### DIFF
--- a/src/modules/OpportunityAppealPhase/Controllers/RegistrationAppealReview.php
+++ b/src/modules/OpportunityAppealPhase/Controllers/RegistrationAppealReview.php
@@ -1,0 +1,502 @@
+<?php
+
+namespace OpportunityAppealPhase\Controllers;
+
+use DateTime;
+use MapasCulturais\App;
+use MapasCulturais\Controllers\EntityController;
+use MapasCulturais\Entities\Registration;
+use MapasCulturais\Entities\RegistrationEvaluation;
+use MapasCulturais\Entities\User;
+use MapasCulturais\i;
+use MapasCulturais\Traits;
+use OpportunityAppealPhase\Entities\RegistrationAppealReview as ReviewEntity;
+
+/**
+ * Controller da entidade RegistrationAppealReview: API de designação de
+ * corretores por slot (PR6 / issue #40).
+ *
+ * Contrato consumido pelo modal e pelo painel de acompanhamento do F2 (#18):
+ * - POST   /registrationappealreview                           → POST_index (designação pelo gestor)
+ * - GET    /api/registrationappealreview/find?registration=…   → API_find (listagem por inscrição, CA-13)
+ * - GET    /api/registrationappealreview/findOne?id=…          → API_findOne
+ * - PUT    /registrationappealreview/single/{id}               → PUT_single (substituir corretor/prazo)
+ * - PATCH  /registrationappealreview/single/{id}               → PATCH_single
+ * - DELETE /registrationappealreview/single/{id}               → DELETE_single (cancelar designação)
+ *
+ * Segurança: a entidade não usa owner nem permission cache, então o pseudo-owner
+ * das checagens genéricas é o próprio usuário logado e as ações canônicas herdadas
+ * de EntityController não restringem por si. Todos os pontos de leitura/escrita
+ * deste controller exigem autenticação e `@control` na oportunidade principal
+ * (fase avaliativa) da inscrição do slot — via checkPermission, nunca ad-hoc.
+ */
+class RegistrationAppealReview extends EntityController
+{
+    use Traits\ControllerAPI;
+
+    /**
+     * Campos da designação derivados do slot no servidor: nunca aceitos do payload.
+     */
+    private const DERIVED_FIELDS = ['registration', 'appealPhase', 'slotOwnerUser'];
+
+    /**
+     * Cria uma designação de correção para um slot de avaliação (CA-4).
+     *
+     * Somente gestores com `@control` na oportunidade principal. O corretor
+     * informado precisa estar entre `eligibleCorrectors()` do slot (CA-3).
+     * Os campos de vinculação (registration, appealPhase, slotOwnerUser) são
+     * derivados do slot no servidor; valores divergentes no payload são
+     * rejeitados. O status inicial é sempre STATUS_DESIGNATED.
+     */
+    function POST_index($data = null)
+    {
+        $this->requireAuthentication();
+        $this->assertFeatureEnabled();
+
+        $app = App::i();
+
+        if (is_null($data)) {
+            $data = $this->postData;
+        }
+
+        if (!is_array($data)) {
+            $this->errorJson(i::__('Corpo da requisição inválido: esperado objeto com os campos da designação.'), 400);
+        }
+
+        $app->applyHookBoundTo($this, "POST({$this->id}.index):data", ['data' => &$data]);
+
+        $slot_id = $this->resolveIdParam($data['originalEvaluation'] ?? null);
+        $corrector_id = $this->resolveIdParam($data['correctorUser'] ?? null);
+
+        if (!$slot_id) {
+            $this->errorJson(i::__('O ID da avaliação original (originalEvaluation) é obrigatório.'), 400);
+        }
+
+        if (!$corrector_id) {
+            $this->errorJson(i::__('O ID do corretor (correctorUser) é obrigatório.'), 400);
+        }
+
+        /** @var RegistrationEvaluation|null $slot */
+        $slot = $app->repo('RegistrationEvaluation')->find($slot_id);
+        if (!$slot) {
+            $this->errorJson(sprintf(i::__('Não existe avaliação com o ID %s.'), $slot_id), 404);
+        }
+
+        /** @var User|null $corrector */
+        $corrector = $app->repo('User')->find($corrector_id);
+        if (!$corrector) {
+            $this->errorJson(sprintf(i::__('Não existe usuário corretor com o ID %s.'), $corrector_id), 404);
+        }
+
+        $registration = $slot->registration;
+        $opportunity = $registration->opportunity;
+
+        // Permissão antes de qualquer validação de domínio: não-gestor recebe 403
+        // sem vencer informação sobre a inscrição, o slot ou a fase de recurso.
+        $opportunity->checkPermission('@control');
+
+        $appeal_phase = $opportunity->appealPhase;
+
+        if (!$appeal_phase) {
+            $this->errorJson(i::__('Não existe fase de recurso para esta oportunidade.'), 400);
+        }
+
+        // Campos derivados no servidor: divergência no payload é erro de contrato.
+        $derived = [
+            'registration' => [$registration->id, 'inscrição'],
+            'appealPhase' => [$appeal_phase->id, 'fase de recurso'],
+            'slotOwnerUser' => [$slot->user->id, 'dono do slot'],
+        ];
+
+        foreach ($derived as $key => [$expected_id, $label]) {
+            if (isset($data[$key]) && $this->resolveIdParam($data[$key]) !== (int) $expected_id) {
+                $this->errorJson(sprintf(i::__('O campo %s não corresponde ao valor derivado da avaliação original (%s).'), $key, $label), 400);
+            }
+        }
+
+        $review = new ReviewEntity();
+        $review->originalEvaluation = $slot;
+        $review->registration = $registration;
+        $review->appealPhase = $appeal_phase;
+        $review->slotOwnerUser = $slot->user;
+        $review->correctorUser = $corrector;
+
+        $this->assertCorrectorEligibility($review, $slot, $corrector);
+
+        // O índice único de designações ativas é a regra definitiva; aqui o erro fica claro.
+        $active_reviews = $app->repo(ReviewEntity::class)->findBy([
+            'originalEvaluation' => $slot->id,
+            'status' => ReviewEntity::getActiveStatuses(),
+        ]);
+
+        if ($active_reviews) {
+            $this->errorJson(i::__('Já existe uma designação ativa para este slot. Substitua ou conclua a designação existente antes de criar outra.'), 400);
+        }
+
+        $correction_type = (string) ($data['correctionType'] ?? ReviewEntity::CORRECTION_TYPE_OFFICIAL);
+        if (!in_array($correction_type, ReviewEntity::getCorrectionTypes(), true)) {
+            $this->errorJson(sprintf(i::__('Tipo de correção inválido (%s). Use "official" ou "record".'), $correction_type), 400);
+        }
+        $review->correctionType = $correction_type;
+
+        $review->releasedScope = $this->parseReleasedScope($data['releasedScope'] ?? null);
+        $review->startsAt = $this->parseDateParam($data['startsAt'] ?? null);
+        $review->endsAt = $this->parseDateParam($data['endsAt'] ?? null);
+        $review->status = ReviewEntity::STATUS_DESIGNATED;
+
+        $this->_finishRequest($review, true);
+    }
+
+    /**
+     * Listagem para o painel de acompanhamento do F2 (CA-13).
+     *
+     * Exige `registration` no query string e `@control` na oportunidade
+     * principal da inscrição; o resultado é sempre escopado à inscrição
+     * autorizada, independentemente dos filtros enviados.
+     */
+    function API_find()
+    {
+        $this->requireAuthentication();
+        $this->assertFeatureEnabled();
+
+        $registration = $this->getAuthorizedRegistrationFromQuery();
+
+        $this->getData['registration'] = 'EQ(' . $registration->id . ')';
+        $this->applyStatusDomainDefaults();
+
+        $data = $this->apiQuery($this->getData);
+        $this->apiResponse($data);
+    }
+
+    /**
+     * Busca unitária restrita: `@control` na oportunidade principal da
+     * inscrição da designação.
+     */
+    function API_findOne()
+    {
+        $this->requireAuthentication();
+        $this->assertFeatureEnabled();
+
+        $review = $this->getRequestedReviewFromQuery();
+        $review->registration->opportunity->checkPermission('@control');
+
+        $this->applyStatusDomainDefaults();
+
+        $data = $this->apiQuery($this->getData, ['findOne' => true]);
+        $this->apiItemResponse($data);
+    }
+
+    /**
+     * Escrita canônica (substituir corretor, novo prazo): restrita a gestores
+     * com `@control` na oportunidade principal. Substituição de corretor
+     * continua sujeita à elegibilidade do CA-3.
+     */
+    function PUT_single($data = null)
+    {
+        $this->requireAuthentication();
+        $this->assertFeatureEnabled();
+
+        $review = $this->getRequestedReview();
+        $review->registration->opportunity->checkPermission('@control');
+
+        if (is_null($data)) {
+            $data = $this->postData;
+        }
+
+        $this->guardMutableFields($review, $data);
+
+        parent::PUT_single($data);
+    }
+
+    function PATCH_single($data = null)
+    {
+        $this->requireAuthentication();
+        $this->assertFeatureEnabled();
+
+        $review = $this->getRequestedReview();
+        $review->registration->opportunity->checkPermission('@control');
+
+        if (is_null($data)) {
+            $data = $this->patchData;
+        }
+
+        $this->guardMutableFields($review, $data);
+
+        parent::PATCH_single($data);
+    }
+
+    /**
+     * Cancelamento de designação: restrito a gestores com `@control`
+     * (a entidade usa hard delete — sem mudança de status).
+     */
+    function DELETE_single()
+    {
+        $this->requireAuthentication();
+        $this->assertFeatureEnabled();
+
+        $this->getRequestedReview()->registration->opportunity->checkPermission('@control');
+
+        parent::DELETE_single();
+    }
+
+    // ============================================================ //
+    // Helpers
+    // ============================================================ //
+
+    private function assertFeatureEnabled(): void
+    {
+        if (!(bool) env('APPEAL_SCORE_CORRECTION', false)) {
+            $this->errorJson(i::__('Correção de notas por recurso desabilitada'), 404);
+        }
+    }
+
+    /**
+     * O domínio de status da designação (0=designada, 1=rascunho, 2=enviada,
+     * 3=reaberta) colide com a suposição do ApiQuery de que status<=0 é
+     * rascunho a esconder (filtro default `e.status > 0`), o que sumiria com
+     * as designações recém-criadas do painel do F2.
+     *
+     * Sem `status` informado, filtramos pelo domínio completo (comportamento
+     * equivalente a "sem filtro"); e sem `@permissions`, usamos `view`, que
+     * para esta entidade é um no-op (ela não usa permission cache) e serve
+     * apenas para desativar o filtro default de status do core. Em conjunto,
+     * os dois parâmetros fazem o core pular o `e.status > 0`.
+     */
+    private function applyStatusDomainDefaults(): void
+    {
+        if (!isset($this->getData['status'])) {
+            $this->getData['status'] = 'IN(' . implode(',', [
+                ReviewEntity::STATUS_DESIGNATED,
+                ReviewEntity::STATUS_DRAFT,
+                ReviewEntity::STATUS_SENT,
+                ReviewEntity::STATUS_REOPENED,
+            ]) . ')';
+        }
+
+        if (!isset($this->getData['@permissions'])) {
+            $this->getData['@permissions'] = 'view';
+        }
+    }
+
+    /**
+     * CA-3: por slot, o gestor só pode designar o dono do slot ou membro da
+     * Comissão de Recursos da fase de recurso. Avaliadores de outros slots da
+     * mesma inscrição são rejeitados.
+     */
+    private function assertCorrectorEligibility(ReviewEntity $review, RegistrationEvaluation $slot, User $corrector): void
+    {
+        $eligible_ids = array_map(
+            static fn (User $user): int => (int) $user->id,
+            $review->eligibleCorrectors($slot)
+        );
+
+        if (!$eligible_ids) {
+            $this->errorJson(i::__('Este slot não admite designação de correção: exige fase principal com método técnico e fase de recurso ativa com Comissão de Recursos.'), 400);
+        }
+
+        if (!in_array((int) $corrector->id, $eligible_ids, true)) {
+            $this->errorJson(i::__('Corretor inelegível para este slot (CA-3): apenas o dono da avaliação original ou membros da Comissão de Recursos podem ser designados.'), 400);
+        }
+    }
+
+    /**
+     * Valida os campos mutáveis via PUT/PATCH antes de delegar ao core:
+     * - campos derivados do slot são imutáveis;
+     * - substituição de corretor exige elegibilidade (CA-3) e é atribuída
+     *   como entidade resolvida (não como ID cru);
+     * - correctionType válidos;
+     * - status restrito ao domínio da designação e aplicado diretamente, para
+     *   não colidir com o changeStatusMap do ciclo padrão de Entity.
+     */
+    private function guardMutableFields(ReviewEntity $review, array &$data): void
+    {
+        $app = App::i();
+
+        foreach (self::DERIVED_FIELDS as $field) {
+            if (array_key_exists($field, $data) && $this->resolveIdParam($data[$field]) !== (int) $review->$field->id) {
+                $this->errorJson(sprintf(i::__('O campo %s é derivado da avaliação original e não pode ser alterado.'), $field), 400);
+            }
+
+            unset($data[$field]);
+        }
+
+        if (array_key_exists('originalEvaluation', $data)) {
+            if ($this->resolveIdParam($data['originalEvaluation']) !== (int) $review->originalEvaluation->id) {
+                $this->errorJson(i::__('O campo originalEvaluation identifica o slot e não pode ser alterado. Crie uma nova designação.'), 400);
+            }
+
+            unset($data['originalEvaluation']);
+        }
+
+        if (array_key_exists('correctorUser', $data)) {
+            $corrector_id = $this->resolveIdParam($data['correctorUser']);
+
+            if ($corrector_id !== (int) $review->correctorUser->id) {
+                /** @var User|null $corrector */
+                $corrector = $app->repo('User')->find($corrector_id);
+
+                if (!$corrector) {
+                    $this->errorJson(sprintf(i::__('Não existe usuário corretor com o ID %s.'), $corrector_id), 404);
+                }
+
+                $this->assertCorrectorEligibility($review, $review->originalEvaluation, $corrector);
+                $review->correctorUser = $corrector;
+            }
+
+            unset($data['correctorUser']);
+        }
+
+        if (isset($data['correctionType'])) {
+            if (!in_array((string) $data['correctionType'], ReviewEntity::getCorrectionTypes(), true)) {
+                $this->errorJson(sprintf(i::__('Tipo de correção inválido (%s). Use "official" ou "record".'), (string) $data['correctionType']), 400);
+            }
+        }
+
+        if (isset($data['releasedScope'])) {
+            $review->releasedScope = $this->parseReleasedScope($data['releasedScope']);
+            unset($data['releasedScope']);
+        }
+
+        if (isset($data['startsAt'])) {
+            $review->startsAt = $this->parseDateParam($data['startsAt']);
+            unset($data['startsAt']);
+        }
+
+        if (isset($data['endsAt'])) {
+            $review->endsAt = $this->parseDateParam($data['endsAt']);
+            unset($data['endsAt']);
+        }
+
+        if (array_key_exists('status', $data)) {
+            $status = (int) $data['status'];
+
+            $valid_statuses = [
+                ReviewEntity::STATUS_DESIGNATED,
+                ReviewEntity::STATUS_DRAFT,
+                ReviewEntity::STATUS_SENT,
+                ReviewEntity::STATUS_REOPENED,
+            ];
+
+            if (!in_array($status, $valid_statuses, true)) {
+                $this->errorJson(i::__('Status inválido para designação de correção.'), 400);
+            }
+
+            $review->status = $status;
+            unset($data['status']);
+        }
+    }
+
+    /**
+     * Extrai e valida a inscrição do parâmetro `registration` (aceita `EQ(n)`
+     * ou inteiro) e exige `@control` na oportunidade principal.
+     */
+    private function getAuthorizedRegistrationFromQuery(): Registration
+    {
+        $app = App::i();
+
+        $raw_value = trim((string) ($this->getData['registration'] ?? ''));
+
+        if (!preg_match('/\d+/', $raw_value, $matches)) {
+            $this->errorJson(i::__('O parâmetro registration (ID da inscrição) é obrigatório.'), 400);
+        }
+
+        /** @var Registration|null $registration */
+        $registration = $app->repo('Registration')->find((int) $matches[0]);
+
+        if (!$registration) {
+            $this->errorJson(sprintf(i::__('Não existe inscrição com o ID %s.'), $matches[0]), 404);
+        }
+
+        $registration->opportunity->checkPermission('@control');
+
+        return $registration;
+    }
+
+    /**
+     * Entidade da requisição para ações single (PUT/PATCH/DELETE).
+     */
+    private function getRequestedReview(): ReviewEntity
+    {
+        $app = App::i();
+
+        $review = $this->requestedEntity;
+
+        if (!$review) {
+            $app->pass();
+        }
+
+        return $review;
+    }
+
+    /**
+     * Carrega a designação referenciada por `id` (formato API `EQ(n)`).
+     */
+    private function getRequestedReviewFromQuery(): ReviewEntity
+    {
+        $app = App::i();
+
+        $raw_value = trim((string) ($this->getData['id'] ?? ''));
+
+        if (!preg_match('/\d+/', $raw_value, $matches)) {
+            $this->errorJson(i::__('O parâmetro id é obrigatório.'), 400);
+        }
+
+        /** @var ReviewEntity|null $review */
+        $review = $app->repo(ReviewEntity::class)->find((int) $matches[0]);
+
+        if (!$review) {
+            $app->pass();
+        }
+
+        return $review;
+    }
+
+    /**
+     * Aceita int, string numérica ou objeto/array com chave `id`.
+     */
+    private function resolveIdParam(mixed $value): int
+    {
+        if (is_array($value) || is_object($value)) {
+            $value = ((array) $value)['id'] ?? null;
+        }
+
+        return (int) $value;
+    }
+
+    /**
+     * @param mixed $value array/objeto já decodificado ou string JSON.
+     */
+    private function parseReleasedScope(mixed $value): ?object
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_string($value)) {
+            $decoded = json_decode($value);
+
+            if (!is_object($decoded)) {
+                $this->errorJson(i::__('releasedScope inválido: esperado objeto JSON.'), 400);
+            }
+
+            return $decoded;
+        }
+
+        return (object) (array) $value;
+    }
+
+    private function parseDateParam(mixed $value): ?DateTime
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        try {
+            return new DateTime((string) $value);
+        } catch (\Exception) {
+            $this->errorJson(i::__('Data inválida: use o formato AAAA-MM-DD HH:MM.'), 400);
+
+            return null;
+        }
+    }
+}

--- a/src/modules/OpportunityAppealPhase/Module.php
+++ b/src/modules/OpportunityAppealPhase/Module.php
@@ -364,6 +364,9 @@ class Module extends \MapasCulturais\Module {
 
         $app->registerController('appealCorrector', \OpportunityAppealPhase\Controllers\AppealCorrector::class);
 
+        // PR6 (#40): API de designação de corretores por slot (criação + listagem do painel do F2).
+        $app->registerController('registrationappealreview', \OpportunityAppealPhase\Controllers\RegistrationAppealReview::class);
+
         $this->registerOpportunityMetadata('appealPhase', [
             'label' => i::__('Fase de recurso'),
             'type'  => 'entity'

--- a/tests/src/AppealAssignmentApiTest.php
+++ b/tests/src/AppealAssignmentApiTest.php
@@ -1,0 +1,498 @@
+<?php
+
+namespace Tests;
+
+use DateTime;
+use MapasCulturais\App;
+use MapasCulturais\Entities\EvaluationMethodConfiguration;
+use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\Entities\Registration;
+use MapasCulturais\Entities\RegistrationEvaluation;
+use MapasCulturais\Entities\User;
+use OpportunityAppealPhase\Entities\RegistrationAppealReview;
+use Psr\Http\Message\ServerRequestInterface;
+use Tests\Abstract\TestCase;
+use Tests\Builders\PhasePeriods\ConcurrentEndingAfter;
+use Tests\Builders\PhasePeriods\Open;
+use Tests\Enums\EvaluationMethods;
+use Tests\Traits\OpportunityBuilder;
+use Tests\Traits\RegistrationDirector;
+use Tests\Traits\RequestFactory;
+use Tests\Traits\UserDirector;
+
+/**
+ * PR6 (#40): API de designação de corretores por slot.
+ *
+ * Cobertura dos critérios de aceitação:
+ * - AC1: criação via API por gestor com @control gera designação com campos do CA-4;
+ * - AC2 (CA-3): corretor fora de eligibleCorrectors() é rejeitado com erro claro;
+ * - AC3: listagem por inscrição devolve status/prazo/corretor por slot (painel F2);
+ * - AC4: permissões (não-gestor → 403; guest → 401) e feature flag.
+ */
+class AppealAssignmentApiTest extends TestCase
+{
+    use OpportunityBuilder,
+        RegistrationDirector,
+        UserDirector,
+        RequestFactory;
+
+    private function enableFlag(): void
+    {
+        $_ENV['APPEAL_SCORE_CORRECTION'] = 'true';
+    }
+
+    private function disableFlag(): void
+    {
+        unset($_ENV['APPEAL_SCORE_CORRECTION']);
+        putenv('APPEAL_SCORE_CORRECTION');
+    }
+
+    /**
+     * Cenário: fase técnica com 2 slots (avaliadores A e B), fase de recurso com
+     * Comissão de Recursos (committeeUser) e usuários de controle.
+     *
+     * @return array{
+     *   admin: User, slotOwnerA: User, slotOwnerB: User,
+     *   committeeUser: User, outsider: User,
+     *   opportunity: Opportunity, registration: Registration,
+     *   slotA: RegistrationEvaluation, slotB: RegistrationEvaluation,
+     *   appealPhase: Opportunity
+     * }
+     */
+    private function createScenario(): array
+    {
+        $this->enableFlag();
+
+        $admin = $this->userDirector->createUser('admin');
+        $slot_owner_a = $this->userDirector->createUser();
+        $slot_owner_b = $this->userDirector->createUser();
+        $committee_user = $this->userDirector->createUser();
+        $outsider = $this->userDirector->createUser();
+
+        $this->login($admin);
+
+        $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase(EvaluationMethods::technical)
+                ->fillRequiredProperties()
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->save()
+                ->addValuer('Comissão', 'Avaliador A', $slot_owner_a->profile)
+                    ->done()
+                ->addValuer('Comissão', 'Avaliador B', $slot_owner_b->profile)
+                    ->done()
+                ->done()
+            ->save();
+
+        /** @var Opportunity $opportunity */
+        $opportunity = $this->opportunityBuilder->getInstance();
+        $registration = $this->registrationDirector->createSentRegistration($opportunity, data: []);
+
+        $app = App::i();
+        $app->disableAccessControl();
+
+        $slot_a = new RegistrationEvaluation();
+        $slot_a->registration = $registration;
+        $slot_a->user = $slot_owner_a;
+        $slot_a->status = RegistrationEvaluation::STATUS_EVALUATED;
+        $slot_a->save(true);
+
+        $slot_b = new RegistrationEvaluation();
+        $slot_b->registration = $registration;
+        $slot_b->user = $slot_owner_b;
+        $slot_b->status = RegistrationEvaluation::STATUS_EVALUATED;
+        $slot_b->save(true);
+
+        $appeal_phase_class = $opportunity->getSpecializedClassName();
+        /** @var Opportunity $appeal_phase */
+        $appeal_phase = new $appeal_phase_class();
+        $appeal_phase->parent = $opportunity;
+        $appeal_phase->status = Opportunity::STATUS_APPEAL_PHASE;
+        $appeal_phase->name = 'Fase de recurso técnica';
+        $appeal_phase->ownerEntity = $opportunity->ownerEntity;
+        $appeal_phase->owner = $opportunity->owner;
+        $appeal_phase->registrationCategories = $opportunity->registrationCategories;
+        $appeal_phase->registrationRanges = $opportunity->registrationRanges;
+        $appeal_phase->registrationProponentTypes = $opportunity->registrationProponentTypes;
+        $appeal_phase->isDataCollection = true;
+        $appeal_phase->isAppealPhase = true;
+        $appeal_phase->registrationFrom = new DateTime('-1 day');
+        $appeal_phase->registrationTo = new DateTime('+1 day');
+        $appeal_phase->save(true);
+
+        $opportunity->appealPhase = $appeal_phase;
+        $opportunity->save(true);
+
+        $appeal_emc = new EvaluationMethodConfiguration();
+        $appeal_emc->opportunity = $appeal_phase;
+        $appeal_emc->type = 'continuous';
+        $appeal_emc->publishEvaluationDetails = true;
+        $appeal_emc->save(true);
+
+        $appeal_phase->evaluationMethodConfiguration = $appeal_emc;
+        $appeal_phase->save(true);
+
+        $appeal_emc->createAgentRelation($committee_user->profile, 'committee 1', true)->save(true);
+
+        $app->enableAccessControl();
+
+        return [
+            'admin' => $admin,
+            'slotOwnerA' => $slot_owner_a,
+            'slotOwnerB' => $slot_owner_b,
+            'committeeUser' => $committee_user,
+            'outsider' => $outsider,
+            'opportunity' => $opportunity,
+            'registration' => $registration,
+            'slotA' => $slot_a,
+            'slotB' => $slot_b,
+            'appealPhase' => $appeal_phase,
+        ];
+    }
+
+    /**
+     * Executa uma requisição in-process e devolve status + JSON do corpo.
+     *
+     * @return array{status: int, json: mixed}
+     */
+    private function dispatch(ServerRequestInterface $request): array
+    {
+        $app = App::i();
+        $app->reset();
+        $app->run($request, false);
+
+        return [
+            'status' => $app->response->getStatusCode(),
+            'json' => json_decode((string) $app->response->getBody(), true),
+        ];
+    }
+
+    /**
+     * @return array{status: int, json: mixed}
+     */
+    private function postAssignment(array $payload): array
+    {
+        return $this->dispatch(
+            $this->requestFactory->POST('registrationappealreview', 'index', [], $payload)
+        );
+    }
+
+    /**
+     * @return array{status: int, json: mixed}
+     */
+    private function findAssignments(Registration $registration, string $select = 'id,status,correctionType,startsAt,endsAt,sentTimestamp'): array
+    {
+        return $this->dispatch(
+            $this->requestFactory->GET(
+                'api/registrationappealreview',
+                'find',
+                [],
+                [
+                    'registration' => 'EQ(' . $registration->id . ')',
+                    '@select' => $select,
+                ],
+                ajax: true
+            )
+        );
+    }
+
+    private function countActiveReviewsForSlot(RegistrationEvaluation $slot): int
+    {
+        $app = App::i();
+
+        return count($app->repo(RegistrationAppealReview::class)->findBy([
+            'originalEvaluation' => $slot->id,
+            'status' => RegistrationAppealReview::getActiveStatuses(),
+        ]));
+    }
+
+    function testManagerCanDesignateCommitteeMemberWithCa4Fields(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['admin']);
+
+        $response = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+            'correctionType' => RegistrationAppealReview::CORRECTION_TYPE_OFFICIAL,
+            'releasedScope' => json_encode(['criteria' => ['c-1'], 'showAppealOpinion' => true]),
+            'startsAt' => '2026-09-01 09:00',
+            'endsAt' => '2026-09-10 18:00',
+        ]);
+
+        $this->assertEquals(200, $response['status'], 'Gestor com @control deve criar designação: ' . json_encode($response['json']));
+        $this->assertNotEmpty($response['json']['id'], 'Resposta deve devolver o ID da designação criada.');
+
+        /** @var RegistrationAppealReview $review */
+        $review = App::i()->repo(RegistrationAppealReview::class)->find($response['json']['id']);
+        $this->assertNotNull($review, 'Designação deve estar persistida.');
+
+        // Campos do CA-4
+        $this->assertEquals($scenario['slotA']->id, $review->originalEvaluation->id);
+        $this->assertEquals($scenario['committeeUser']->id, $review->correctorUser->id);
+        $this->assertEquals(RegistrationAppealReview::CORRECTION_TYPE_OFFICIAL, $review->correctionType);
+        $this->assertEquals(['criteria' => ['c-1'], 'showAppealOpinion' => true], (array) $review->releasedScope);
+        $this->assertEquals('2026-09-01 09:00:00', $review->startsAt->format('Y-m-d H:i:s'));
+        $this->assertEquals('2026-09-10 18:00:00', $review->endsAt->format('Y-m-d H:i:s'));
+
+        // Campos derivados do slot no servidor
+        $this->assertEquals($scenario['registration']->id, $review->registration->id);
+        $this->assertEquals($scenario['appealPhase']->id, $review->appealPhase->id);
+        $this->assertEquals($scenario['slotOwnerA']->id, $review->slotOwnerUser->id);
+        $this->assertEquals(RegistrationAppealReview::STATUS_DESIGNATED, $review->status);
+        $this->assertNull($review->sentTimestamp, 'Designação recém-criada não tem envio.');
+    }
+
+    function testSlotOwnerIsEligibleCorrector(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['admin']);
+
+        $response = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['slotOwnerA']->id,
+            'correctionType' => RegistrationAppealReview::CORRECTION_TYPE_RECORD,
+        ]);
+
+        $this->assertEquals(200, $response['status'], 'O dono do slot é corretor elegível (CA-3a): ' . json_encode($response['json']));
+        $this->assertEquals(1, $this->countActiveReviewsForSlot($scenario['slotA']));
+    }
+
+    function testEvaluatorFromAnotherSlotIsRejected(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['admin']);
+
+        // R17: avaliador de OUTRO slot da mesma inscrição, fora da Comissão de Recursos.
+        $response = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['slotOwnerB']->id,
+        ]);
+
+        $this->assertEquals(400, $response['status'], 'Avaliador de outro slot deve ser rejeitado (CA-3).');
+        $this->assertTrue($response['json']['error'] ?? false, 'Resposta de erro deve seguir o contrato errorJson.');
+        $this->assertStringContainsStringIgnoringCase('eleg', (string) $response['json']['data'], 'Mensagem deve explicar a inelegibilidade (CA-3).');
+        $this->assertEquals(0, $this->countActiveReviewsForSlot($scenario['slotA']), 'Nenhuma designação deve ser persistida.');
+    }
+
+    function testNonManagerForbidden(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['outsider']);
+
+        $response = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ]);
+
+        $this->assertEquals(403, $response['status'], 'Usuário sem @control na oportunidade recebe 403.');
+        $this->assertEquals(0, $this->countActiveReviewsForSlot($scenario['slotA']), 'Nenhuma designação deve ser persistida.');
+    }
+
+    function testNonAdminManagerWithControlCanDesignate(): void
+    {
+        $scenario = $this->createScenario();
+
+        $manager = $this->userDirector->createUser();
+        $app = App::i();
+        $app->disableAccessControl();
+        $scenario['opportunity']->createAgentRelation($manager->profile, 'group-admin', true)->save(true);
+        $app->enableAccessControl();
+
+        // userHasControl consulta as AgentRelations ao vivo; pcache é filtro de
+        // listagem da API, não usado neste fluxo.
+        $this->login($manager);
+
+        $response = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ]);
+
+        $this->assertEquals(200, $response['status'], 'Gestor não-admin com relação de controle (group-admin) deve designar: ' . json_encode($response['json']));
+    }
+
+    function testGuestUnauthorized(): void
+    {
+        $scenario = $this->createScenario();
+        $this->logout();
+
+        $post = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ]);
+
+        $this->assertEquals(401, $post['status'], 'Guest recebe 401 na criação.');
+
+        $find = $this->findAssignments($scenario['registration']);
+        $this->assertEquals(401, $find['status'], 'Guest recebe 401 na listagem.');
+    }
+
+    function testFlagOffReturns404(): void
+    {
+        $scenario = $this->createScenario();
+        $this->disableFlag();
+        $this->login($scenario['admin']);
+
+        $response = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ]);
+
+        $this->assertEquals(404, $response['status'], 'Feature flag desligada deve retornar 404.');
+    }
+
+    function testDuplicateActiveDesignationRejected(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['admin']);
+
+        $first = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ]);
+
+        $this->assertEquals(200, $first['status']);
+
+        $second = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['slotOwnerA']->id,
+        ]);
+
+        $this->assertEquals(400, $second['status'], 'Segunda designação ativa no mesmo slot deve ser rejeitada com erro claro (índice único).');
+        $this->assertEquals(1, $this->countActiveReviewsForSlot($scenario['slotA']));
+    }
+
+    function testFindListsAssignmentsPerRegistrationForPanel(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['admin']);
+
+        $review_a = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+            'startsAt' => '2026-09-01 09:00',
+            'endsAt' => '2026-09-10 18:00',
+        ]);
+        $this->assertEquals(200, $review_a['status']);
+
+        $review_b = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotB']->id,
+            'correctorUser' => $scenario['slotOwnerB']->id,
+        ]);
+        $this->assertEquals(200, $review_b['status']);
+
+        // Designação de OUTRA inscrição: não pode vazar para o painel desta.
+        $other_registration = $this->registrationDirector->createSentRegistration($scenario['opportunity'], data: []);
+        $app = App::i();
+        $app->disableAccessControl();
+        $slot_c = new RegistrationEvaluation();
+        $slot_c->registration = $other_registration;
+        $slot_c->user = $scenario['slotOwnerA'];
+        $slot_c->status = RegistrationEvaluation::STATUS_EVALUATED;
+        $slot_c->save(true);
+        $app->enableAccessControl();
+
+        $review_c = $this->postAssignment([
+            'originalEvaluation' => $slot_c->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ]);
+        $this->assertEquals(200, $review_c['status']);
+
+        $response = $this->findAssignments($scenario['registration']);
+
+        $this->assertEquals(200, $response['status'], 'Listagem do painel deve funcionar para gestor com @control.');
+        $items = $response['json'];
+        $this->assertIsArray($items);
+        $this->assertCount(2, $items, 'Listagem escopada à inscrição: 2 slots designados, sem vazar a outra inscrição.');
+
+        $by_id = [];
+        foreach ($items as $item) {
+            $by_id[$item['id']] = $item;
+        }
+
+        $this->assertArrayHasKey($review_a['json']['id'], $by_id);
+        $this->assertArrayHasKey($review_b['json']['id'], $by_id);
+
+        $panel_item = $by_id[$review_a['json']['id']];
+        $this->assertEquals(RegistrationAppealReview::STATUS_DESIGNATED, $panel_item['status']);
+        $this->assertArrayHasKey('startsAt', $panel_item, 'Painel (CA-13) exige prazo.');
+        $this->assertArrayHasKey('endsAt', $panel_item);
+        $this->assertArrayHasKey('sentTimestamp', $panel_item, 'Painel (CA-13) exige data de envio.');
+
+        // Corretor por slot: resolvido pela entidade (serialização da relação varia na ApiQuery).
+        /** @var RegistrationAppealReview $persisted_a */
+        $persisted_a = $app->repo(RegistrationAppealReview::class)->find($review_a['json']['id']);
+        $this->assertEquals($scenario['committeeUser']->id, $persisted_a->correctorUser->id);
+        $this->assertEquals($scenario['slotA']->id, $persisted_a->originalEvaluation->id);
+    }
+
+    function testFindForbiddenForNonManager(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['outsider']);
+
+        $response = $this->findAssignments($scenario['registration']);
+
+        $this->assertEquals(403, $response['status'], 'Listagem por inscrição exige @control na oportunidade.');
+    }
+
+    function testPatchSubstitutionEnforcesEligibility(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['admin']);
+
+        $created = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ]);
+        $this->assertEquals(200, $created['status']);
+        $review_id = $created['json']['id'];
+
+        // Substituição por corretor inelegível (avaliador de outro slot) → CA-3.
+        $ineligible = $this->dispatch(
+            $this->requestFactory->PATCH('registrationappealreview', 'single', [$review_id], [
+                'correctorUser' => $scenario['slotOwnerB']->id,
+            ])
+        );
+        $this->assertEquals(400, $ineligible['status'], 'Substituição por corretor inelegível deve ser rejeitada (CA-3).');
+
+        // Substituição por corretor elegível (dono do slot) → OK.
+        $eligible = $this->dispatch(
+            $this->requestFactory->PATCH('registrationappealreview', 'single', [$review_id], [
+                'correctorUser' => $scenario['slotOwnerA']->id,
+            ])
+        );
+        $this->assertEquals(200, $eligible['status'], 'Substituição por corretor elegível deve ser aceita: ' . json_encode($eligible['json']));
+
+        /** @var RegistrationAppealReview $persisted */
+        $persisted = App::i()->repo(RegistrationAppealReview::class)->find($review_id);
+        $this->assertEquals($scenario['slotOwnerA']->id, $persisted->correctorUser->id, 'Substituição deve persistir o novo corretor.');
+    }
+
+    function testDeleteForbiddenForOutsider(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['admin']);
+
+        $created = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ]);
+        $this->assertEquals(200, $created['status']);
+        $review_id = $created['json']['id'];
+
+        $this->login($scenario['outsider']);
+
+        $deleted = $this->dispatch(
+            $this->requestFactory->DELETE('registrationappealreview', 'single', [$review_id])
+        );
+
+        $this->assertEquals(403, $deleted['status'], 'Exclusão de designação exige @control na oportunidade.');
+        $this->assertNotNull(App::i()->repo(RegistrationAppealReview::class)->find($review_id), 'Designação não pode ser removida por não-gestor.');
+    }
+}


### PR DESCRIPTION
Desbloqueia os critérios 3–4 do F2 (#18, PR #41 — a flag `endpointAvailable` liga sozinha com o controller registrado).

- `Module.php`: registro do controller `registrationappealreview` (padrão do módulo, ao lado de `appealCorrector`).
- `Controllers/RegistrationAppealReview.php`: `POST_index` (criação pelo gestor com `@control`; CA-4 completo: slot/corretor/tipo/escopo/prazo; derivados `slotOwnerUser`/`registration`/`appealPhase`; `STATUS_DESIGNATED`), `API_find`/`API_findOne` (painel de acompanhamento por inscrição, escopo restrito), `PUT|PATCH single/{id}` (substituição de corretor/prazo, CA-3 mantido), `DELETE single/{id}` (cancelamento). Todas as actions: `requireAuthentication` + `@control`; CA-3 validação autoritativa no backend (`eligibleCorrectors()`); feature flag do módulo (flag off → 404).
- `tests/src/AppealAssignmentApiTest.php`: 12 testes — criação válida com CA-4, dono do slot elegível, avaliador de outro slot rejeitado, não-gestor 403, gestor não-admin OK, visitante 401, flag off 404, designação ativa duplicada rejeitada, listagem escopada por inscrição, listagem vedada a não-gestor, substituição com CA-3, DELETE vedado a terceiro.

**Verificação:** novos **12/12** (51 assertions); suites correlatas OK (ApplyCorrection 10/10, CorrectorEnvironment 7/7, TwoStagePublish 4/4); `RegistrationAppealReviewTest` (6 errors) e `RoutesTest` (13 failures) provados pré-existentes via stash na base (deprecations PHP 8.4 / EM do core).

**Notas técnicas (comentadas no código):** `ApiQuery` aplicaria `status > 0` por default e esconderia `STATUS_DESIGNATED=0` — defaults ajustados no controller (`status=IN(0,1,2,3)` + `@permissions=view`, no-op para entidade sem pcache); `userHasControl` consulta AgentRelations ao vivo (sem `processPCache` necessário).
