### PR TITLE
F7 — Ciclo do corretor para métodos não-técnicos (documental/simples) (#51)

### DIFF
--- a/src/modules/OpportunityAppealPhase/AppealReview/CorrectorEnvironment.php
+++ b/src/modules/OpportunityAppealPhase/AppealReview/CorrectorEnvironment.php
@@ -39,12 +39,19 @@ class CorrectorEnvironment
             ? $this->filterEvaluationData((array) $review->correctedValue, $scope_ids)
             : null;
 
+        $main_emc = $slot->registration->opportunity->evaluationMethodConfiguration;
+        $method_id = $main_emc ? (string) $main_emc->type->id : '';
+
         $payload = [
             'assignmentId' => (int) $review->id,
             'evaluationId' => (int) $slot->id,
             'registrationId' => (int) $review->registration->id,
             'registrationNumber' => $review->registration->number,
             'opportunityName' => (string) $review->registration->opportunity->name,
+            // F7 (#51): método da fase principal — define como o frontend
+            // renderiza o formulário (critérios técnicos, campos documentais
+            // ou resultado global do simples).
+            'method' => $method_id,
             'criteria' => $this->buildCriteriaMetadata($slot, $scope_ids),
             'targetEvaluatorName' => $this->resolveEvaluatorName($review),
             'deadline' => $review->endsAt ? $review->endsAt->format('c') : null,
@@ -53,6 +60,12 @@ class CorrectorEnvironment
             'originalEvaluation' => (object) $original,
             'draft' => $draft !== null ? (object) $draft : null,
         ];
+
+        if ($method_id === 'documentary') {
+            $payload['fields'] = $this->buildDocumentaryFields($review, $scope_ids);
+        } elseif ($method_id === 'simple') {
+            $payload['statusOptions'] = $this->buildSimpleStatusOptions();
+        }
 
         if ($this->shouldShowAppealOpinion($review)) {
             $payload['committeeOpinion'] = $this->buildCommitteeOpinion($review);
@@ -171,6 +184,63 @@ class CorrectorEnvironment
         }
 
         return $out;
+    }
+
+    /**
+     * F7 (#51): campos exigidos pela qualificação documental (mesma fonte do
+     * formulário documentary-evaluation-form): configurações de campo e de
+     * anexo das fases da oportunidade, chaveadas por fieldName/fileGroupName
+     * — as mesmas chaves do evaluationData e do releasedScope. Filtrado pelo
+     * escopo liberado.
+     *
+     * @param string[]|null $scope_ids null = todos
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildDocumentaryFields(RegistrationAppealReview $review, ?array $scope_ids): array
+    {
+        $main_phase = $review->registration->opportunity;
+
+        $items = [];
+
+        foreach ($main_phase->allPhases as $phase) {
+            foreach ($phase->registrationFieldConfigurations as $field) {
+                $items[$field->getFieldName()] = (string) ($field->title ?? $field->getFieldName());
+            }
+
+            foreach ($phase->registrationFileConfigurations as $file) {
+                $items[$file->fileGroupName] = (string) ($file->title ?? $file->fileGroupName);
+            }
+        }
+
+        $out = [];
+        foreach ($items as $id => $title) {
+            if ($scope_ids !== null && !in_array((string) $id, $scope_ids, true)) {
+                continue;
+            }
+
+            $out[] = [
+                'id' => (string) $id,
+                'title' => $title,
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * F7 (#51): opções de resultado global do método simples — mesmas
+     * values/labels do formulário simple-evaluation-form.
+     *
+     * @return array<int, array<string, string>>
+     */
+    private function buildSimpleStatusOptions(): array
+    {
+        return [
+            ['value' => '2', 'label' => i::__('Inválida')],
+            ['value' => '3', 'label' => i::__('Não selecionada')],
+            ['value' => '8', 'label' => i::__('Suplente')],
+            ['value' => '10', 'label' => i::__('Selecionada')],
+        ];
     }
 
     /**

--- a/src/modules/OpportunityAppealPhase/AppealReview/Service.php
+++ b/src/modules/OpportunityAppealPhase/AppealReview/Service.php
@@ -47,7 +47,7 @@ class Service
         }
 
         $this->assertWithinWindow($review);
-        $this->assertTechnicalSlot($slot);
+        $this->assertEvaluationMethodResolvable($slot);
 
         if ($corrected_data !== null) {
             $review->correctedValue = (object) (array) $corrected_data;
@@ -208,6 +208,11 @@ class Service
         $revision->save(true);
     }
 
+    /**
+     * Resultado recalculado pelo método do slot (setEvaluationData delega ao
+     * EvaluationMethod::getEvaluationResult): technical = pontuação ponderada;
+     * simple = código do status global; documentary = 1/-1 (válida/inválida).
+     */
     private function computeScore(RegistrationEvaluation $slot, array $evaluation_data): ?float
     {
         $tmp = new RegistrationEvaluation();
@@ -244,10 +249,19 @@ class Service
         }
     }
 
-    private function assertTechnicalSlot(RegistrationEvaluation $slot): void
+    /**
+     * F7 (#51): a correção vale para TODOS os métodos de avaliação (antes
+     * restrita ao técnico). O que a aplicação exige do slot é apenas ter um
+     * método resolvível (EMC presente) — é o método que define o formato do
+     * evaluationData e o cálculo do resultado:
+     * - technical: critérios (ids) → pontuação ponderada;
+     * - documentary: fieldName/fileGroupName → {evaluation, obs} por campo;
+     * - simple: resultado global (status) + obs.
+     */
+    private function assertEvaluationMethodResolvable(RegistrationEvaluation $slot): void
     {
         $emc = $slot->registration->opportunity->evaluationMethodConfiguration;
-        if (!$emc || $emc->type->id !== 'technical') {
+        if (!$emc) {
             throw new PermissionDenied(App::i()->user, $slot, 'applyCorrection');
         }
     }
@@ -256,6 +270,10 @@ class Service
      * Mescla apenas chaves liberadas em released_scope.criteria (ou .fields).
      * Chaves fora do escopo com valor diferente do atual são rejeitadas;
      * chaves fora do escopo iguais ao atual (ex.: rascunho com snapshot completo) são ignoradas.
+     *
+     * Genérico por método (F7): as chaves são as do evaluationData — critérios
+     * (technical), fieldName/fileGroupName (documentary; o obs por campo viaja
+     * DENTRO do objeto do campo) ou status/obs (simple).
      */
     private function mergeWithinReleasedScope(RegistrationEvaluation $slot, RegistrationAppealReview $review, array $incoming): array
     {

--- a/src/modules/OpportunityAppealPhase/Module.php
+++ b/src/modules/OpportunityAppealPhase/Module.php
@@ -413,9 +413,16 @@ class Module extends \MapasCulturais\Module {
         return (bool) env('APPEAL_TWO_STAGE_PUBLISH', $this->config['featureFlag.appealTwoStagePublish']);
     }
 
+    /**
+     * F7 (#51): o acesso do corretor designado ao slot vale para TODOS os
+     * métodos de avaliação (antes restrito ao técnico). Guardas mantidos:
+     * feature flag, designação ativa do corretor para o slot (com inscrição,
+     * fase de recurso e dono conferidos por findActiveForEvaluationAndUser),
+     * janela de prazo e elegibilidade (eligibleCorrectors).
+     */
     public function canDesignatedCorrectorAccessSlot(RegistrationEvaluation $slot, $user): bool
     {
-        if (!$this->isAppealScoreCorrectionEnabled() || !$this->isTechnicalEvaluationSlot($slot)) {
+        if (!$this->isAppealScoreCorrectionEnabled()) {
             return false;
         }
 
@@ -432,14 +439,6 @@ class Module extends \MapasCulturais\Module {
         }
 
         return false;
-    }
-
-    private function isTechnicalEvaluationSlot(RegistrationEvaluation $slot): bool
-    {
-        $opportunity = $slot->registration->opportunity;
-        $emc = $opportunity->evaluationMethodConfiguration;
-
-        return (bool) $emc && $emc->type->id === 'technical';
     }
 
     private function isAppealScoreCorrectionEnabled(): bool

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/script.js
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/script.js
@@ -60,6 +60,31 @@ app.component('opportunity-appeal-correction-evaluation', {
             return this.environment?.criteria || [];
         },
 
+        // F7 (#51): método da fase principal define o formulário renderizado
+        method() {
+            return this.environment?.method || 'technical';
+        },
+
+        isTechnical() {
+            return this.method === 'technical';
+        },
+
+        isDocumentary() {
+            return this.method === 'documentary';
+        },
+
+        isSimple() {
+            return this.method === 'simple';
+        },
+
+        fieldsList() {
+            return this.environment?.fields || [];
+        },
+
+        statusOptions() {
+            return this.environment?.statusOptions || [];
+        },
+
         totalScore() {
             let result = 0;
 
@@ -108,10 +133,56 @@ app.component('opportunity-appeal-correction-evaluation', {
             return Number.isFinite(number) ? number : 0;
         },
 
+        /**
+         * F7: garante a forma do formData por método — documental precisa de
+         * {evaluation, obs} por campo liberado; simples precisa de status/obs.
+         */
+        initFormDataByMethod() {
+            if (this.isDocumentary) {
+                for (const field of this.fieldsList) {
+                    const current = this.formData.data[field.id];
+
+                    this.formData.data[field.id] = {
+                        evaluation: '',
+                        obs: '',
+                        ...(current && typeof current === 'object' ? current : {}),
+                    };
+                }
+            } else if (this.isSimple) {
+                this.formData.data.status = this.formData.data.status ?? '';
+                this.formData.data.obs = this.formData.data.obs ?? '';
+            }
+        },
+
         originalNote(criterion) {
             const value = this.environment?.originalEvaluation?.[criterion.id];
 
             return (value === null || value === undefined || value === '') ? '-' : value;
+        },
+
+        originalFieldEvaluation(field) {
+            const value = this.environment?.originalEvaluation?.[field.id]?.evaluation;
+
+            return this.fieldEvaluationLabel(value);
+        },
+
+        fieldEvaluationLabel(value) {
+            if (value === 'valid') {
+                return this.text('field-valid');
+            }
+
+            if (value === 'invalid') {
+                return this.text('field-invalid');
+            }
+
+            return this.text('field-not-evaluated');
+        },
+
+        originalStatus() {
+            const value = this.environment?.originalEvaluation?.status;
+            const option = this.statusOptions.find(option => option.value === String(value ?? ''));
+
+            return option ? option.label : (value ?? '—');
         },
 
         async fetchEnvironment() {
@@ -129,6 +200,7 @@ app.component('opportunity-appeal-correction-evaluation', {
                         ...this.environment.originalEvaluation,
                         ...(this.environment.draft || {}),
                     };
+                    this.initFormDataByMethod();
                 } else {
                     this.error = {
                         status: res.status,

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/style.css
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/style.css
@@ -1,0 +1,28 @@
+/*
+ * opportunity-appeal-correction-evaluation (F3 #19 + F7 #51)
+ *
+ * Estilo local no padrão do módulo (auto-enfileirado, sem build — mesmo
+ * precedente do mc-modal): apenas o layout das opções por campo do método
+ * documental; o restante usa as classes do tema (grid-12, card, button).
+ */
+
+.opportunity-appeal-correction-evaluation__field-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .75rem;
+}
+
+.opportunity-appeal-correction-evaluation__field-option {
+    align-items: center;
+    cursor: pointer;
+    display: inline-flex;
+    gap: .25rem;
+}
+
+.opportunity-appeal-correction-evaluation__field-option input {
+    margin: 0;
+}
+
+.opportunity-appeal-correction-evaluation__criterion textarea {
+    width: 100%;
+}

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/template.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/template.php
@@ -67,7 +67,8 @@ $this->import('
             </div>
         </section>
 
-        <section class="grid-12 section">
+        <!-- F7 (#51): formulário conforme o método do slot -->
+        <section v-if="isTechnical" class="grid-12 section">
             <h3 class="col-12"><?= i::__('Critérios liberados para correção') ?></h3>
             <div class="section__content col-12">
                 <div class="card">
@@ -91,6 +92,81 @@ $this->import('
                     <div class="opportunity-appeal-correction-evaluation__results">
                         <h4><?= i::__('Pontuação total') ?>: <strong>{{ totalScore }}</strong></h4>
                     </div>
+                </div>
+            </div>
+        </section>
+
+        <section v-else-if="isDocumentary" class="grid-12 section">
+            <h3 class="col-12"><?= i::__('Campos liberados para correção') ?></h3>
+            <div class="section__content col-12">
+                <div class="card">
+                    <div class="opportunity-appeal-correction-evaluation__criterion" v-for="field in fieldsList" :key="field.id">
+                        <label><strong>{{ field.title }}</strong></label>
+                        <div class="grid-12">
+                            <div class="col-6">
+                                <label><?= i::__('Avaliação original') ?></label>
+                                <p class="semibold">{{ originalFieldEvaluation(field) }}</p>
+                            </div>
+                            <div class="col-6">
+                                <label :for="'corrected-field-' + field.id"><?= i::__('Avaliação corrigida') ?></label>
+                                <div class="opportunity-appeal-correction-evaluation__field-options">
+                                    <label class="opportunity-appeal-correction-evaluation__field-option">
+                                        <input type="radio" value="" v-model="formData.data[field.id].evaluation" :disabled="isLocked" :name="'corrected-field-' + field.id">
+                                        <?= i::__('Não avaliada') ?>
+                                    </label>
+                                    <label class="opportunity-appeal-correction-evaluation__field-option">
+                                        <input type="radio" value="valid" v-model="formData.data[field.id].evaluation" :disabled="isLocked" :name="'corrected-field-' + field.id">
+                                        <?= i::__('Válida') ?>
+                                    </label>
+                                    <label class="opportunity-appeal-correction-evaluation__field-option">
+                                        <input type="radio" value="invalid" v-model="formData.data[field.id].evaluation" :disabled="isLocked" :name="'corrected-field-' + field.id">
+                                        <?= i::__('Inválida') ?>
+                                    </label>
+                                </div>
+                            </div>
+                        </div>
+                        <label :for="'corrected-field-obs-' + field.id"><?= i::__('Observações do campo') ?></label>
+                        <textarea
+                            :id="'corrected-field-obs-' + field.id"
+                            :name="'corrected-field-obs-' + field.id"
+                            :disabled="isLocked"
+                            v-model="formData.data[field.id].obs"></textarea>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section v-else-if="isSimple" class="grid-12 section">
+            <h3 class="col-12"><?= i::__('Correção do resultado') ?></h3>
+            <div class="section__content col-12">
+                <div class="card">
+                    <div class="grid-12">
+                        <div class="col-6">
+                            <label><?= i::__('Status original') ?></label>
+                            <p class="semibold">{{ originalStatus() }}</p>
+                        </div>
+                        <div class="col-6">
+                            <label for="corrected-global-status"><?= i::__('Status corrigido') ?></label>
+                            <select
+                                id="corrected-global-status"
+                                name="corrected-global-status"
+                                v-model="formData.data.status"
+                                :disabled="isLocked">
+
+                                <option value="" disabled><?= i::__('Selecione o status') ?></option>
+                                <option v-for="option in statusOptions" :key="option.value" :value="option.value">{{ option.label }}</option>
+                            </select>
+                        </div>
+                        <div class="col-12">
+                            <label for="corrected-global-obs"><?= i::__('Observações') ?></label>
+                            <textarea
+                                id="corrected-global-obs"
+                                name="corrected-global-obs"
+                                :disabled="isLocked"
+                                v-model="formData.data.obs"></textarea>
+                        </div>
+                    </div>
+                    <mc-alert type="helper"><?= i::__('Método de avaliação sem critérios: a correção libera o resultado integral da avaliação.') ?></mc-alert>
                 </div>
             </div>
         </section>

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/texts.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/texts.php
@@ -14,4 +14,9 @@ return [
     'note-higher-configured' => i::__('Nota maior que a configurada para avaliação'),
     'draft-saved' => i::__('Rascunho salvo com sucesso'),
     'correction-sent' => i::__('Correção enviada com sucesso'),
+
+    // F7 (#51): qualificação documental
+    'field-valid' => i::__('Válida'),
+    'field-invalid' => i::__('Inválida'),
+    'field-not-evaluated' => i::__('Não avaliada'),
 ];

--- a/tests/src/AppealCorrectorCycleTest.php
+++ b/tests/src/AppealCorrectorCycleTest.php
@@ -1,0 +1,377 @@
+<?php
+
+namespace Tests;
+
+use DateTime;
+use MapasCulturais\App;
+use MapasCulturais\Entities\EvaluationMethodConfiguration;
+use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\Entities\Registration;
+use MapasCulturais\Entities\RegistrationEvaluation;
+use MapasCulturais\Entities\RegistrationFieldConfiguration;
+use MapasCulturais\Entities\RegistrationStep;
+use MapasCulturais\Entities\User;
+use OpportunityAppealPhase\Entities\RegistrationAppealReview;
+use Psr\Http\Message\ServerRequestInterface;
+use Tests\Abstract\TestCase;
+use Tests\Builders\PhasePeriods\ConcurrentEndingAfter;
+use Tests\Builders\PhasePeriods\Open;
+use Tests\Enums\EvaluationMethods;
+use Tests\Traits\OpportunityBuilder;
+use Tests\Traits\RegistrationDirector;
+use Tests\Traits\RegistrationFieldBuilder;
+use Tests\Traits\RequestFactory;
+use Tests\Traits\UserDirector;
+
+/**
+ * F7 (#51): ciclo do corretor para métodos não-técnicos (documental/simples).
+ *
+ * Cobertura (por método):
+ * - designação (F6 aberta) → corretor designado ACESSA o slot (canUser via
+ *   hook do módulo + ambiente GET 200, antes PermissionDenied) → rascunho →
+ *   envio → RegistrationEvaluation atualizada in-place + snapshot
+ *   originalValue + designação SENT;
+ * - escopo restrito documental: campo fora do escopo com valor divergente é
+ *   rejeitado (400); campo dentro do escopo é aceito.
+ */
+class AppealCorrectorCycleTest extends TestCase
+{
+    use OpportunityBuilder,
+        RegistrationDirector,
+        RegistrationFieldBuilder,
+        UserDirector,
+        RequestFactory;
+
+    private function enableFlag(): void
+    {
+        $_ENV['APPEAL_SCORE_CORRECTION'] = 'true';
+    }
+
+    /**
+     * @return array{admin: User, slotOwner: User, committeeUser: User,
+     *   opportunity: Opportunity, registration: Registration,
+     *   slot: RegistrationEvaluation, appealPhase: Opportunity,
+     *   fields: array<string, RegistrationFieldConfiguration>}
+     */
+    private function createScenario(EvaluationMethods $method): array
+    {
+        $this->enableFlag();
+
+        $admin = $this->userDirector->createUser('admin');
+        $slot_owner = $this->userDirector->createUser();
+        $committee_user = $this->userDirector->createUser();
+
+        $this->login($admin);
+
+        $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase($method)
+                ->fillRequiredProperties()
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->save()
+                ->addValuer('Comissão', 'Avaliador do Slot', $slot_owner->profile)
+                    ->done()
+                ->done()
+            ->save();
+
+        /** @var Opportunity $opportunity */
+        $opportunity = $this->opportunityBuilder->getInstance();
+
+        $fields = [];
+        if ($method === EvaluationMethods::documentary) {
+            // Campos exigem uma etapa (isFieldVisisble → isStepVisible), no
+            // mesmo padrão da criação de fase de recurso do módulo.
+            $app = App::i();
+            $app->disableAccessControl();
+
+            $step = new RegistrationStep();
+            $step->opportunity = $opportunity;
+            $step->name = '';
+            $step->save(true);
+
+            $app->enableAccessControl();
+
+            foreach (['A' => 'Documento A', 'B' => 'Documento B'] as $key => $title) {
+                $field = $this->registrationFieldBuilder
+                    ->reset($opportunity, 'text', 'doc-field-' . strtolower($key))
+                    ->fillRequiredProperties()
+                    ->setTitle($title)
+                    ->setStep($step)
+                    ->save()
+                    ->getInstance();
+
+                $fields[$title] = $field;
+            }
+
+            $opportunity->registerRegistrationMetadata();
+        }
+
+        $registration = $this->registrationDirector->createSentRegistration($opportunity, data: []);
+
+        $app = App::i();
+        $app->disableAccessControl();
+
+        $slot = new RegistrationEvaluation();
+        $slot->registration = $registration;
+        $slot->user = $slot_owner;
+        $slot->status = RegistrationEvaluation::STATUS_EVALUATED;
+
+        if ($method === EvaluationMethods::documentary) {
+            $data = [];
+            foreach ($fields as $field) {
+                $data[$field->getFieldName()] = ['evaluation' => 'valid', 'obs' => ''];
+            }
+            $slot->setEvaluationData((object) $data);
+        } else {
+            $slot->setEvaluationData((object) ['status' => '3', 'obs' => 'original']);
+        }
+
+        $slot->save(true);
+
+        $appeal_phase_class = $opportunity->getSpecializedClassName();
+        /** @var Opportunity $appeal_phase */
+        $appeal_phase = new $appeal_phase_class();
+        $appeal_phase->parent = $opportunity;
+        $appeal_phase->status = Opportunity::STATUS_APPEAL_PHASE;
+        $appeal_phase->name = 'Fase de recurso ' . $method->name;
+        $appeal_phase->ownerEntity = $opportunity->ownerEntity;
+        $appeal_phase->owner = $opportunity->owner;
+        $appeal_phase->registrationCategories = $opportunity->registrationCategories;
+        $appeal_phase->registrationRanges = $opportunity->registrationRanges;
+        $appeal_phase->registrationProponentTypes = $opportunity->registrationProponentTypes;
+        $appeal_phase->isDataCollection = true;
+        $appeal_phase->isAppealPhase = true;
+        $appeal_phase->registrationFrom = new DateTime('-1 day');
+        $appeal_phase->registrationTo = new DateTime('+1 day');
+        $appeal_phase->save(true);
+
+        $opportunity->appealPhase = $appeal_phase;
+        $opportunity->save(true);
+
+        $appeal_emc = new EvaluationMethodConfiguration();
+        $appeal_emc->opportunity = $appeal_phase;
+        $appeal_emc->type = 'continuous';
+        $appeal_emc->publishEvaluationDetails = true;
+        $appeal_emc->save(true);
+
+        $appeal_phase->evaluationMethodConfiguration = $appeal_emc;
+        $appeal_phase->save(true);
+
+        $appeal_emc->createAgentRelation($committee_user->profile, 'committee 1', true)->save(true);
+
+        $app->enableAccessControl();
+
+        return [
+            'admin' => $admin,
+            'slotOwner' => $slot_owner,
+            'committeeUser' => $committee_user,
+            'opportunity' => $opportunity,
+            'registration' => $registration,
+            'slot' => $slot,
+            'appealPhase' => $appeal_phase,
+            'fields' => $fields,
+        ];
+    }
+
+    /**
+     * @return array{status: int, json: mixed}
+     */
+    private function dispatch(ServerRequestInterface $request): array
+    {
+        $app = App::i();
+        $app->reset();
+        $app->run($request, false);
+
+        return [
+            'status' => $app->response->getStatusCode(),
+            'json' => json_decode((string) $app->response->getBody(), true),
+        ];
+    }
+
+    /**
+     * @return array{status: int, json: mixed}
+     */
+    private function designate(array $scenario, ?array $released_scope = null): array
+    {
+        $this->login($scenario['admin']);
+
+        $payload = [
+            'originalEvaluation' => $scenario['slot']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ];
+
+        if ($released_scope !== null) {
+            $payload['releasedScope'] = json_encode($released_scope);
+        }
+
+        return $this->dispatch(
+            $this->requestFactory->POST('registrationappealreview', 'index', [], $payload)
+        );
+    }
+
+    /**
+     * @return array{status: int, json: mixed}
+     */
+    private function environment(int $assignment_id, User $corrector): array
+    {
+        $this->login($corrector);
+
+        return $this->dispatch(
+            $this->requestFactory->GET('appealCorrector', 'environment', [$assignment_id], ajax: true)
+        );
+    }
+
+    /**
+     * @return array{status: int, json: mixed}
+     */
+    private function applyCorrection(RegistrationEvaluation $slot, array $evaluation_data, bool $draft): array
+    {
+        return $this->dispatch(
+            $this->requestFactory->POST('registrationevaluation', 'applyAppealCorrection', [$slot->id], [
+                'evaluationData' => $evaluation_data,
+                'draft' => $draft,
+            ])
+        );
+    }
+
+    /**
+     * Documental: designar → corretor acessa (hook + ambiente por método) →
+     * rascunho → envio → slot atualizado in-place + snapshot + SENT.
+     */
+    function testDocumentaryCorrectorFullCycle(): void
+    {
+        $scenario = $this->createScenario(EvaluationMethods::documentary);
+        [$field_a, $field_b] = array_values($scenario['fields']);
+        $field_a_name = $field_a->getFieldName();
+        $field_b_name = $field_b->getFieldName();
+
+        $created = $this->designate($scenario);
+        $this->assertEquals(200, $created['status'], 'Designação em documental (F6): ' . json_encode($created['json']));
+        $review_id = (int) $created['json']['id'];
+
+        // Antes do F7: PermissionDenied. Agora: hook concede view/modify ao corretor.
+        $corrector = $scenario['committeeUser'];
+        $this->login($corrector);
+        $this->assertTrue($scenario['slot']->canUser('view', $corrector), 'Corretor designado deve ver o slot documental (hook do módulo, F7).');
+        $this->assertTrue($scenario['slot']->canUser('modify', $corrector), 'Corretor designado deve modificar o slot documental (hook do módulo, F7).');
+
+        // Ambiente por método: method=documentary + campos liberados (sem restrição)
+        $environment = $this->environment($review_id, $corrector);
+        $this->assertEquals(200, $environment['status'], 'Ambiente do corretor em documental: ' . json_encode($environment['json']));
+        $this->assertSame('documentary', $environment['json']['method']);
+        $field_ids = array_map(static fn (array $f): string => $f['id'], $environment['json']['fields'] ?? []);
+        $this->assertContains($field_a_name, $field_ids, 'Ambiente deve expor os campos documentais (fieldName).');
+        $this->assertContains($field_b_name, $field_ids);
+
+        // Rascunho: campo A corrigido para inválido
+        $data = (array) $scenario['slot']->getEvaluationData();
+        $data[$field_a_name] = ['evaluation' => 'invalid', 'obs' => 'ilegível'];
+
+        $draft = $this->applyCorrection($scenario['slot'], $data, draft: true);
+        $this->assertEquals(200, $draft['status'], 'Rascunho em documental: ' . json_encode($draft['json']));
+
+        /** @var RegistrationAppealReview $review */
+        $review = App::i()->repo(RegistrationAppealReview::class)->find($review_id);
+        $this->assertSame(RegistrationAppealReview::STATUS_DRAFT, (int) $review->status);
+        $this->assertEquals('invalid', ((array) $review->correctedValue)[$field_a_name]['evaluation'], 'Rascunho persiste correctedValue por campo.');
+
+        // Envio definitivo: slot atualizado in-place, snapshot original, SENT
+        $sent = $this->applyCorrection($scenario['slot'], $data, draft: false);
+        $this->assertEquals(200, $sent['status'], 'Envio em documental: ' . json_encode($sent['json']));
+
+        $slot = App::i()->repo('RegistrationEvaluation')->find($scenario['slot']->id);
+        $this->assertSame('invalid', ((array) $slot->getEvaluationData())[$field_a_name]['evaluation'], 'Slot documental atualizado in-place.');
+        $this->assertSame('valid', ((array) $slot->getEvaluationData())[$field_b_name]['evaluation'], 'Campo fora da correção permanece.');
+        $this->assertSame((string) RegistrationEvaluation::STATUS_SENT, (string) $slot->status);
+
+        $review = App::i()->repo(RegistrationAppealReview::class)->find($review_id);
+        $this->assertSame(RegistrationAppealReview::STATUS_SENT, (int) $review->status);
+        $this->assertNotNull($review->sentTimestamp);
+        $this->assertEquals('valid', ((array) $review->originalValue)[$field_a_name]['evaluation'], 'Snapshot do valor original preservado.');
+    }
+
+    /**
+     * Simples: mesmo ciclo com resultado global (status + obs), sem seletor.
+     */
+    function testSimpleCorrectorFullCycle(): void
+    {
+        $scenario = $this->createScenario(EvaluationMethods::simple);
+
+        $created = $this->designate($scenario);
+        $this->assertEquals(200, $created['status'], 'Designação em simples (F6): ' . json_encode($created['json']));
+        $review_id = (int) $created['json']['id'];
+
+        $corrector = $scenario['committeeUser'];
+        $this->login($corrector);
+        $this->assertTrue($scenario['slot']->canUser('modify', $corrector), 'Corretor designado deve modificar o slot simples (hook do módulo, F7).');
+
+        $environment = $this->environment($review_id, $corrector);
+        $this->assertEquals(200, $environment['status'], 'Ambiente do corretor em simples: ' . json_encode($environment['json']));
+        $this->assertSame('simple', $environment['json']['method']);
+        $this->assertNotEmpty($environment['json']['statusOptions'], 'Ambiente simples expõe as opções de status global.');
+        $this->assertSame('3', (string) $environment['json']['originalEvaluation']['status']);
+
+        $data = ['status' => '10', 'obs' => 'recurso deferido: selecionada'];
+
+        $draft = $this->applyCorrection($scenario['slot'], $data, draft: true);
+        $this->assertEquals(200, $draft['status'], 'Rascunho em simples: ' . json_encode($draft['json']));
+
+        $sent = $this->applyCorrection($scenario['slot'], $data, draft: false);
+        $this->assertEquals(200, $sent['status'], 'Envio em simples: ' . json_encode($sent['json']));
+
+        $slot = App::i()->repo('RegistrationEvaluation')->find($scenario['slot']->id);
+        $this->assertSame('10', (string) ((array) $slot->getEvaluationData())['status'], 'Slot simples atualizado in-place (status global).');
+        $this->assertSame('recurso deferido: selecionada', ((array) $slot->getEvaluationData())['obs']);
+        $this->assertSame((string) RegistrationEvaluation::STATUS_SENT, (string) $slot->status);
+
+        $review = App::i()->repo(RegistrationAppealReview::class)->find($review_id);
+        $this->assertSame(RegistrationAppealReview::STATUS_SENT, (int) $review->status);
+        $this->assertEquals('3', (string) ((array) $review->originalValue)['status'], 'Snapshot do status original preservado.');
+        $this->assertNotNull(App::i()->repo('Registration')->find($scenario['registration']->id)->refreshed()->consolidatedResult, 'Reconsolidação unitária executada.');
+    }
+
+    /**
+     * Escopo restrito documental: campo fora do escopo com valor divergente é
+     * rejeitado (400); envio somente com o campo liberado é aceito.
+     */
+    function testDocumentaryRestrictedScopeRejectsOutOfScopeField(): void
+    {
+        $scenario = $this->createScenario(EvaluationMethods::documentary);
+        [$field_a, $field_b] = array_values($scenario['fields']);
+        $field_a_name = $field_a->getFieldName();
+        $field_b_name = $field_b->getFieldName();
+
+        $created = $this->designate($scenario, ['criteria' => [$field_a_name]]);
+        $this->assertEquals(200, $created['status']);
+        $review_id = (int) $created['json']['id'];
+
+        $this->login($scenario['committeeUser']);
+
+        // Ambiente: somente o campo liberado é exposto
+        $environment = $this->environment($review_id, $scenario['committeeUser']);
+        $field_ids = array_map(static fn (array $f): string => $f['id'], $environment['json']['fields'] ?? []);
+        $this->assertEquals([$field_a_name], $field_ids, 'Escopo documental filtra os campos do ambiente.');
+
+        // Campo B fora do escopo com valor DIVERGENTE → rejeitado
+        $data = (array) $scenario['slot']->getEvaluationData();
+        $data[$field_a_name] = ['evaluation' => 'invalid', 'obs' => ''];
+        $data[$field_b_name] = ['evaluation' => 'invalid', 'obs' => ''];
+
+        $rejected = $this->applyCorrection($scenario['slot'], $data, draft: false);
+        $this->assertEquals(400, $rejected['status'], 'Campo fora do escopo com valor divergente deve ser rejeitado.');
+        $this->assertTrue($rejected['json']['error'] ?? false);
+
+        // Somente o campo liberado → aceito
+        $data[$field_b_name] = ['evaluation' => 'valid', 'obs' => ''];
+        $accepted = $this->applyCorrection($scenario['slot'], $data, draft: false);
+        $this->assertEquals(200, $accepted['status'], 'Correção dentro do escopo deve ser aplicada: ' . json_encode($accepted['json']));
+
+        $slot = App::i()->repo('RegistrationEvaluation')->find($scenario['slot']->id);
+        $this->assertSame('invalid', ((array) $slot->getEvaluationData())[$field_a_name]['evaluation'], 'Campo liberado corrigido in-place.');
+    }
+}


### PR DESCRIPTION
Fecha o ciclo da Variante 3 (override na #7): corretor designado para slot **não-técnico** passa a acessar o ambiente e aplicar a correção.

- **Gates abertos** (guardas mantidos: flag, designação ativa, janela, `eligibleCorrectors`): `Module::canDesignatedCorrectorAccessSlot` sem exigência de método técnico; `Service::assertTechnicalSlot` → `assertEvaluationMethodResolvable` (exige EMC resolvível).
- **Ambiente por método** (`CorrectorEnvironment` + componente do F3): técnico inalterado; **documental** radios Válida/Inválida + obs por campo liberado (fonte: configurações de campo/anexo das fases, mesmo padrão do `documentary-evaluation-form`, filtrado pelo escopo da F6); **simples** status global + obs ("abre tudo", sem seletor — coerente com a F6).
- **`applyCorrection` por método** (in-place + revisão + reconsolidação unitária + `releasedScope` preservados): documental `{fieldName|fileGroupName: {evaluation, obs}}`; simples `{status, obs}`; técnico critérios id→pontuação.
- **Testes**: novo `AppealCorrectorCycleTest` **3 testes / 37 asserções OK** — ciclo completo documental; simples (3→10 + obs); escopo restrito documental (fora do escopo → 400, dentro → 200 in-place). Sem regressão (ApplyCorrection 10/35, AssignmentApi 12/51, ReleasedScope 3/16 verdes; falhas restantes provadas pré-existentes via stash).
