### PR TITLE
F3 — Ambiente do corretor designado (#19)

### DIFF
--- a/src/modules/OpportunityAppealPhase/AppealReview/CorrectorEnvironment.php
+++ b/src/modules/OpportunityAppealPhase/AppealReview/CorrectorEnvironment.php
@@ -41,6 +41,11 @@ class CorrectorEnvironment
 
         $payload = [
             'assignmentId' => (int) $review->id,
+            'evaluationId' => (int) $slot->id,
+            'registrationId' => (int) $review->registration->id,
+            'registrationNumber' => $review->registration->number,
+            'opportunityName' => (string) $review->registration->opportunity->name,
+            'criteria' => $this->buildCriteriaMetadata($slot, $scope_ids),
             'targetEvaluatorName' => $this->resolveEvaluatorName($review),
             'deadline' => $review->endsAt ? $review->endsAt->format('c') : null,
             'status' => self::STATUS_LABELS[(int) $review->status] ?? (string) $review->status,
@@ -100,6 +105,72 @@ class CorrectorEnvironment
         }
 
         return $owner ? (string) $owner->email : '';
+    }
+
+    /**
+     * Metadata of the criteria released for correction, from the MAIN phase
+     * evaluation method configuration (not the appeal phase). Criteria ids in
+     * the scope that do not exist in the configuration are ignored.
+     *
+     * @param string[]|null $scope_ids null = all criteria
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildCriteriaMetadata(RegistrationEvaluation $slot, ?array $scope_ids): array
+    {
+        $emc = $slot->registration->opportunity->evaluationMethodConfiguration;
+        if (!$emc) {
+            return [];
+        }
+
+        $sections = $emc->sections ?? [];
+        $criteria = $emc->criteria ?? [];
+
+        // metadata may still be raw JSON strings before unserialize (same normalization
+        // as EvaluationMethodConfiguration::validateCriteriaSectionsIntegrity)
+        if (is_string($sections)) {
+            $sections = json_decode($sections);
+        }
+        if (is_string($criteria)) {
+            $criteria = json_decode($criteria);
+        }
+
+        $sections = (array) $sections;
+        $criteria = (array) $criteria;
+
+        $section_names = [];
+        foreach ($sections as $section) {
+            $section = (object) $section;
+            if (isset($section->id)) {
+                $section_names[(string) $section->id] = (string) ($section->name ?? '');
+            }
+        }
+
+        $out = [];
+        foreach ($criteria as $criterion) {
+            $criterion = (object) $criterion;
+            if (!isset($criterion->id)) {
+                continue;
+            }
+
+            $id = (string) $criterion->id;
+            if ($scope_ids !== null && !in_array($id, $scope_ids, true)) {
+                continue;
+            }
+
+            $sid = isset($criterion->sid) ? (string) $criterion->sid : null;
+
+            $out[] = [
+                'id' => $id,
+                'title' => (string) ($criterion->title ?? $id),
+                'min' => (float) ($criterion->min ?? 0),
+                'max' => (float) ($criterion->max ?? 0),
+                'weight' => (float) ($criterion->weight ?? 1),
+                'sectionId' => $sid,
+                'sectionName' => $sid !== null ? ($section_names[$sid] ?? '') : null,
+            ];
+        }
+
+        return $out;
     }
 
     /**

--- a/src/modules/OpportunityAppealPhase/Controllers/AppealCorrector.php
+++ b/src/modules/OpportunityAppealPhase/Controllers/AppealCorrector.php
@@ -10,9 +10,11 @@ use OpportunityAppealPhase\AppealReview\CorrectorEnvironment;
 use OpportunityAppealPhase\Entities\RegistrationAppealReview;
 
 /**
- * Ambiente read-only do corretor designado (PR4.5).
+ * Ambiente do corretor designado (issue #19 / F3).
  *
- * GET /appealCorrector/environment/{assignmentId}
+ * GET /appealCorrector/environment/{assignmentId}  -> read-only JSON payload
+ * GET /appealCorrector/correction/{assignmentId}   -> correction page (dumb page:
+ *    permission/deadline/feature flag checks belong to the environment endpoint)
  */
 class AppealCorrector extends Controller
 {
@@ -44,5 +46,28 @@ class AppealCorrector extends Controller
         }
 
         $this->json($payload);
+    }
+
+    function GET_correction()
+    {
+        $this->requireAuthentication();
+
+        $app = App::i();
+
+        $assignment_id = (int) ($this->data['id'] ?? $this->urlData['id'] ?? 0);
+        if (!$assignment_id) {
+            $app->pass();
+        }
+
+        /** @var RegistrationAppealReview|null $review */
+        $review = $app->repo(RegistrationAppealReview::class)->find($assignment_id);
+        if (!$review) {
+            $app->pass();
+        }
+
+        $this->render('correction', [
+            'assignmentId' => (int) $review->id,
+            'assignment' => $review,
+        ]);
     }
 }

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/script.js
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/script.js
@@ -1,0 +1,255 @@
+app.component('opportunity-appeal-correction-evaluation', {
+    template: $TEMPLATES['opportunity-appeal-correction-evaluation'],
+
+    props: {
+        assignmentId: {
+            type: [Number, String],
+            required: true,
+        },
+    },
+
+    setup() {
+        const messages = useMessages();
+        const text = Utils.getTexts('opportunity-appeal-correction-evaluation');
+
+        return { messages, text };
+    },
+
+    data() {
+        return {
+            loading: true,
+            environment: null,
+            error: null,
+            formData: {},
+            savingDraft: false,
+            sending: false,
+            submitted: false,
+        };
+    },
+
+    computed: {
+        isLocked() {
+            if (this.submitted) {
+                return true;
+            }
+
+            if (!this.environment) {
+                return false;
+            }
+
+            if (this.environment.status === 'sent') {
+                return true;
+            }
+
+            if (this.environment.deadline) {
+                return new Date(this.environment.deadline) < new Date();
+            }
+
+            return false;
+        },
+
+        formattedDeadline() {
+            if (!this.environment?.deadline) {
+                return '';
+            }
+
+            return new Date(this.environment.deadline).toLocaleString('pt-BR');
+        },
+
+        criteriaList() {
+            return this.environment?.criteria || [];
+        },
+
+        totalScore() {
+            let result = 0;
+
+            for (const criterion of this.criteriaList) {
+                const value = this.formData.data?.[criterion.id];
+
+                if (value === null || value === undefined || value === '') {
+                    continue;
+                }
+
+                result += this.toNumber(value) * this.toNumber(criterion.weight);
+            }
+
+            return parseFloat(result.toFixed(2));
+        },
+
+        statusLabel() {
+            const labels = {
+                designated: this.text('status-designated'),
+                draft: this.text('status-draft'),
+                sent: this.text('status-sent'),
+                reopened: this.text('status-reopened'),
+            };
+
+            return labels[this.environment?.status] || this.environment?.status || '';
+        },
+
+        correctionTypeLabel() {
+            const labels = {
+                official: this.text('correction-type-official'),
+                record: this.text('correction-type-record'),
+            };
+
+            return labels[this.environment?.correctionType] || this.environment?.correctionType || '';
+        },
+    },
+
+    mounted() {
+        this.fetchEnvironment();
+    },
+
+    methods: {
+        toNumber(value) {
+            const number = Number(value);
+
+            return Number.isFinite(number) ? number : 0;
+        },
+
+        originalNote(criterion) {
+            const value = this.environment?.originalEvaluation?.[criterion.id];
+
+            return (value === null || value === undefined || value === '') ? '-' : value;
+        },
+
+        async fetchEnvironment() {
+            this.loading = true;
+            this.error = null;
+
+            try {
+                const api = new API();
+                const url = Utils.createUrl('appealCorrector', 'environment', [this.assignmentId]);
+                const res = await api.GET(url);
+
+                if (res.ok) {
+                    this.environment = await res.json();
+                    this.formData.data = {
+                        ...this.environment.originalEvaluation,
+                        ...(this.environment.draft || {}),
+                    };
+                } else {
+                    this.error = {
+                        status: res.status,
+                        message: this.environmentErrorMessage(res.status),
+                    };
+                }
+            } catch (e) {
+                this.error = { status: 0, message: this.text('error-generic') };
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        environmentErrorMessage(status) {
+            if (status === 403) {
+                return this.text('error-forbidden');
+            }
+
+            if (status === 404) {
+                return this.text('error-not-found');
+            }
+
+            return this.text('error-generic');
+        },
+
+        handleInput(criterion) {
+            if (this.isLocked) {
+                return;
+            }
+
+            const value = this.formData.data[criterion.id];
+
+            if (value === '' || value === null || value === undefined) {
+                return;
+            }
+
+            const max = this.toNumber(criterion.max);
+
+            if (this.toNumber(value) > max) {
+                this.messages.error(this.text('note-higher-configured'));
+                this.formData.data[criterion.id] = max;
+            } else if (value < 0) {
+                this.formData.data[criterion.id] = 0;
+            }
+        },
+
+        async extractErrorMessage(res) {
+            try {
+                const data = await res.json();
+
+                if (data?.message) {
+                    return data.message;
+                }
+
+                // errorJson() responds {error: true, data: <message>}
+                if (data?.data) {
+                    return typeof data.data === 'string' ? data.data : JSON.stringify(data.data);
+                }
+            } catch (e) {
+                // body is not JSON, fall through to generic message
+            }
+
+            return this.text('error-generic');
+        },
+
+        async saveDraft() {
+            if (this.savingDraft || this.isLocked) {
+                return;
+            }
+
+            this.savingDraft = true;
+
+            try {
+                const api = new API('registrationevaluation');
+                const url = api.createUrl('applyAppealCorrection', { id: this.environment.evaluationId });
+                const res = await api.POST(url, {
+                    evaluationData: { ...this.formData.data },
+                    draft: true,
+                });
+
+                if (res.ok) {
+                    const data = await res.json();
+                    this.environment.draft = data.review?.correctedValue || { ...this.formData.data };
+                    this.messages.success(this.text('draft-saved'));
+                } else {
+                    this.messages.error(await this.extractErrorMessage(res));
+                }
+            } catch (e) {
+                this.messages.error(this.text('error-generic'));
+            } finally {
+                this.savingDraft = false;
+            }
+        },
+
+        async sendCorrection() {
+            if (this.sending || this.isLocked) {
+                return;
+            }
+
+            this.sending = true;
+
+            try {
+                const api = new API('registrationevaluation');
+                const url = api.createUrl('applyAppealCorrection', { id: this.environment.evaluationId });
+                const res = await api.POST(url, {
+                    evaluationData: { ...this.formData.data },
+                    draft: false,
+                });
+
+                if (res.ok) {
+                    this.submitted = true;
+                    this.environment.status = 'sent';
+                    this.messages.success(this.text('correction-sent'));
+                } else {
+                    this.messages.error(await this.extractErrorMessage(res));
+                }
+            } catch (e) {
+                this.messages.error(this.text('error-generic'));
+            } finally {
+                this.sending = false;
+            }
+        },
+    },
+});

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/template.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/template.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * @var MapasCulturais\App $app
+ * @var MapasCulturais\Themes\BaseV2\Theme $this
+ */
+
+use MapasCulturais\i;
+
+$this->import('
+    mc-alert
+    mc-icon
+    mc-loading
+    mc-modal
+');
+?>
+
+<div class="opportunity-appeal-correction-evaluation">
+    <mc-loading v-if="loading" :condition="loading"><?= i::__('carregando...') ?></mc-loading>
+
+    <mc-alert v-else-if="error" type="danger">{{ error.message }}</mc-alert>
+
+    <template v-else>
+        <section class="grid-12 section">
+            <h3 class="col-12"><?= i::__('Correção de avaliação (recurso)') ?></h3>
+            <div class="section__content col-12">
+                <div class="card">
+                    <div class="grid-12">
+                        <div class="col-6">
+                            <label><?= i::__('Oportunidade') ?></label>
+                            <p class="semibold">{{ environment.opportunityName }}</p>
+                        </div>
+                        <div class="col-3">
+                            <label><?= i::__('Inscrição') ?></label>
+                            <p class="semibold">{{ environment.registrationNumber }}</p>
+                        </div>
+                        <div class="col-3">
+                            <label><?= i::__('Prazo') ?></label>
+                            <p class="semibold">{{ formattedDeadline }}</p>
+                        </div>
+                        <div class="col-6">
+                            <label><?= i::__('Avaliador original') ?></label>
+                            <p class="semibold">{{ environment.targetEvaluatorName }}</p>
+                        </div>
+                        <div class="col-3">
+                            <label><?= i::__('Status') ?></label>
+                            <p><span class="opportunity-appeal-correction-evaluation__badge">{{ statusLabel }}</span></p>
+                        </div>
+                        <div class="col-3">
+                            <label><?= i::__('Tipo de correção') ?></label>
+                            <p><span class="opportunity-appeal-correction-evaluation__badge">{{ correctionTypeLabel }}</span></p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section v-if="environment.committeeOpinion" class="grid-12 section">
+            <h3 class="col-12"><?= i::__('Parecer da Comissão de Recursos') ?></h3>
+            <div class="section__content col-12">
+                <div class="card" v-for="opinion in environment.committeeOpinion.evaluations" :key="opinion.evaluationId">
+                    <p>
+                        <strong>{{ opinion.valuerName }}</strong>
+                        <span v-if="opinion.resultString"> · {{ opinion.resultString }}</span>
+                    </p>
+                    <p v-if="opinion.evaluationData?.obs">{{ opinion.evaluationData.obs }}</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="grid-12 section">
+            <h3 class="col-12"><?= i::__('Critérios liberados para correção') ?></h3>
+            <div class="section__content col-12">
+                <div class="card">
+                    <div class="opportunity-appeal-correction-evaluation__criterion" v-for="criterion in criteriaList" :key="criterion.id">
+                        <label><strong>{{ criterion.title }}</strong></label>
+                        <div class="grid-12">
+                            <div class="col-6">
+                                <label><?= i::__('Nota original') ?></label>
+                                <input disabled min="0" step="0.1" type="number" :value="originalNote(criterion)">
+                            </div>
+                            <div class="col-6">
+                                <label><?= i::__('Nota corrigida') ?></label>
+                                <input :disabled="isLocked" min="0" step="0.1" type="number" v-model.number="formData.data[criterion.id]" @input="handleInput(criterion)">
+                            </div>
+                        </div>
+                        <div class="grid-12">
+                            <small class="col-8"><?= i::__('Nota máxima') ?>: <strong>{{ criterion.max }}</strong></small>
+                            <small class="col-4"><?= i::__('Peso') ?>: <strong>{{ criterion.weight }}</strong></small>
+                        </div>
+                    </div>
+                    <div class="opportunity-appeal-correction-evaluation__results">
+                        <h4><?= i::__('Pontuação total') ?>: <strong>{{ totalScore }}</strong></h4>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <mc-alert v-if="isLocked" type="warning"><?= i::__('Correção enviada, edição bloqueada.') ?></mc-alert>
+
+        <div class="grid-12" v-if="!isLocked">
+            <div class="col-6">
+                <button class="button button--primary-outline" :class="{'btn disabled': savingDraft}" @click="saveDraft()">
+                    <?= i::__('Salvar rascunho') ?>
+                </button>
+            </div>
+            <div class="col-6">
+                <mc-modal title="<?= i::__('Enviar correção') ?>">
+                    <template #default>
+                        <p><?= i::__('Ao confirmar, a correção será aplicada à avaliação e a edição será bloqueada. Esta ação não pode ser desfeita.') ?></p>
+                    </template>
+
+                    <template #actions="modal">
+                        <button class="button button--text" @click="modal.close()"><?= i::__('Cancelar') ?></button>
+                        <button class="button button--primary" :class="{'btn disabled': sending}" @click="sendCorrection(); modal.close()">
+                            <?= i::__('Confirmar envio') ?>
+                        </button>
+                    </template>
+
+                    <template #button="modal">
+                        <button class="button button--primary" @click="modal.open()">
+                            <?= i::__('Enviar definitivamente') ?>
+                        </button>
+                    </template>
+                </mc-modal>
+            </div>
+        </div>
+    </template>
+</div>

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/texts.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/texts.php
@@ -1,0 +1,17 @@
+<?php
+use MapasCulturais\i;
+
+return [
+    'status-designated' => i::__('Designada'),
+    'status-draft' => i::__('Rascunho'),
+    'status-sent' => i::__('Enviada'),
+    'status-reopened' => i::__('Reaberta'),
+    'correction-type-official' => i::__('Correção oficial'),
+    'correction-type-record' => i::__('Somente registro'),
+    'error-forbidden' => i::__('Você não tem permissão para acessar este ambiente de correção.'),
+    'error-not-found' => i::__('Designação não encontrada ou correção de notas desabilitada.'),
+    'error-generic' => i::__('Não foi possível carregar o ambiente de correção.'),
+    'note-higher-configured' => i::__('Nota maior que a configurada para avaliação'),
+    'draft-saved' => i::__('Rascunho salvo com sucesso'),
+    'correction-sent' => i::__('Correção enviada com sucesso'),
+];

--- a/src/modules/OpportunityAppealPhase/views/appealcorrector/correction.php
+++ b/src/modules/OpportunityAppealPhase/views/appealcorrector/correction.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @var MapasCulturais\App $app
+ * @var MapasCulturais\Themes\BaseV2\Theme $this
+ * @var int $assignmentId
+ * @var OpportunityAppealPhase\Entities\RegistrationAppealReview $assignment
+ */
+
+use MapasCulturais\i;
+
+$this->layout = 'default';
+
+$this->import('
+    mc-breadcrumb
+    opportunity-appeal-correction-evaluation
+');
+
+$breadcrumb = [
+    ['label' => i::__('Início'), 'url' => $app->createUrl('panel', 'opportunities')],
+    ['label' => i::__('Painel de controle'), 'url' => $app->createUrl('panel', 'opportunities')],
+    ['label' => i::__('Correção de avaliação (recurso)')],
+];
+
+$this->breadcrumb = $breadcrumb;
+?>
+
+<div class="main-app">
+    <mc-breadcrumb></mc-breadcrumb>
+    <opportunity-appeal-correction-evaluation :assignment-id="<?= (int) $assignmentId ?>"></opportunity-appeal-correction-evaluation>
+</div>

--- a/tests/src/AppealCorrectorEnvironmentTest.php
+++ b/tests/src/AppealCorrectorEnvironmentTest.php
@@ -300,4 +300,52 @@ class AppealCorrectorEnvironmentTest extends TestCase
         $this->expectException(PermissionDenied::class);
         (new CorrectorEnvironment())->build($scenario['review']);
     }
+
+    function testPayloadExposesCriteriaMetadataAndSlotIdentity(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['corrector']);
+
+        $payload = (new CorrectorEnvironment())->build($scenario['review']);
+
+        $this->assertEquals((int) $scenario['slotA']->id, $payload['evaluationId']);
+        $this->assertEquals((int) $scenario['registration']->id, $payload['registrationId']);
+        $this->assertEquals($scenario['registration']->number, $payload['registrationNumber']);
+        $this->assertNotEmpty($payload['opportunityName']);
+
+        $this->assertIsArray($payload['criteria']);
+        $this->assertCount(1, $payload['criteria']);
+
+        $criteria_ids = array_map(static fn ($criterion) => $criterion['id'], $payload['criteria']);
+        $this->assertEquals(['c-1'], $criteria_ids);
+
+        $criterion = $payload['criteria'][0];
+        $this->assertEquals('Critério 1', $criterion['title']);
+        $this->assertEquals(10, $criterion['max']);
+        $this->assertEquals(1, $criterion['weight']);
+        $this->assertEquals('sec-1', $criterion['sectionId']);
+        $this->assertEquals('Seção 1', $criterion['sectionName']);
+    }
+
+    function testCorrectionPageRendersForCorrector(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['corrector']);
+
+        $request = $this->requestFactory->GET(
+            'appealCorrector',
+            'correction',
+            [$scenario['review']->id],
+            ajax: false
+        );
+
+        $app = App::i();
+        $app->reset();
+        $app->run($request, false);
+
+        $this->assertEquals(200, $app->response->getStatusCode());
+        $body = (string) $app->response->getBody();
+        $this->assertStringContainsString('opportunity-appeal-correction-evaluation', $body);
+        $this->assertStringContainsString((string) $scenario['review']->id, $body);
+    }
 }


### PR DESCRIPTION
Closes #19 · Parte da épica #7 (R01, correção de notas após deferimento de recurso).

## O que entra
- **Página do corretor** `GET /appealCorrector/correction/{assignmentId}` (view `correction.php`, layout padrão BaseV2) — página burra: permissão, prazo e feature flag continuam a cargo do endpoint.
- **Componente** `opportunity-appeal-correction-evaluation`: consome o endpoint read-only do PR4.5 escopado por `assignmentId`; exibe cabeçalho (oportunidade, inscrição, avaliador original, prazo, status, tipo de correção), parecer da Comissão somente quando liberado no payload, critérios liberados com nota original (leitura) vs nota corrigida (edição com clamp na máxima) e total ponderado; ações **Salvar rascunho** (`draft: true`) e **Enviar definitivamente** (modal de confirmação, `draft: false`); após envio a edição trava (localmente e pelo backend).
- **Payload PR4.5 aditivo** (`CorrectorEnvironment`): acrescenta `evaluationId`, `registrationId`, `registrationNumber`, `opportunityName` e `criteria` (metadados dos critérios liberados: título, mín/máx, peso, seção). Contrato existente inalterado — os testes do PR4.5 seguem verdes sem edição.

## Evidência
- Teste alvo: `AppealCorrectorEnvironmentTest` — **OK (9 tests, 39 assertions)**, incluindo 2 novos: `testPayloadExposesCriteriaMetadataAndSlotIdentity` e `testCorrectionPageRendersForCorrector` (página renderiza 200 com o componente e o id da designação).
- Suíte completa comparada antes/depois: **727 → 729 tests, mesmos 3 erros pré-existentes** (`EvaluationMethodApplyResultsByRegistrationTest`, output inesperado, anteriores à mudança), zero novos failures/errors.

## Critérios de aceitação da #19
- [x] Corretor vê apenas o slot designado (payload escopado + teste `testReturnsOnlyDesignatedSlotCriteria`)
- [x] Critérios fora do escopo não são editáveis (só critérios do `released_scope` chegam à UI; backend rejeita fora do escopo)
- [x] Salvar rascunho persiste sem reconsolidar (`saveDraft` não toca consolidação)
- [x] Enviar definitivo bloqueia edição e dispara reconsolidação (`applyCorrection` + UI trava)
- [x] Parecer da Comissão só aparece quando liberado (`v-if="environment.committeeOpinion"`; ausente quando `showAppealOpinion=false`)

## Fora de escopo (mantido)
- Backend de correção (PR4 #13) e notificações (PR5 #39) — já mergeados.

## Notas
- View em `views/appealcorrector/` (minúsculas) porque `App::getController()` lowercaza o id e `resolveFilename` é case-sensitive.
- Base: `epic/7-correcao-notas` (topologia de branch da épica; PRs #41/#43 idem).
