### PR TITLE
F6 — Seletor de escopo de critérios na designação (CA-4) (#49)

### DIFF
--- a/docs/reference/prd.md
+++ b/docs/reference/prd.md
@@ -151,6 +151,8 @@ Extensão da fase de recurso (RF-A15) para permitir que gestores designem corret
 - o avaliador original daquele slot; ou
 - membro da Comissão de Recursos da fase de recurso.
 
+**Matriz de métodos (F6 / #49, Variante 3 — override registrado na #7 em 2026-09-09):** a designação é elegível para **todos** os métodos de avaliação. O seletor de escopo de critérios (`releasedScope`) existe somente para **avaliação técnica** (seções/critérios do EMC) e **qualificação documental** (campos e documentos exigidos); nos **demais métodos** (simples etc.) a correção é liberada integral (`releasedScope` nulo). Semântica: todos os critérios marcados → `null` (= sem restrição, compatível com `getReleasedCriteriaIds()`); subconjunto → `{criteria: [...]}`; lista vazia é rejeitada (400).
+
 A correção persiste in-place na `RegistrationEvaluation` original, mantendo seu dono (`user`) inalterado. A consolidação da inscrição recalcula automaticamente a partir das N avaliações (incluindo as corrigidas). O histórico fica em `EntityRevision` (mensagem customizada identificando corretor e slot) e na tabela `registration_appeal_review` (fonte primária para telas e exportações).
 
 **CA verificáveis:**
@@ -172,7 +174,7 @@ A correção persiste in-place na `RegistrationEvaluation` original, mantendo se
 | CA-13 | Gestor acompanha status individual de cada designação (designado / rascunho / enviado / reaberto), prazo e data de envio, podendo substituir corretor ou reabrir com novo prazo. |
 
 **Fora de escopo do MVP (fase 2):**
-- Métodos de avaliação além de `EvaluationMethodTechnical`.
+- ~~Métodos de avaliação além de `EvaluationMethodTechnical`~~ *(superado pelo F6/#49 — elegibilidade aberta a todos os métodos; seletor de critérios em técnica/documental, demais liberados integral — ver "Matriz de métodos" acima e em `Entities/RegistrationAppealReview.php::eligibleCorrectors`)*.
 - Criação de novas oportunidades/fases.
 - Reabertura da fase principal ou de seus prazos.
 - Mais de um recurso por inscrição.

--- a/src/modules/OpportunityAppealPhase/Controllers/RegistrationAppealReview.php
+++ b/src/modules/OpportunityAppealPhase/Controllers/RegistrationAppealReview.php
@@ -352,7 +352,9 @@ class RegistrationAppealReview extends EntityController
             }
         }
 
-        if (isset($data['releasedScope'])) {
+        // F6: array_key_exists (não isset) para que releasedScope null LIMPE
+        // a restrição na substituição (todos os critérios liberados).
+        if (array_key_exists('releasedScope', $data)) {
             $review->releasedScope = $this->parseReleasedScope($data['releasedScope']);
             unset($data['releasedScope']);
         }
@@ -465,12 +467,17 @@ class RegistrationAppealReview extends EntityController
 
     /**
      * @param mixed $value array/objeto já decodificado ou string JSON.
+     *
+     * F6 (#49): escopo com lista de critérios explícita e vazia é rejeitado
+     * (null = sem restrição; ao menos um critério quando houver restrição).
      */
     private function parseReleasedScope(mixed $value): ?object
     {
         if ($value === null || $value === '') {
             return null;
         }
+
+        $scope = null;
 
         if (is_string($value)) {
             $decoded = json_decode($value);
@@ -479,10 +486,18 @@ class RegistrationAppealReview extends EntityController
                 $this->errorJson(i::__('releasedScope inválido: esperado objeto JSON.'), 400);
             }
 
-            return $decoded;
+            $scope = $decoded;
+        } else {
+            $scope = (object) (array) $value;
         }
 
-        return (object) (array) $value;
+        $criteria = $scope->criteria ?? $scope->fields ?? null;
+
+        if ($criteria !== null && count((array) $criteria) === 0) {
+            $this->errorJson(i::__('O escopo de critérios não pode ser vazio: selecione ao menos um critério ou envie a designação sem restrição (releasedScope nulo libera todos).'), 400);
+        }
+
+        return $scope;
     }
 
     private function parseDateParam(mixed $value): ?DateTime

--- a/src/modules/OpportunityAppealPhase/Entities/RegistrationAppealReview.php
+++ b/src/modules/OpportunityAppealPhase/Entities/RegistrationAppealReview.php
@@ -230,8 +230,10 @@ class RegistrationAppealReview extends Entity
     /**
      * Retorna os usuários elegíveis para corrigir o slot vinculado a esta designação.
      *
-     * No MVP, a correção é restrita a oportunidades cuja fase principal usa
-     * `EvaluationMethodTechnical`.
+     * Elegibilidade aberta a todos os métodos de avaliação (F6 / #49,
+     * Variante 3 — override registrado na #7 em 2026-09-09): a escolha de
+     * critérios existe para `technical` e `documentary`; nos demais métodos
+     * a correção liberada é integral (releasedScope nulo).
      *
      * @return User[]
      */
@@ -246,7 +248,7 @@ class RegistrationAppealReview extends Entity
         $main_phase = $slot->registration->opportunity;
         $main_emc = $main_phase->evaluationMethodConfiguration;
 
-        if (!$main_emc || $main_emc->type->id !== 'technical') {
+        if (!$main_emc) {
             return [];
         }
 

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/README.md
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/README.md
@@ -107,6 +107,28 @@ atual e duas ações:
 
 Slot com status **enviado** (2) não exibe ações.
 
+## Escopo de critérios (F6 / #49, Variante 3)
+
+Elegibilidade aberta a **todos** os métodos de avaliação (gate técnico
+removido de `eligibleCorrectors()` e do `init.php`). O seletor de escopo
+(`criteriaCatalogs` do config, injetado por `init.php`) existe somente para:
+
+| Método | Seletor | Fonte dos itens |
+|--------|---------|-----------------|
+| Técnica | Sim — seções/critérios do EMC principal | `EvaluationMethodTechnical` (chave do evaluationData = id do critério) |
+| Qualificação documental | Sim — campos e documentos das fases | `EvaluationMethodDocumentary` (chave = `fieldName`/`fileGroupName`) |
+| Demais (simples etc.) | Não — nada renderiza | `releasedScope` nulo ("abre tudo") |
+
+**Semântica persistida em `releasedScope`**: TODOS os critérios marcados →
+`null` (= sem restrição, compatível com `getReleasedCriteriaIds()` do
+`AppealReview\Service`); subconjunto → `{criteria: [...]}`; seleção VAZIA é
+rejeitada — no cliente (salvar bloqueado com aviso) e no backend
+(`parseReleasedScope` → 400 "O escopo de critérios não pode ser vazio…").
+Na substituição (F5) a checklist vem pré-preenchida com o escopo vigente e o
+PATCH envia `releasedScope` junto (`null` LIMPA a restrição — o controller
+usa `array_key_exists`). O painel de acompanhamento exibe "X de Y critérios"
+(restrito) ou "todos liberados" (nulo).
+
 ## Defaults de criação
 
 Por linha marcada cria-se: `status=DESIGNATED`, `correctionType=official`

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/init.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/init.php
@@ -96,6 +96,12 @@ $config = [
     // RegistrationEvaluation não expõe o nome do avaliador (a relação user
     // não expande no @select — volta sempre escalar).
     'evaluators' => new stdClass(),
+
+    // F6 (#49): opportunityId (fase principal) => catálogo de critérios
+    // selecionáveis {method, sections: [{id, name, items: [{id, label, max}]}],
+    // total} — presente somente para technical/documentary com itens. Demais
+    // métodos: null (designação sem seletor; releasedScope nulo = tudo).
+    'criteriaCatalogs' => new stdClass(),
 ];
 
 $requested_entity = $this->controller->requestedEntity ?? null;
@@ -105,10 +111,14 @@ $opportunity = $requested_entity ? $this->getOpportunityFromEntity($requested_en
     F1 (#17) — override 2026-09-08 (épica #7): a coluna "Designar correção"
     pertence à lista de inscritos da FASE DE RECURSO, não à da fase
     principal. Contexto elegível: a oportunidade em contexto É a fase de
-    recurso ativa (STATUS_APPEAL_PHASE), com EMC, cuja fase pai é técnica
-    com EMC, e o usuário tem @control na fase pai (onde @control cascateia
-    para a fase de recurso). Gates espelhados de
-    RegistrationAppealReview::eligibleCorrectors().
+    recurso ativa (STATUS_APPEAL_PHASE), com EMC, cuja fase pai tem EMC, e o
+    usuário tem @control na fase pai (onde @control cascateia para a fase de
+    recurso). Gates espelhados de RegistrationAppealReview::eligibleCorrectors().
+
+    F6 (#49) — override 2026-09-09 (Variante 3): elegibilidade aberta a TODOS
+    os métodos de avaliação (removida a exigência de método técnico); o
+    seletor de escopo de critérios existe apenas para technical e documentary
+    (criteriaCatalogs abaixo); nos demais, a correção é liberada integral.
 */
 if ($opportunity instanceof Opportunity && $opportunity->status === Opportunity::STATUS_APPEAL_PHASE) {
     $appeal_phase = $opportunity;
@@ -117,7 +127,6 @@ if ($opportunity instanceof Opportunity && $opportunity->status === Opportunity:
     $is_eligible_context = $main_phase
         && $appeal_phase->evaluationMethodConfiguration
         && $main_phase->evaluationMethodConfiguration
-        && $main_phase->evaluationMethodConfiguration->type->id === 'technical'
         && $main_phase->canUser('@control');
 
     if ($is_eligible_context) {
@@ -155,6 +164,95 @@ if ($opportunity instanceof Opportunity && $opportunity->status === Opportunity:
         $config['appealPhases']->{$main_phase_id} = $appeal_phase_id;
         $config['committees']->{$main_phase_id} = array_values($committee);
         $config['evaluators']->{$main_phase_id} = $evaluators;
+
+        /*
+            F6 (#49): catálogo de critérios por método da fase principal.
+            - technical: seções/critérios do EMC principal; a chave do
+              evaluationData é o id do critério
+              (technical-evaluation-form/template.php:16-21).
+            - documentary: campos e documentos exigidos das fases da
+              oportunidade; a chave é fieldName/fileGroupName
+              (documentary-evaluation-form/init.php:43-60).
+            - demais métodos: sem catálogo → designação sem seletor
+              (releasedScope nulo = correção integral).
+        */
+        $criteria_catalog = null;
+        $method_id = (string) $main_phase->evaluationMethodConfiguration->type->id;
+
+        if ($method_id === 'technical') {
+            $sections = is_array($main_phase->evaluationMethodConfiguration->sections) ? $main_phase->evaluationMethodConfiguration->sections : [];
+            $criteria = is_array($main_phase->evaluationMethodConfiguration->criteria) ? $main_phase->evaluationMethodConfiguration->criteria : [];
+
+            $catalog_sections = [];
+            $total = 0;
+
+            foreach ($sections as $section) {
+                $section_items = [];
+
+                foreach ($criteria as $criterion) {
+                    if (($criterion->sid ?? null) === ($section->id ?? null)) {
+                        $section_items[] = [
+                            'id' => (string) $criterion->id,
+                            'label' => (string) ($criterion->title ?? $criterion->id),
+                            'max' => $criterion->max ?? null,
+                        ];
+                    }
+                }
+
+                if ($section_items) {
+                    $catalog_sections[] = [
+                        'id' => (string) $section->id,
+                        'name' => (string) ($section->name ?? ''),
+                        'items' => $section_items,
+                    ];
+                    $total += count($section_items);
+                }
+            }
+
+            if ($total > 0) {
+                $criteria_catalog = [
+                    'method' => $method_id,
+                    'sections' => $catalog_sections,
+                    'total' => $total,
+                ];
+            }
+        } elseif ($method_id === 'documentary') {
+            $items = [];
+
+            foreach ($main_phase->allPhases as $phase) {
+                foreach ($phase->registrationFieldConfigurations as $field) {
+                    $items[$field->fieldName] = [
+                        'id' => (string) $field->fieldName,
+                        'label' => (string) ($field->title ?? $field->fieldName),
+                        'max' => null,
+                    ];
+                }
+
+                foreach ($phase->registrationFileConfigurations as $file) {
+                    $items[$file->fileGroupName] = [
+                        'id' => (string) $file->fileGroupName,
+                        'label' => (string) ($file->title ?? $file->fileGroupName),
+                        'max' => null,
+                    ];
+                }
+            }
+
+            if ($items) {
+                $criteria_catalog = [
+                    'method' => $method_id,
+                    'sections' => [
+                        [
+                            'id' => '',
+                            'name' => '',
+                            'items' => array_values($items),
+                        ],
+                    ],
+                    'total' => count($items),
+                ];
+            }
+        }
+
+        $config['criteriaCatalogs']->{$main_phase_id} = $criteria_catalog;
 
         // Tabela da fase de recurso (chaveada pela própria fase de recurso)
         $config['appealContexts']->{$appeal_phase_id} = ['mainPhaseId' => $main_phase_id];

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/script.js
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/script.js
@@ -79,6 +79,24 @@ app.component('opportunity-appeal-correction-assignment', {
                 : null;
         },
 
+        /**
+         * F6 (#49): catálogo de critérios selecionáveis da fase principal
+         * (injetado no init.php; presente só para technical/documentary).
+         */
+        criteriaCatalog() {
+            const catalogs = this.config.criteriaCatalogs || {};
+            return this.opportunityId != null
+                ? catalogs[this.opportunityId] ?? null
+                : null;
+        },
+
+        hasCriteriaSelector() {
+            const catalog = this.criteriaCatalog;
+            return !!catalog
+                && (catalog.total ?? 0) > 0
+                && this.allCriteriaIds().length > 0;
+        },
+
         markedSlots() {
             return this.slots.filter(slot => slot.checked);
         },
@@ -87,13 +105,23 @@ app.component('opportunity-appeal-correction-assignment', {
             return this.markedSlots.some(slot => !this.normalizeId(slot.correctorUserId));
         },
 
+        /**
+         * F6: seleção de escopo vazia (nenhum critério) invalida o salvar
+         * quando o seletor existe para o método da fase principal.
+         */
+        hasInvalidScopeSelection() {
+            return this.hasCriteriaSelector
+                && this.markedSlots.some(slot => this.scopeInvalidFrom(slot.scopeCriteria));
+        },
+
         canSave() {
             return this.endpointAvailable
                 && this.correctionEligible
                 && !this.loading
                 && !this.saving
                 && this.markedSlots.length > 0
-                && !this.hasInvalidSelection;
+                && !this.hasInvalidSelection
+                && !this.hasInvalidScopeSelection;
         },
 
         designatedCount() {
@@ -199,6 +227,9 @@ app.component('opportunity-appeal-correction-assignment', {
                 registration: evaluation.registration,
                 checked: false,
                 correctorUserId: null,
+                // F6: escopo inicia com TODOS os critérios (persiste null)
+                scopeCriteria: this.hasCriteriaSelector ? this.allCriteriaIds() : null,
+                scopeOpen: false,
             }));
 
             this.preSelectCorrectors();
@@ -218,7 +249,7 @@ app.component('opportunity-appeal-correction-assignment', {
 
             const api = new API('registrationappealreview');
             const reviews = await api.fetch('find', {
-                '@select': 'id,originalEvaluation.id,status,correctionType,endsAt,sentTimestamp,correctorUser',
+                '@select': 'id,originalEvaluation.id,status,correctionType,endsAt,sentTimestamp,correctorUser,releasedScope',
                 'registration': `EQ(${this.registrationId})`,
                 '@order': 'id ASC',
             }, { raw: true, rawProcessor: data => data });
@@ -234,6 +265,7 @@ app.component('opportunity-appeal-correction-assignment', {
                 endsAt: review.endsAt,
                 sentTimestamp: review.sentTimestamp,
                 correctorUserId: this.normalizeId(review.correctorUser),
+                releasedScope: this.normalizeScope(review.releasedScope),
             }));
         },
 
@@ -366,6 +398,96 @@ app.component('opportunity-appeal-correction-assignment', {
                 : this.text('committee tag');
         },
 
+        // ============================================================ //
+        // F6 (#49): seletor de escopo de critérios (Variante 3)
+        // Semântica persistida: TODOS marcados → releasedScope null (sem
+        // restrição, compatível com getReleasedCriteriaIds); subconjunto →
+        // {criteria: [...]}; vazio → inválido (cliente bloqueia, backend 400).
+        // ============================================================ //
+
+        allCriteriaIds() {
+            const catalog = this.criteriaCatalog;
+            if (!catalog) {
+                return [];
+            }
+
+            const ids = [];
+            for (const section of catalog.sections || []) {
+                for (const item of section.items || []) {
+                    ids.push(item.id);
+                }
+            }
+
+            return ids;
+        },
+
+        scopePayloadFrom(selected) {
+            if (!this.hasCriteriaSelector) {
+                return null;
+            }
+
+            if (!selected || selected.length >= this.allCriteriaIds().length) {
+                return null;
+            }
+
+            return { criteria: [...selected] };
+        },
+
+        scopeInvalidFrom(selected) {
+            return this.hasCriteriaSelector && (!selected || selected.length === 0);
+        },
+
+        slotScopeCount(slot) {
+            if (!this.hasCriteriaSelector) {
+                return 0;
+            }
+
+            return slot?.scopeCriteria?.length ?? this.criteriaCatalog.total;
+        },
+
+        /**
+         * Escopo vigente da designação para o painel: "todos liberados"
+         * (null) ou "X de Y critérios".
+         */
+        reviewScopeLabel(review) {
+            const ids = this.scopeCriteriaIds(review);
+
+            if (ids == null) {
+                return this.text('all criteria released');
+            }
+
+            const total = this.criteriaCatalog?.total ?? ids.length;
+            return this.text('scope count')
+                .replace('%s', ids.length)
+                .replace('%s', total);
+        },
+
+        scopeCriteriaIds(review) {
+            const scope = this.normalizeScope(review?.releasedScope);
+            if (!scope) {
+                return null;
+            }
+
+            const criteria = scope.criteria ?? scope.fields ?? null;
+            return criteria ? criteria.map(id => String(id)) : null;
+        },
+
+        normalizeScope(value) {
+            if (value == null) {
+                return null;
+            }
+
+            if (typeof value === 'string') {
+                try {
+                    value = JSON.parse(value);
+                } catch (error) {
+                    return null;
+                }
+            }
+
+            return value && typeof value === 'object' ? value : null;
+        },
+
         /**
          * Designação ATIVA (status 0/1/3) com API disponível pode ser
          * gerenciada da tela (substituir/cancelar). ENVIADO (2) não tem ações.
@@ -396,6 +518,10 @@ app.component('opportunity-appeal-correction-assignment', {
             slot.substitutionOpen = true;
             // Default: o corretor atual (PATCH só é enviado se mudar).
             slot.substituteUserId = review.correctorUserId ?? this.slotUserId(slot);
+            // F6: checklist pré-preenchida com o escopo vigente (todos quando
+            // null); trocar para "todos marcados" volta a liberar integral.
+            slot.substituteScopeCriteria = this.scopeCriteriaIds(review) ?? (this.hasCriteriaSelector ? this.allCriteriaIds() : null);
+            slot.substituteScopeOpen = this.hasCriteriaSelector;
         },
 
         cancelSubstitution(slot) {
@@ -404,7 +530,8 @@ app.component('opportunity-appeal-correction-assignment', {
 
         canConfirmSubstitution(slot) {
             return !slot.substituting
-                && this.normalizeId(slot.substituteUserId) != null;
+                && this.normalizeId(slot.substituteUserId) != null
+                && !this.scopeInvalidFrom(slot.substituteScopeCriteria);
         },
 
         /**
@@ -428,6 +555,7 @@ app.component('opportunity-appeal-correction-assignment', {
             try {
                 const response = await api.PATCH(url, {
                     correctorUser: this.normalizeId(slot.substituteUserId),
+                    releasedScope: this.scopePayloadFrom(slot.substituteScopeCriteria),
                 });
 
                 if (!response.ok) {
@@ -625,6 +753,8 @@ app.component('opportunity-appeal-correction-assignment', {
                 correctorUser: this.normalizeId(slot.correctorUserId),
                 status: this.config.statusDesignated ?? 0,
                 correctionType: this.config.correctionTypeDefault || 'official',
+                // F6: null = correção integral (todos ou método sem critérios)
+                releasedScope: this.scopePayloadFrom(slot.scopeCriteria),
             };
         },
 

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/style.css
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/style.css
@@ -214,6 +214,46 @@
     gap: .5rem;
 }
 
+/* F6 (#49): seletor de escopo de critérios */
+.opportunity-appeal-correction-assignment__scope {
+    display: flex;
+    flex-direction: column;
+    gap: .25rem;
+    margin-top: .25rem;
+}
+
+.opportunity-appeal-correction-assignment__scope-list {
+    background-color: var(--mc-gray-100);
+    border: 1px solid var(--mc-gray-300);
+    border-radius: var(--mc-border-radius-xs);
+    display: flex;
+    flex-direction: column;
+    gap: .5rem;
+    margin-top: .25rem;
+    max-height: 16rem;
+    overflow-y: auto;
+    padding: .5rem;
+}
+
+.opportunity-appeal-correction-assignment__scope-section {
+    display: flex;
+    flex-direction: column;
+    gap: .25rem;
+    font-size: .875rem;
+}
+
+.opportunity-appeal-correction-assignment__scope-item {
+    align-items: center;
+    cursor: pointer;
+    display: flex;
+    gap: .5rem;
+    padding-left: .25rem;
+}
+
+.opportunity-appeal-correction-assignment__scope-item input {
+    margin: 0;
+}
+
 /* Mesmo breakpoint do mc-modal/.grid-12 (800px): linhas empilham. */
 @media (max-width: 800px) {
     .opportunity-appeal-correction-assignment__header {

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/template.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/template.php
@@ -120,6 +120,48 @@ $this->import('
                             class="opportunity-appeal-correction-assignment__slot-hint danger__color">
                             <?= i::__('Selecione o corretor para salvar esta designação') ?>
                         </div>
+
+                        <!-- F6 (#49): seletor de escopo (só para métodos com critérios) -->
+                        <div v-if="slot.checked && hasCriteriaSelector" class="opportunity-appeal-correction-assignment__scope">
+                            <button
+                                type="button"
+                                class="button button--sm button--text primary__color"
+                                @click="slot.scopeOpen = !slot.scopeOpen">
+
+                                <mc-icon :name="slot.scopeOpen ? 'arrow-up' : 'arrow-down'"></mc-icon>
+                                {{ text('criteria scope') }} ({{ slotScopeCount(slot) }}/{{ criteriaCatalog.total }})
+                            </button>
+
+                            <div v-if="slot.scopeOpen" class="opportunity-appeal-correction-assignment__scope-list">
+                                <div
+                                    v-for="section in criteriaCatalog.sections"
+                                    :key="section.id || section.name"
+                                    class="opportunity-appeal-correction-assignment__scope-section">
+
+                                    <div v-if="section.name" class="semibold">{{ section.name }}</div>
+
+                                    <label
+                                        v-for="item in section.items"
+                                        :key="item.id"
+                                        class="opportunity-appeal-correction-assignment__scope-item"
+                                        :for="'scope-' + slot.id + '-' + item.id">
+
+                                        <input
+                                            type="checkbox"
+                                            :id="'scope-' + slot.id + '-' + item.id"
+                                            :name="'scope-' + slot.id + '[]'"
+                                            :value="item.id"
+                                            v-model="slot.scopeCriteria">
+
+                                        <span>{{ item.label }}</span>
+                                    </label>
+                                </div>
+
+                                <div v-if="scopeInvalidFrom(slot.scopeCriteria)" class="opportunity-appeal-correction-assignment__slot-hint danger__color">
+                                    {{ text('select at least one criterion') }}
+                                </div>
+                            </div>
+                        </div>
                     </template>
                 </div>
 
@@ -146,6 +188,12 @@ $this->import('
                         <div v-if="reviewSentAt(reviewForSlot(slot))" class="opportunity-appeal-correction-assignment__status-detail">
                             <mc-icon name="send"></mc-icon>
                             <span><?= i::__('Enviada em') ?>: {{ reviewSentAt(reviewForSlot(slot)) }}</span>
+                        </div>
+
+                        <!-- F6: escopo da designação (todos liberados / X de Y) -->
+                        <div class="opportunity-appeal-correction-assignment__status-detail">
+                            <mc-icon name="list"></mc-icon>
+                            <span>{{ reviewScopeLabel(reviewForSlot(slot)) }}</span>
                         </div>
 
                         <!-- F5 (#45): gestão de designação ativa (substituir/cancelar) — únicos controles ativos da linha -->
@@ -197,6 +245,48 @@ $this->import('
 
                             <div v-if="slot.substituteUserId == null" class="opportunity-appeal-correction-assignment__slot-hint danger__color">
                                 <?= i::__('Selecione o novo corretor para confirmar') ?>
+                            </div>
+
+                            <!-- F6: escopo pré-preenchido com o vigente na substituição -->
+                            <div v-if="hasCriteriaSelector" class="opportunity-appeal-correction-assignment__scope">
+                                <button
+                                    type="button"
+                                    class="button button--sm button--text primary__color"
+                                    @click="slot.substituteScopeOpen = !slot.substituteScopeOpen">
+
+                                    <mc-icon :name="slot.substituteScopeOpen ? 'arrow-up' : 'arrow-down'"></mc-icon>
+                                    {{ text('criteria scope') }} ({{ (slot.substituteScopeCriteria || []).length }}/{{ criteriaCatalog.total }})
+                                </button>
+
+                                <div v-if="slot.substituteScopeOpen" class="opportunity-appeal-correction-assignment__scope-list">
+                                    <div
+                                        v-for="section in criteriaCatalog.sections"
+                                        :key="section.id || section.name"
+                                        class="opportunity-appeal-correction-assignment__scope-section">
+
+                                        <div v-if="section.name" class="semibold">{{ section.name }}</div>
+
+                                        <label
+                                            v-for="item in section.items"
+                                            :key="item.id"
+                                            class="opportunity-appeal-correction-assignment__scope-item"
+                                            :for="'substitute-scope-' + slot.id + '-' + item.id">
+
+                                            <input
+                                                type="checkbox"
+                                                :id="'substitute-scope-' + slot.id + '-' + item.id"
+                                                :name="'substitute-scope-' + slot.id + '[]'"
+                                                :value="item.id"
+                                                v-model="slot.substituteScopeCriteria">
+
+                                            <span>{{ item.label }}</span>
+                                        </label>
+                                    </div>
+
+                                    <div v-if="scopeInvalidFrom(slot.substituteScopeCriteria)" class="opportunity-appeal-correction-assignment__slot-hint danger__color">
+                                        {{ text('select at least one criterion') }}
+                                    </div>
+                                </div>
                             </div>
 
                             <div class="opportunity-appeal-correction-assignment__substitution-actions">

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/texts.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/texts.php
@@ -44,6 +44,12 @@ $texts = [
     'replace error' => i::__('Não foi possível substituir o corretor.'),
     'designation canceled' => i::__('Designação cancelada com sucesso.'),
     'cancel designation error' => i::__('Não foi possível cancelar a designação.'),
+
+    // F6 (#49): seletor de escopo de critérios
+    'criteria scope' => i::__('Escopo de critérios'),
+    'all criteria released' => i::__('todos liberados'),
+    'scope count' => i::__('%s de %s critérios'),
+    'select at least one criterion' => i::__('Selecione ao menos um critério'),
     'endpoint unavailable' => i::__('A criação e o acompanhamento de designações estão temporariamente indisponíveis: a API da entidade de designação (RegistrationAppealReview) ainda não está registrada no backend.'),
 ];
 

--- a/tests/src/AppealReleasedScopeTest.php
+++ b/tests/src/AppealReleasedScopeTest.php
@@ -1,0 +1,276 @@
+<?php
+
+namespace Tests;
+
+use DateTime;
+use MapasCulturais\App;
+use MapasCulturais\Entities\EvaluationMethodConfiguration;
+use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\Entities\Registration;
+use MapasCulturais\Entities\RegistrationEvaluation;
+use MapasCulturais\Entities\User;
+use OpportunityAppealPhase\Entities\RegistrationAppealReview;
+use Psr\Http\Message\ServerRequestInterface;
+use Tests\Abstract\TestCase;
+use Tests\Builders\PhasePeriods\ConcurrentEndingAfter;
+use Tests\Builders\PhasePeriods\Open;
+use Tests\Enums\EvaluationMethods;
+use Tests\Traits\OpportunityBuilder;
+use Tests\Traits\RegistrationDirector;
+use Tests\Traits\RequestFactory;
+use Tests\Traits\UserDirector;
+
+/**
+ * F6 (#49): abertura de elegibilidade para todos os métodos + seletor de
+ * escopo de critérios (Variante 3, override registrado na #7 em 2026-09-09).
+ *
+ * Cobertura:
+ * - AC1: método NÃO-técnico (simple) tem designação aceita e
+ *   eligibleCorrectors() devolve dono do slot + Comissão de Recursos;
+ * - AC2: releasedScope com criteria explícito e VAZIO → 400 no POST;
+ * - AC3: POST sem releasedScope persiste null (correção integral) e o PATCH
+ *   com releasedScope null LIMPA restrição existente.
+ */
+class AppealReleasedScopeTest extends TestCase
+{
+    use OpportunityBuilder,
+        RegistrationDirector,
+        UserDirector,
+        RequestFactory;
+
+    private function enableFlag(): void
+    {
+        $_ENV['APPEAL_SCORE_CORRECTION'] = 'true';
+    }
+
+    /**
+     * Cenário análogo ao de AppealAssignmentApiTest, com método parametrizável.
+     *
+     * @return array{admin: User, slotOwner: User, committeeUser: User,
+     *   opportunity: Opportunity, registration: Registration,
+     *   slot: RegistrationEvaluation, appealPhase: Opportunity}
+     */
+    private function createScenario(EvaluationMethods $method = EvaluationMethods::simple): array
+    {
+        $this->enableFlag();
+
+        $admin = $this->userDirector->createUser('admin');
+        $slot_owner = $this->userDirector->createUser();
+        $committee_user = $this->userDirector->createUser();
+
+        $this->login($admin);
+
+        $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase($method)
+                ->fillRequiredProperties()
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->save()
+                ->addValuer('Comissão', 'Avaliador do Slot', $slot_owner->profile)
+                    ->done()
+                ->done()
+            ->save();
+
+        /** @var Opportunity $opportunity */
+        $opportunity = $this->opportunityBuilder->getInstance();
+        $registration = $this->registrationDirector->createSentRegistration($opportunity, data: []);
+
+        $app = App::i();
+        $app->disableAccessControl();
+
+        $slot = new RegistrationEvaluation();
+        $slot->registration = $registration;
+        $slot->user = $slot_owner;
+        $slot->status = RegistrationEvaluation::STATUS_EVALUATED;
+        $slot->save(true);
+
+        $appeal_phase_class = $opportunity->getSpecializedClassName();
+        /** @var Opportunity $appeal_phase */
+        $appeal_phase = new $appeal_phase_class();
+        $appeal_phase->parent = $opportunity;
+        $appeal_phase->status = Opportunity::STATUS_APPEAL_PHASE;
+        $appeal_phase->name = 'Fase de recurso ' . $method->value;
+        $appeal_phase->ownerEntity = $opportunity->ownerEntity;
+        $appeal_phase->owner = $opportunity->owner;
+        $appeal_phase->registrationCategories = $opportunity->registrationCategories;
+        $appeal_phase->registrationRanges = $opportunity->registrationRanges;
+        $appeal_phase->registrationProponentTypes = $opportunity->registrationProponentTypes;
+        $appeal_phase->isDataCollection = true;
+        $appeal_phase->isAppealPhase = true;
+        $appeal_phase->registrationFrom = new DateTime('-1 day');
+        $appeal_phase->registrationTo = new DateTime('+1 day');
+        $appeal_phase->save(true);
+
+        $opportunity->appealPhase = $appeal_phase;
+        $opportunity->save(true);
+
+        $appeal_emc = new EvaluationMethodConfiguration();
+        $appeal_emc->opportunity = $appeal_phase;
+        $appeal_emc->type = 'continuous';
+        $appeal_emc->publishEvaluationDetails = true;
+        $appeal_emc->save(true);
+
+        $appeal_phase->evaluationMethodConfiguration = $appeal_emc;
+        $appeal_phase->save(true);
+
+        $appeal_emc->createAgentRelation($committee_user->profile, 'committee 1', true)->save(true);
+
+        $app->enableAccessControl();
+
+        return [
+            'admin' => $admin,
+            'slotOwner' => $slot_owner,
+            'committeeUser' => $committee_user,
+            'opportunity' => $opportunity,
+            'registration' => $registration,
+            'slot' => $slot,
+            'appealPhase' => $appeal_phase,
+        ];
+    }
+
+    /**
+     * @return array{status: int, json: mixed}
+     */
+    private function dispatch(ServerRequestInterface $request): array
+    {
+        $app = App::i();
+        $app->reset();
+        $app->run($request, false);
+
+        return [
+            'status' => $app->response->getStatusCode(),
+            'json' => json_decode((string) $app->response->getBody(), true),
+        ];
+    }
+
+    /**
+     * @return array{status: int, json: mixed}
+     */
+    private function postAssignment(array $payload): array
+    {
+        return $this->dispatch(
+            $this->requestFactory->POST('registrationappealreview', 'index', [], $payload)
+        );
+    }
+
+    /**
+     * @return array{status: int, json: mixed}
+     */
+    private function patchAssignment(int $id, array $payload): array
+    {
+        return $this->dispatch(
+            $this->requestFactory->PATCH('registrationappealreview', 'single', [$id], $payload)
+        );
+    }
+
+    /**
+     * AC1 (F6): com a fase principal em método SIMPLES (não-técnico), a
+     * designação é aceita — elegibilidade aberta a todos os métodos — e
+     * eligibleCorrectors() devolve dono do slot + Comissão de Recursos.
+     */
+    function testNonTechnicalMethodIsEligibleForDesignation(): void
+    {
+        $scenario = $this->createScenario(EvaluationMethods::simple);
+        $this->login($scenario['admin']);
+
+        // eligibleCorrectors: dono do slot + comissão (sem early-return técnico)
+        $probe = new RegistrationAppealReview();
+        $probe->originalEvaluation = $scenario['slot'];
+        $probe->registration = $scenario['registration'];
+        $probe->appealPhase = $scenario['appealPhase'];
+        $probe->slotOwnerUser = $scenario['slotOwner'];
+        $probe->correctorUser = $scenario['committeeUser'];
+
+        $eligible_ids = array_map(
+            static fn (User $user): int => (int) $user->id,
+            $probe->eligibleCorrectors($scenario['slot'])
+        );
+
+        $this->assertContains($scenario['slotOwner']->id, $eligible_ids, 'Dono do slot deve ser elegível em método não-técnico (F6).');
+        $this->assertContains($scenario['committeeUser']->id, $eligible_ids, 'Comissão de Recursos deve ser elegível em método não-técnico (F6).');
+        $this->assertCount(2, $eligible_ids, 'Elegibilidade em método não-técnico: dono + comissão, sem duplicatas.');
+
+        $response = $this->postAssignment([
+            'originalEvaluation' => $scenario['slot']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ]);
+
+        $this->assertEquals(200, $response['status'], 'Designação em método não-técnico deve ser criada (F6): ' . json_encode($response['json']));
+
+        /** @var RegistrationAppealReview $review */
+        $review = App::i()->repo(RegistrationAppealReview::class)->find($response['json']['id']);
+        $this->assertNull($review->releasedScope, 'Sem seletor (método simples) o escopo persiste null = tudo liberado.');
+    }
+
+    /**
+     * AC2 (F6): releasedScope com criteria vazio é rejeitado com 400 e
+     * mensagem clara — no POST e no PATCH.
+     */
+    function testEmptyCriteriaScopeIsRejected(): void
+    {
+        $scenario = $this->createScenario(EvaluationMethods::technical);
+        $this->login($scenario['admin']);
+
+        $post_response = $this->postAssignment([
+            'originalEvaluation' => $scenario['slot']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+            'releasedScope' => json_encode(['criteria' => []]),
+        ]);
+
+        $this->assertEquals(400, $post_response['status'], 'POST com criteria vazio deve ser rejeitado (F6).');
+        $this->assertTrue($post_response['json']['error'] ?? false);
+        $this->assertStringContainsStringIgnoringCase('escopo', (string) $post_response['json']['data'], 'Mensagem deve explicar a rejeição do escopo vazio.');
+
+        // Cria designação válida para exercitar o PATCH
+        $created = $this->postAssignment([
+            'originalEvaluation' => $scenario['slot']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ]);
+        $this->assertEquals(200, $created['status']);
+
+        $patch_response = $this->patchAssignment((int) $created['json']['id'], [
+            'releasedScope' => json_encode(['criteria' => []]),
+        ]);
+
+        $this->assertEquals(400, $patch_response['status'], 'PATCH com criteria vazio deve ser rejeitado (F6).');
+        $this->assertTrue($patch_response['json']['error'] ?? false);
+    }
+
+    /**
+     * AC3 (F6): POST sem releasedScope persiste null (integral) e o PATCH com
+     * releasedScope null LIMPA a restrição previamente gravada.
+     */
+    function testNullScopeMeansUnrestrictedAndClearsRestrictionOnPatch(): void
+    {
+        $scenario = $this->createScenario(EvaluationMethods::technical);
+        $this->login($scenario['admin']);
+
+        // Restrição parcial
+        $created = $this->postAssignment([
+            'originalEvaluation' => $scenario['slot']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+            'releasedScope' => json_encode(['criteria' => ['c-1', 'c-2']]),
+        ]);
+        $this->assertEquals(200, $created['status']);
+
+        /** @var RegistrationAppealReview $review */
+        $review = App::i()->repo(RegistrationAppealReview::class)->find($created['json']['id']);
+        $this->assertEquals(['criteria' => ['c-1', 'c-2']], (array) $review->releasedScope);
+
+        // "Todos marcados" na substituição → payload null → LIMPA a restrição
+        $patch_response = $this->patchAssignment((int) $created['json']['id'], [
+            'correctorUser' => $scenario['slotOwner']->id,
+            'releasedScope' => null,
+        ]);
+        $this->assertEquals(200, $patch_response['status'], 'PATCH com releasedScope null deve limpar a restrição: ' . json_encode($patch_response['json']));
+
+        $review = App::i()->repo(RegistrationAppealReview::class)->find($created['json']['id']);
+        $this->assertNull($review->releasedScope, 'releasedScope null após PATCH = todos os critérios liberados.');
+        $this->assertEquals($scenario['slotOwner']->id, $review->correctorUser->id);
+    }
+}


### PR DESCRIPTION
Fecha o CA-4 na interface e abre a elegibilidade do fluxo para todos os métodos de avaliação (Variante 3 — override registrado na #7, 2026-09-09, por @israelmelo).

- **Elegibilidade**: gates deixam de exigir método técnico — `RegistrationAppealReview::eligibleCorrectors()` (removido early-return + comentário MVP) e o gate do `init.php` do componente (contexto = fase de recurso ativa com EMC + `@control`); o controller do PR6 herda via `eligibleCorrectors`.
- **Seletor de critérios** (só onde existem): Técnica (seções/critérios do EMC, âncora `EvaluationMethodTechnical/Module.php:155-166`) e Qualificação Documental (campos+anexos, âncora `documentary-evaluation-form/init.php:43-60`), injetadas em `criteriaCatalogs[mainPhaseId]`; nos demais métodos nada renderiza — tudo liberado por definição.
- **Semântica** (documentada no README do componente e no PRD): todos marcados → `releasedScope: null` (sem restrição); subconjunto → `{criteria:[...]}`; seleção vazia → bloqueio no cliente e 400 no backend (`parseReleasedScope`).
- **UI**: checklist expansível na linha de designação e pré-preenchida na substituição do F5; painel exibe "X de Y critérios" ou "todos liberados".
- **PRD vivo** atualizado: matriz de métodos (técnica: seletor · documental: seletor · demais: liberado).

**Verificação:** `php -l` OK; `node --check` OK; novo `AppealReleasedScopeTest` **3 testes / 16 asserções OK** (gates abertos para não-técnico; empty-criteria → 400); sem regressão (suites vizinhas verde; falhas da base provadas pré-existentes via stash).

**Nota para o registro (follow-up mapeado):** o ciclo do CORRETOR continua técnico-only (`Module.php` `canDesignatedCorrectorAccessSlot`, `Service::assertTechnicalSlot`, render técnico do CorrectorEnvironment) — corretor de slot documental/simples ainda não acessa o ambiente nem aplica correção. Designação aberta ≠ correção aberta; follow-up a criar.
