### PR TITLE
F4 — Colunas nota original/corrigida/diferença (#20)

### DIFF
--- a/docs/rounds/R01-2026-08-correcao-notas-recurso/deviations.md
+++ b/docs/rounds/R01-2026-08-correcao-notas-recurso/deviations.md
@@ -13,3 +13,10 @@
 - **Razão:** "A coluna deve estar na lista de inscrição da fase de recurso" — decisão do revisor; CA-1/issue #17 eram ambíguos sobre qual lista.
 - **Decisão registrada em:** override na épica #7 (2026-09-08, por @israelmelo).
 - **Documento de referência atualizado:** docs/reference/prd.md (CA-1 esclarecido).
+
+### 2026-09-10 — F4 (#20): filtragem pelas colunas de nota
+- **Planejado:** "Tornar filtrável nas tabelas" (item 4 do "o que fazer" da #20).
+- **Implementado:** colunas selecionáveis via `@select` (propriedades virtuais nos hooks `ApiQuery(…).findResult`), mas **filtro** lança `PropertyDoesNotExists` na ApiQuery e `@order` pelas virtuais é ignorado — filtragem não exposta na UI; limitação documentada nos commits.
+- **Razão:** a ApiQuery não suporta filtrar/ordenar por propriedades virtuais computadas em hook; suportar exigiria estender o core da ApiQuery — fora do escopo da tarefa.
+- **Decisão registrada em:** relato do especialista ao facilitador na execução do F4 (2026-09-10).
+- **Documento de referência atualizado:** n/a — comportamento novo, sem contradição com PRD (CA-11 exige exibição, não filtragem); follow-up possível registrado na conversa da rodada.

--- a/src/core/Controllers/Opportunity.php
+++ b/src/core/Controllers/Opportunity.php
@@ -1092,7 +1092,10 @@ class Opportunity extends EntityController {
         sort($evaluation_ids);
 
         $edata = [
-            '@select' => 'id,result,evaluationData,registration,user,status,createTimestamp,updateTimestamp',
+            // F4 (#20): colunas computadas de nota por slot (CA-11), preenchidas
+            // pelo hook ApiQuery(registrationevaluation).findResult do módulo
+            // OpportunityAppealPhase quando há @select com essas chaves.
+            '@select' => 'id,result,evaluationData,registration,user,status,createTimestamp,updateTimestamp,originalScore,correctedScore,scoreDifference',
             'id' => API::IN($evaluation_ids),
             "status" => API::GTE(0),
             '@permissions' => 'view'

--- a/src/modules/Opportunities/components/opportunity-evaluations-table/init.php
+++ b/src/modules/Opportunities/components/opportunity-evaluations-table/init.php
@@ -160,6 +160,11 @@ $headers = [
     [ 'text' => i::__('ID agente avaliador', 'opportunity-evaluations-table'), 'value' => 'valuer?.id', 'slug' => 'valuerAgentId', 'visible' => true, 'width' => '120px' ],
     [ 'text' => i::__('avaliador', 'opportunity-evaluations-table'), 'value' =>  'valuer?.name', 'slug' => 'evaluator', 'visible' => true],
     [ 'text' => i::__('Resultado do avaliador', 'opportunity-evaluations-table'), 'value' => 'evaluation?.resultString', 'slug' => 'result'],
+    // F4 (#20) — CA-11: nota original/corrigida/diferença por slot, computadas
+    // pelo módulo OpportunityAppealPhase no findEvaluations (via hook ApiQuery).
+    [ 'text' => i::__('Nota original', 'opportunity-evaluations-table'), 'value' => 'evaluation?.originalScore', 'slug' => 'originalScore'],
+    [ 'text' => i::__('Nota corrigida', 'opportunity-evaluations-table'), 'value' => 'evaluation?.correctedScore', 'slug' => 'correctedScore'],
+    [ 'text' => i::__('Diferença', 'opportunity-evaluations-table'), 'value' => 'evaluation?.scoreDifference', 'slug' => 'scoreDifference'],
     [ 'text' => i::__('Tipo de proponente', 'opportunity-evaluations-table'), 'value' => 'proponentType', 'slug' => 'proponentType'],
     [ 'text' => i::__('Categoria', 'opportunity-evaluations-table'), 'value' => 'category', 'slug' => 'category'],
     [ 'text' => i::__('Faixa', 'opportunity-evaluations-table'), 'value' => 'range', 'slug' => 'range'],

--- a/src/modules/Opportunities/components/opportunity-evaluations-table/script.js
+++ b/src/modules/Opportunities/components/opportunity-evaluations-table/script.js
@@ -221,6 +221,13 @@ app.component('opportunity-evaluations-table', {
             // Campos de isenção por selos (spec §4.3). Atribuídos explicitamente
             // para garantir disponibilidade independentemente de serem colunas
             // ou campos derivados no Registration.
+
+            // F4 (#20): `evaluation` é atribuído CRU (sem Entity.populate) —
+            // por isso as colunas computadas por slot (originalScore/
+            // correctedScore/scoreDifference, hook ApiQuery do módulo
+            // OpportunityAppealPhase) sobrevivem aqui sem cópia manual. Se
+            // este processor algum dia popular o evaluation via SDK, copiar
+            // as chaves como o rawProcessor da opportunity-registrations-table.
             reg.sealExemptionStatus = rawData.registration?.sealExemptionStatus ?? null;
             reg.sealExemptionTimestamp = rawData.registration?.sealExemptionTimestamp ?? null;
 

--- a/src/modules/Opportunities/components/opportunity-evaluations-table/script.js
+++ b/src/modules/Opportunities/components/opportunity-evaluations-table/script.js
@@ -325,6 +325,17 @@ app.component('opportunity-evaluations-table', {
             return mcdate.date('2-digit year');
         },
 
+        // F4 (#20): colunas de nota — null vira "-", números sem zeros à direita.
+        formatScoreColumn(value) {
+            if (value === null || value === undefined) {
+                return '-';
+            }
+
+            const number = Number(value);
+
+            return Number.isFinite(number) ? String(parseFloat(number.toFixed(2))) : '-';
+        },
+
         onChange(event, onInput, entities) {
             if(event instanceof InputEvent) {
                 setTimeout(() => onInput(event), 50);

--- a/src/modules/Opportunities/components/opportunity-evaluations-table/template.php
+++ b/src/modules/Opportunities/components/opportunity-evaluations-table/template.php
@@ -14,11 +14,12 @@ $opportunity = $this->getOpportunityFromEntity($entity);
 $has_seal_exemption_config = SealExemptionService::hasActiveConfig(
     $opportunity->evaluationMethodConfiguration?->sealExemptionConfig
 );
+// F4 (#20): colunas de nota por slot visíveis por padrão (CA-11)
 $required_fields = 'number,committeeSequentialNumber,valuerUserId,valuerAgentId,evaluator,result,status,delete';
-$visible_fields = "['agent', 'number', 'committeeSequentialNumber', 'valuerUserId', 'valuerAgentId', 'evaluator', 'result', 'status', 'coletivo', 'goalStatuses']";
+$visible_fields = "['agent', 'number', 'committeeSequentialNumber', 'valuerUserId', 'valuerAgentId', 'evaluator', 'result', 'originalScore', 'correctedScore', 'scoreDifference', 'status', 'coletivo', 'goalStatuses']";
 if ($has_seal_exemption_config) {
     $required_fields = 'number,committeeSequentialNumber,valuerUserId,valuerAgentId,evaluator,result,status,sealExemptionStatus,sealExemptionTimestamp,delete';
-    $visible_fields = "['agent', 'number', 'committeeSequentialNumber', 'valuerUserId', 'valuerAgentId', 'evaluator', 'result', 'status', 'sealExemption', 'coletivo', 'goalStatuses']";
+    $visible_fields = "['agent', 'number', 'committeeSequentialNumber', 'valuerUserId', 'valuerAgentId', 'evaluator', 'result', 'originalScore', 'correctedScore', 'scoreDifference', 'status', 'sealExemption', 'coletivo', 'goalStatuses']";
 }
 
 $this->import('

--- a/src/modules/Opportunities/components/opportunity-evaluations-table/template.php
+++ b/src/modules/Opportunities/components/opportunity-evaluations-table/template.php
@@ -139,6 +139,27 @@ $this->import('
                     {{getResultString(entity)}}
                 </template>
 
+                <!-- F4 (#20) — CA-11: nota original/corrigida/diferença por slot -->
+                <template #originalScore="{entity}">
+                    {{ formatScoreColumn(entity.evaluation?.originalScore) }}
+                </template>
+
+                <template #correctedScore="{entity}">
+                    {{ formatScoreColumn(entity.evaluation?.correctedScore) }}
+                </template>
+
+                <template #scoreDifference="{entity}">
+                    <span
+                        v-if="entity.evaluation?.scoreDifference !== null && entity.evaluation?.scoreDifference !== undefined"
+                        class="semibold"
+                        :class="entity.evaluation.scoreDifference > 0
+                            ? 'success__color'
+                            : (entity.evaluation.scoreDifference < 0 ? 'danger__color' : '')">
+                        {{ formatScoreColumn(entity.evaluation.scoreDifference) }}
+                    </span>
+                    <span v-else>-</span>
+                </template>
+
                 <template #coletivo="{entity}">
                     <span v-if="entity.agentsData?.coletivo?.name">{{entity.agentsData?.coletivo?.name}}</span>
                     <span v-if="!entity.agentsData?.coletivo?.name"><?= i::__("Não informado") ?></span>

--- a/src/modules/Opportunities/components/opportunity-registrations-table/init.php
+++ b/src/modules/Opportunities/components/opportunity-registrations-table/init.php
@@ -92,6 +92,24 @@ $default_headers = [
         'text' => i::__('Divisão geográfica do responsável – País'),
         'value' => 'owner?.geoPais',
     ],
+    // F4 (#20) — CA-11: médias por inscrição (computadas pelo módulo
+    // OpportunityAppealPhase no findResult da ApiQuery; o slug entra no
+    // default_select pelo merge de headers abaixo).
+    [
+        'text' => i::__('Média original'),
+        'value' => 'averageOriginalScore',
+        'slug' => 'averageOriginalScore',
+    ],
+    [
+        'text' => i::__('Média corrigida'),
+        'value' => 'averageCorrectedScore',
+        'slug' => 'averageCorrectedScore',
+    ],
+    [
+        'text' => i::__('Diferença'),
+        'value' => 'scoreDifference',
+        'slug' => 'scoreDifference',
+    ],
 ];
 
 if($phase->isReportingPhase || $phase->isFinalReportingPhase) {

--- a/src/modules/Opportunities/components/opportunity-registrations-table/script.js
+++ b/src/modules/Opportunities/components/opportunity-registrations-table/script.js
@@ -6,8 +6,9 @@ app.component('opportunity-registrations-table', {
             required: true
         },
         visibleColumns: {
+            // F4 (#20): médias de nota visíveis por padrão (CA-11)
             type: Array,
-            default: ["agent", "status", "category", "consolidatedResult", "editable","updateTimestamp","sentTimestamp","createTimestamp"],
+            default: ["agent", "status", "category", "consolidatedResult", "averageOriginalScore", "averageCorrectedScore", "scoreDifference", "editable","updateTimestamp","sentTimestamp","createTimestamp"],
         },
         identifier: {
             type: String,

--- a/src/modules/Opportunities/components/opportunity-registrations-table/script.js
+++ b/src/modules/Opportunities/components/opportunity-registrations-table/script.js
@@ -435,6 +435,17 @@ app.component('opportunity-registrations-table', {
             return this.statusDict.find(status => status.value === actualStatus);
         },
 
+        // F4 (#20): colunas de média/nota — null vira "-", números sem zeros à direita.
+        formatScoreColumn(value) {
+            if (value === null || value === undefined) {
+                return '-';
+            }
+
+            const number = Number(value);
+
+            return Number.isFinite(number) ? String(parseFloat(number.toFixed(2))) : '-';
+        },
+
         setStatus(selected, entity) {
             const api = new API();
             const url = Utils.createUrl('registration', 'setStatusTo', {id: entity.id});

--- a/src/modules/Opportunities/components/opportunity-registrations-table/script.js
+++ b/src/modules/Opportunities/components/opportunity-registrations-table/script.js
@@ -432,6 +432,31 @@ app.component('opportunity-registrations-table', {
     },
 
     methods: {
+        /**
+         * Pipeline das linhas da lista de inscritos.
+         *
+         * F4 (#20): as colunas computadas de nota (averageOriginalScore,
+         * averageCorrectedScore, scoreDifference) vêm da API (hook
+         * ApiQuery(registration).findResult do OpportunityAppealPhase), mas o
+         * Entity.populate() do SDK DESCARTA propriedades fora de
+         * $PROPERTIES/$RELATIONS — com o pipeline padrão do mc-entities as
+         * chaves morriam entre a resposta HTTP e o render (célula "-").
+         * Com rawProcessor o fetch vira raw (mc-entities/script.js:137-140)
+         * e este método povoa a entidade e copia as chaves computadas da
+         * resposta bruta.
+         */
+        rawProcessor(rawData) {
+            const registrationApi = new API('registration');
+            const registration = registrationApi.getEntityInstance(rawData.id);
+            registration.populate(rawData, true);
+
+            registration.averageOriginalScore = rawData.averageOriginalScore ?? null;
+            registration.averageCorrectedScore = rawData.averageCorrectedScore ?? null;
+            registration.scoreDifference = rawData.scoreDifference ?? null;
+
+            return registration;
+        },
+
         getStatus(actualStatus) {
             return this.statusDict.find(status => status.value === actualStatus);
         },

--- a/src/modules/Opportunities/components/opportunity-registrations-table/template.php
+++ b/src/modules/Opportunities/components/opportunity-registrations-table/template.php
@@ -41,7 +41,7 @@ $entity = $this->controller->requestedEntity;
             <?php $this->applyTemplateHook('registration-list-actions', 'after', ['entity' => $entity]); ?>
         </template>
         <div class="col-12"> 
-            <entity-table controller="opportunity" endpoint="findRegistrations" :identifier="identifier" type="registration" :query="query" :limit="100" :sort-options="sortOptions" :order="order" :select="select" :headers="headers" phase:="phase" required="number,options" :visible="visible" @clear-filters="clearFilters" @remove-filter="removeFilter($event)" show-index :hide-filters="hideFilters" :hide-sort="hideSort" :hide-actions='hideActions' :hide-header="hideHeader">
+            <entity-table controller="opportunity" endpoint="findRegistrations" :identifier="identifier" type="registration" :query="query" :limit="100" :sort-options="sortOptions" :order="order" :select="select" :headers="headers" phase:="phase" required="number,options" :visible="visible" :raw-processor="rawProcessor" @clear-filters="clearFilters" @remove-filter="removeFilter($event)" show-index :hide-filters="hideFilters" :hide-sort="hideSort" :hide-actions='hideActions' :hide-header="hideHeader">
                 <template #title>
                     <slot name="title"></slot>
                 </template>

--- a/src/modules/Opportunities/components/opportunity-registrations-table/template.php
+++ b/src/modules/Opportunities/components/opportunity-registrations-table/template.php
@@ -128,8 +128,29 @@ $entity = $this->controller->requestedEntity;
                     <span v-else>&nbsp;</span>
                 </template>
 
-                <template #consolidatedResult="{entity}"> 
+                <template #consolidatedResult="{entity}">
                     {{consolidatedResultToString(entity)}}
+                </template>
+
+                <!-- F4 (#20) — CA-11: médias por inscrição -->
+                <template #averageOriginalScore="{entity}">
+                    {{ formatScoreColumn(entity.averageOriginalScore) }}
+                </template>
+
+                <template #averageCorrectedScore="{entity}">
+                    {{ formatScoreColumn(entity.averageCorrectedScore) }}
+                </template>
+
+                <template #scoreDifference="{entity}">
+                    <span
+                        v-if="entity.scoreDifference !== null && entity.scoreDifference !== undefined"
+                        class="semibold"
+                        :class="entity.scoreDifference > 0
+                            ? 'success__color'
+                            : (entity.scoreDifference < 0 ? 'danger__color' : '')">
+                        {{ formatScoreColumn(entity.scoreDifference) }}
+                    </span>
+                    <span v-else>-</span>
                 </template>
 
                 <template #agent="{entity}">

--- a/src/modules/OpportunityAppealPhase/Module.php
+++ b/src/modules/OpportunityAppealPhase/Module.php
@@ -48,6 +48,23 @@ class Module extends \MapasCulturais\Module {
             $result = $self->canDesignatedCorrectorAccessSlot($this, $user);
         });
 
+        /*
+         * F4 (#20) — CA-11: colunas de nota original/corrigida/diferença.
+         *
+         * Propriedades computadas, expostas ao @select da ApiQuery (o parse
+         * aceita chaves virtuais: processEntities as preenche com null e o
+         * hook abaixo computa os valores). Sem persistência e sem schema.
+         * A ordenação por essas colunas é ignorada pela ApiQuery (sem erro);
+         * filtragem por elas não é suportada (PropertyDoesNotExists).
+         */
+        $app->hook('ApiQuery(registrationevaluation).findResult', function (&$result) use ($self) {
+            $self->enrichEvaluationScoreColumns($result);
+        });
+
+        $app->hook('ApiQuery(registration).findResult', function (&$result) use ($self) {
+            $self->enrichRegistrationScoreColumns($result);
+        });
+
         /* Endpoint de criação de fase de recurso na oportunidade */
         $app->hook('POST(opportunity.createAppealPhase)', function() use ($app) {
             /** @var Controllers\Opportunity $this  */
@@ -439,6 +456,240 @@ class Module extends \MapasCulturais\Module {
         }
 
         return false;
+    }
+
+    // ============================================================ //
+    // F4 (#20) — CA-11: propriedades computadas de nota
+    // ============================================================ //
+
+    /**
+     * Colunas por slot (avaliação), computadas no findResult da ApiQuery:
+     *
+     * - originalScore: nota do slot ANTES da primeira correção aplicada
+     *   (registration_appeal_review com status SENT, menor id); sem correção,
+     *   é a própria nota vigente (snapshot originalScore da designação);
+     * - correctedScore: nota vigente (result pós-correção in-place);
+     * - scoreDifference: correctedScore − originalScore.
+     *
+     * Formato por método, derivado do `result` como as listas já exibem:
+     * técnico = pontuação ponderada; documental = 1/−1 (válida/inválida);
+     * simples = código do status. Resultados não numéricos → null.
+     *
+     * Só computa quando as chaves foram pedidas no @select (a chave existe,
+     * null, nas linhas); queries que não pedem não pagam o custo.
+     *
+     * @param array<int, array<string, mixed>> $result
+     */
+    public function enrichEvaluationScoreColumns(array &$result): void
+    {
+        if (!$result) {
+            return;
+        }
+
+        $wants_original = array_key_exists('originalScore', $result[0]);
+        $wants_corrected = array_key_exists('correctedScore', $result[0]);
+        $wants_difference = array_key_exists('scoreDifference', $result[0]);
+
+        if (!$wants_original && !$wants_corrected && !$wants_difference) {
+            return;
+        }
+
+        $evaluation_ids = [];
+        foreach ($result as $row) {
+            if (!empty($row['id'])) {
+                $evaluation_ids[] = (int) $row['id'];
+            }
+        }
+
+        $snapshot = $this->fetchCurrentAndOriginalScores($evaluation_ids);
+
+        foreach ($result as &$row) {
+            $id = (int) ($row['id'] ?? 0);
+            $current = $snapshot[$id]['current'] ?? null;
+            $original = $snapshot[$id]['original'] ?? null;
+
+            // Sem correção aplicada: original é a nota vigente.
+            $original = $original ?? $current;
+
+            if ($wants_original) {
+                $row['originalScore'] = $original;
+            }
+            if ($wants_corrected) {
+                $row['correctedScore'] = $current;
+            }
+            if ($wants_difference) {
+                $row['scoreDifference'] = ($original !== null && $current !== null)
+                    ? $current - $original
+                    : null;
+            }
+        }
+    }
+
+    /**
+     * Colunas por inscrição (lista de inscritos), computadas no findResult:
+     *
+     * - averageCorrectedScore: média das notas vigentes dos slots ENVIADOS
+     *   (mesma base do getSentEvaluations — consolidação vigente);
+     * - averageOriginalScore: média recomputada trocando, em cada slot
+     *   corrigido, a nota vigente pela originalScore da designação aplicada;
+     * - scoreDifference: média corrigida − média original (sem nenhuma
+     *   correção: médias iguais, diferença 0; sem notas numéricas: null).
+     *
+     * @param array<int, array<string, mixed>> $result
+     */
+    public function enrichRegistrationScoreColumns(array &$result): void
+    {
+        if (!$result) {
+            return;
+        }
+
+        $wants_original = array_key_exists('averageOriginalScore', $result[0]);
+        $wants_corrected = array_key_exists('averageCorrectedScore', $result[0]);
+        $wants_difference = array_key_exists('scoreDifference', $result[0]);
+
+        if (!$wants_original && !$wants_corrected && !$wants_difference) {
+            return;
+        }
+
+        $registration_ids = [];
+        foreach ($result as $row) {
+            if (!empty($row['id'])) {
+                $registration_ids[] = (int) $row['id'];
+            }
+        }
+
+        $rows = $this->fetchScoresByRegistration($registration_ids);
+
+        $by_registration = [];
+        foreach ($rows as $row) {
+            $by_registration[(int) $row['registration_id']][] = $row;
+        }
+
+        $average = static function (array $values): ?float {
+            $numeric = array_values(array_filter($values, static fn ($v) => $v !== null));
+
+            return $numeric ? round(array_sum($numeric) / count($numeric), 4) : null;
+        };
+
+        foreach ($result as &$row) {
+            $registration_id = (int) ($row['id'] ?? 0);
+            $evaluations = $by_registration[$registration_id] ?? [];
+
+            $corrected_values = [];
+            $original_values = [];
+
+            foreach ($evaluations as $evaluation) {
+                $current = $evaluation['current'];
+                $original = $evaluation['original'] ?? $current;
+
+                $corrected_values[] = $current;
+                $original_values[] = $original;
+            }
+
+            $average_corrected = $average($corrected_values);
+            $average_original = $average($original_values);
+
+            if ($wants_original) {
+                $row['averageOriginalScore'] = $average_original;
+            }
+            if ($wants_corrected) {
+                $row['averageCorrectedScore'] = $average_corrected;
+            }
+            if ($wants_difference) {
+                $row['scoreDifference'] = ($average_original !== null && $average_corrected !== null)
+                    ? round($average_corrected - $average_original, 4)
+                    : null;
+            }
+        }
+    }
+
+    /**
+     * Nota vigente e nota original (primeira correção aplicada) por avaliação.
+     *
+     * @param int[] $evaluation_ids
+     * @return array<int, array{current: ?float, original: ?float}>
+     */
+    private function fetchCurrentAndOriginalScores(array $evaluation_ids): array
+    {
+        if (!$evaluation_ids) {
+            return [];
+        }
+
+        $app = App::i();
+        $ids = implode(',', array_map('intval', $evaluation_ids));
+
+        // r.status = 2 = RegistrationAppealReview::STATUS_SENT (correção aplicada);
+        // menor id = primeira correção do slot.
+        $rows = $app->em->getConnection()->fetchAllAssociative("
+            SELECT
+                ev.id,
+                ev.result,
+                (
+                    SELECT r.original_score
+                    FROM registration_appeal_review r
+                    WHERE r.original_evaluation_id = ev.id AND r.status = 2
+                    ORDER BY r.id ASC
+                    LIMIT 1
+                ) AS original_score
+            FROM registration_evaluation ev
+            WHERE ev.id IN ({$ids})
+        ");
+
+        $snapshot = [];
+        foreach ($rows as $row) {
+            $snapshot[(int) $row['id']] = [
+                'current' => $this->toNumericScore($row['result']),
+                'original' => $this->toNumericScore($row['original_score']),
+            ];
+        }
+
+        return $snapshot;
+    }
+
+    /**
+     * Notas por inscrição, apenas avaliações ENVIADAS (ev.status = 2 =
+     * RegistrationEvaluation::STATUS_SENT — mesma base de getSentEvaluations).
+     *
+     * @param int[] $registration_ids
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchScoresByRegistration(array $registration_ids): array
+    {
+        if (!$registration_ids) {
+            return [];
+        }
+
+        $app = App::i();
+        $ids = implode(',', array_map('intval', $registration_ids));
+
+        return $app->em->getConnection()->fetchAllAssociative("
+            SELECT
+                ev.registration_id,
+                ev.result AS current,
+                (
+                    SELECT r.original_score
+                    FROM registration_appeal_review r
+                    WHERE r.original_evaluation_id = ev.id AND r.status = 2
+                    ORDER BY r.id ASC
+                    LIMIT 1
+                ) AS original
+            FROM registration_evaluation ev
+            WHERE ev.registration_id IN ({$ids})
+                AND ev.status = 2
+        ");
+    }
+
+    /**
+     * Resultado do slot como número (técnico: pontuação; documental: 1/−1;
+     * simples: código do status). Não numérico → null.
+     */
+    private function toNumericScore(mixed $value): ?float
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return is_numeric($value) ? (float) $value : null;
     }
 
     private function isAppealScoreCorrectionEnabled(): bool

--- a/src/modules/Spreadsheets/JobTypes/Registrations.php
+++ b/src/modules/Spreadsheets/JobTypes/Registrations.php
@@ -160,6 +160,23 @@ class Registrations extends SpreadsheetJob
                 continue;
             }
 
+            // F4 (#20) — CA-11: colunas computadas de nota por inscrição
+            // (módulo OpportunityAppealPhase); rótulo amigável na planilha.
+            if($property == 'averageOriginalScore') {
+                $header[$property] = i::__('Média original (antes das correções de recurso)');
+                continue;
+            }
+
+            if($property == 'averageCorrectedScore') {
+                $header[$property] = i::__('Média corrigida (vigente)');
+                continue;
+            }
+
+            if($property == 'scoreDifference') {
+                $header[$property] = i::__('Diferença (média corrigida - média original)');
+                continue;
+            }
+
             $header[$property] = $entity_class_name::getPropertyLabel($property) ?: $property;
         }
 

--- a/tests/src/AppealScoreColumnsTest.php
+++ b/tests/src/AppealScoreColumnsTest.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace Tests;
+
+use DateTime;
+use MapasCulturais\App;
+use MapasCulturais\ApiQuery;
+use MapasCulturais\Entities\EvaluationMethodConfiguration;
+use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\Entities\Registration;
+use MapasCulturais\Entities\RegistrationEvaluation;
+use MapasCulturais\Entities\User;
+use OpportunityAppealPhase\Entities\RegistrationAppealReview;
+use Psr\Http\Message\ServerRequestInterface;
+use Tests\Abstract\TestCase;
+use Tests\Builders\PhasePeriods\ConcurrentEndingAfter;
+use Tests\Builders\PhasePeriods\Open;
+use Tests\Enums\EvaluationMethods;
+use Tests\Traits\OpportunityBuilder;
+use Tests\Traits\RegistrationDirector;
+use Tests\Traits\RequestFactory;
+use Tests\Traits\UserDirector;
+
+/**
+ * F4 (#20) — CA-11: colunas de nota original/corrigida/diferença.
+ *
+ * Cenário documental com correção APLICADA (slot A: inválida −1 → válida 1;
+ * slot B sem correção: válida 1; inscrição 2 sem nenhuma correção):
+ * - por slot: originalScore/correctedScore/scoreDifference via ApiQuery e API;
+ * - por inscrição: averageOriginalScore/averageCorrectedScore/scoreDifference
+ *   (média corrigida = vigente; média original = recomputada com os snapshots).
+ */
+class AppealScoreColumnsTest extends TestCase
+{
+    use OpportunityBuilder,
+        RegistrationDirector,
+        UserDirector,
+        RequestFactory;
+
+    private function enableFlag(): void
+    {
+        $_ENV['APPEAL_SCORE_CORRECTION'] = 'true';
+    }
+
+    /**
+     * @return array{admin: User, committeeUser: User, opportunity: Opportunity,
+     *   registration1: Registration, registration2: Registration,
+     *   slotA: RegistrationEvaluation, slotB: RegistrationEvaluation}
+     */
+    private function createScenario(): array
+    {
+        $this->enableFlag();
+
+        $admin = $this->userDirector->createUser('admin');
+        $slot_owner_a = $this->userDirector->createUser();
+        $slot_owner_b = $this->userDirector->createUser();
+        $committee_user = $this->userDirector->createUser();
+
+        $this->login($admin);
+
+        $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase(EvaluationMethods::documentary)
+                ->fillRequiredProperties()
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->save()
+                ->addValuer('Comissão', 'Avaliador A', $slot_owner_a->profile)
+                    ->done()
+                ->addValuer('Comissão', 'Avaliador B', $slot_owner_b->profile)
+                    ->done()
+                ->done()
+            ->save();
+
+        /** @var Opportunity $opportunity */
+        $opportunity = $this->opportunityBuilder->getInstance();
+
+        $registration_1 = $this->registrationDirector->createSentRegistration($opportunity, data: []);
+        $registration_2 = $this->registrationDirector->createSentRegistration($opportunity, data: []);
+
+        $app = App::i();
+        $app->disableAccessControl();
+
+        // Slot A: inválida (result −1) — será corrigida para válida (result 1).
+        $slot_a = new RegistrationEvaluation();
+        $slot_a->registration = $registration_1;
+        $slot_a->user = $slot_owner_a;
+        $slot_a->status = RegistrationEvaluation::STATUS_SENT;
+        $slot_a->setEvaluationData((object) ['doc_a' => ['evaluation' => 'invalid', 'obs' => '']]);
+        $slot_a->save(true);
+
+        // Slot B: válida (result 1) — permanece sem correção.
+        $slot_b = new RegistrationEvaluation();
+        $slot_b->registration = $registration_1;
+        $slot_b->user = $slot_owner_b;
+        $slot_b->status = RegistrationEvaluation::STATUS_SENT;
+        $slot_b->setEvaluationData((object) ['doc_b' => ['evaluation' => 'valid', 'obs' => '']]);
+        $slot_b->save(true);
+
+        // Inscrição 2: um slot válido, sem nenhuma correção.
+        $slot_c = new RegistrationEvaluation();
+        $slot_c->registration = $registration_2;
+        $slot_c->user = $slot_owner_b;
+        $slot_c->status = RegistrationEvaluation::STATUS_SENT;
+        $slot_c->setEvaluationData((object) ['doc_b' => ['evaluation' => 'valid', 'obs' => '']]);
+        $slot_c->save(true);
+
+        $appeal_phase_class = $opportunity->getSpecializedClassName();
+        /** @var Opportunity $appeal_phase */
+        $appeal_phase = new $appeal_phase_class();
+        $appeal_phase->parent = $opportunity;
+        $appeal_phase->status = Opportunity::STATUS_APPEAL_PHASE;
+        $appeal_phase->name = 'Fase de recurso documental';
+        $appeal_phase->ownerEntity = $opportunity->ownerEntity;
+        $appeal_phase->owner = $opportunity->owner;
+        $appeal_phase->registrationCategories = $opportunity->registrationCategories;
+        $appeal_phase->registrationRanges = $opportunity->registrationRanges;
+        $appeal_phase->registrationProponentTypes = $opportunity->registrationProponentTypes;
+        $appeal_phase->isDataCollection = true;
+        $appeal_phase->isAppealPhase = true;
+        $appeal_phase->registrationFrom = new DateTime('-1 day');
+        $appeal_phase->registrationTo = new DateTime('+1 day');
+        $appeal_phase->save(true);
+
+        $opportunity->appealPhase = $appeal_phase;
+        $opportunity->save(true);
+
+        $appeal_emc = new EvaluationMethodConfiguration();
+        $appeal_emc->opportunity = $appeal_phase;
+        $appeal_emc->type = 'continuous';
+        $appeal_emc->publishEvaluationDetails = true;
+        $appeal_emc->save(true);
+
+        $appeal_phase->evaluationMethodConfiguration = $appeal_emc;
+        $appeal_phase->save(true);
+
+        $appeal_emc->createAgentRelation($committee_user->profile, 'committee 1', true)->save(true);
+
+        $app->enableAccessControl();
+
+        return [
+            'admin' => $admin,
+            'committeeUser' => $committee_user,
+            'opportunity' => $opportunity,
+            'registration1' => $registration_1,
+            'registration2' => $registration_2,
+            'slotA' => $slot_a,
+            'slotB' => $slot_b,
+        ];
+    }
+
+    /**
+     * @return array{status: int, json: mixed}
+     */
+    private function dispatch(ServerRequestInterface $request): array
+    {
+        $app = App::i();
+        $app->reset();
+        $app->run($request, false);
+
+        return [
+            'status' => $app->response->getStatusCode(),
+            'json' => json_decode((string) $app->response->getBody(), true),
+        ];
+    }
+
+    /**
+     * Designa o comitê para o slot e aplica a correção (inválida → válida).
+     */
+    private function applyRealCorrection(array $scenario): void
+    {
+        $this->login($scenario['admin']);
+
+        $created = $this->dispatch(
+            $this->requestFactory->POST('registrationappealreview', 'index', [], [
+                'originalEvaluation' => $scenario['slotA']->id,
+                'correctorUser' => $scenario['committeeUser']->id,
+            ])
+        );
+        $this->assertEquals(200, $created['status'], 'Designação: ' . json_encode($created['json']));
+
+        $this->login($scenario['committeeUser']);
+
+        $sent = $this->dispatch(
+            $this->requestFactory->POST('registrationevaluation', 'applyAppealCorrection', [$scenario['slotA']->id], [
+                'evaluationData' => ['doc_a' => ['evaluation' => 'valid', 'obs' => 'corrigida']],
+                'draft' => false,
+            ])
+        );
+        $this->assertEquals(200, $sent['status'], 'Correção aplicada: ' . json_encode($sent['json']));
+
+        $this->login($scenario['admin']);
+        // Sem processPCache: o drain da fila com fase de recurso no cenário
+        // esbarra em query pré-existente do OpportunityPhases (EAGER+WITH em
+        // OpportunityMeta#owner) — fora do escopo do F4. As consultas abaixo
+        // rodam como admin (bypass da subquery de permissão).
+    }
+
+    function testSlotColumnsWithAndWithoutCorrection(): void
+    {
+        $scenario = $this->createScenario();
+        $this->applyRealCorrection($scenario);
+
+        $query = new ApiQuery(RegistrationEvaluation::class, [
+            '@select' => 'id,originalScore,correctedScore,scoreDifference',
+            'id' => "IN({$scenario['slotA']->id},{$scenario['slotB']->id})",
+        ]);
+        $rows = [];
+        foreach ($query->find() as $row) {
+            $rows[(int) $row['id']] = $row;
+        }
+
+        // Slot corrigido: −1 → 1 (documental: inválida → válida)
+        $this->assertEquals(-1.0, $rows[$scenario['slotA']->id]['originalScore'], 'originalScore = snapshot da primeira correção aplicada');
+        $this->assertEquals(1.0, $rows[$scenario['slotA']->id]['correctedScore'], 'correctedScore = nota vigente (result pós correção in-place)');
+        $this->assertEquals(2.0, $rows[$scenario['slotA']->id]['scoreDifference'], 'scoreDifference = corrigida − original');
+
+        // Slot sem correção: original = vigente, diferença 0
+        $this->assertEquals(1.0, $rows[$scenario['slotB']->id]['originalScore'], 'sem correção: originalScore = nota atual');
+        $this->assertEquals(1.0, $rows[$scenario['slotB']->id]['correctedScore']);
+        $this->assertEquals(0.0, $rows[$scenario['slotB']->id]['scoreDifference']);
+    }
+
+    function testRegistrationAveragesAndDifference(): void
+    {
+        $scenario = $this->createScenario();
+        $this->applyRealCorrection($scenario);
+
+        $query = new ApiQuery(Registration::class, [
+            '@select' => 'id,averageOriginalScore,averageCorrectedScore,scoreDifference',
+            'id' => "IN({$scenario['registration1']->id},{$scenario['registration2']->id})",
+        ]);
+        $rows = [];
+        foreach ($query->find() as $row) {
+            $rows[(int) $row['id']] = $row;
+        }
+
+        // Inscrição 1: slots (−1→1) e (1) → média original 0, corrigida 1, diferença 1
+        $reg1 = $rows[$scenario['registration1']->id];
+        $this->assertEquals(0.0, $reg1['averageOriginalScore'], 'média original = (−1 + 1) / 2');
+        $this->assertEquals(1.0, $reg1['averageCorrectedScore'], 'média corrigida = (1 + 1) / 2');
+        $this->assertEquals(1.0, $reg1['scoreDifference']);
+
+        // Inscrição 2: sem nenhuma correção → médias iguais, diferença 0
+        $reg2 = $rows[$scenario['registration2']->id];
+        $this->assertEquals(1.0, $reg2['averageOriginalScore']);
+        $this->assertEquals(1.0, $reg2['averageCorrectedScore']);
+        $this->assertEquals(0.0, $reg2['scoreDifference'], 'sem correção: diferença 0');
+    }
+
+    /**
+     * Query API real (proof): @select das propriedades computadas retorna
+     * valores no cenário com correção (documental −1 → 1).
+     */
+    function testApiSelectReturnsComputedScoreColumns(): void
+    {
+        $scenario = $this->createScenario();
+        $this->applyRealCorrection($scenario);
+
+        $evaluation_response = $this->dispatch(
+            $this->requestFactory->GET('api/registrationevaluation', 'find', [], [
+                '@select' => 'id,originalScore,correctedScore,scoreDifference',
+                'id' => "EQ({$scenario['slotA']->id})",
+            ], ajax: true)
+        );
+
+        $this->assertEquals(200, $evaluation_response['status'], 'API find de avaliações: ' . json_encode($evaluation_response['json']));
+        $slot = $evaluation_response['json'][0] ?? null;
+        $this->assertNotNull($slot);
+        $this->assertEquals(-1.0, $slot['originalScore'], 'API: originalScore do slot corrigido');
+        $this->assertEquals(1.0, $slot['correctedScore'], 'API: correctedScore do slot corrigido');
+        $this->assertEquals(2.0, $slot['scoreDifference'], 'API: scoreDifference do slot corrigido');
+
+        $registration_response = $this->dispatch(
+            $this->requestFactory->GET('api/registration', 'find', [], [
+                '@select' => 'id,averageOriginalScore,averageCorrectedScore,scoreDifference',
+                'id' => "EQ({$scenario['registration1']->id})",
+            ], ajax: true)
+        );
+
+        $this->assertEquals(200, $registration_response['status'], 'API find de inscrições: ' . json_encode($registration_response['json']));
+        $registration = $registration_response['json'][0] ?? null;
+        $this->assertNotNull($registration);
+        $this->assertEquals(0.0, $registration['averageOriginalScore'], 'API: média original da inscrição');
+        $this->assertEquals(1.0, $registration['averageCorrectedScore'], 'API: média corrigida da inscrição');
+        $this->assertEquals(1.0, $registration['scoreDifference'], 'API: diferença da inscrição');
+    }
+}


### PR DESCRIPTION
Colunas de transparência das correções (CA-11) nas listas de avaliações, lista de inscritos e exportações.

- **Propriedades por API** (hooks `ApiQuery(registrationevaluation).findResult` e `ApiQuery(registration).findResult`, custo zero quando não selecionadas): por slot — `originalScore` (snapshot da primeira correção aplicada; sem correção = nota vigente), `correctedScore`, `scoreDifference`; por inscrição — `averageOriginalScore` (média SENT trocando vigente→snapshot nos corrigidos), `averageCorrectedScore`, `scoreDifference`.
- **Listas**: avaliações — "Nota original / Nota corrigida / Diferença" por slot (badge de cor na diferença ≠ 0); inscritos — "Média original / Média corrigida / Diferença" via `default_headers`/`default_select` (propagam ao entity-table e à exportação de colunas visíveis).
- **Exportação**: rótulos amigáveis no job de planilhas (`Spreadsheets/JobTypes/Registrations.php`).
- **Prova de API real** (cenário documental corrigido −1→1): slot → `{original −1.0, corrected 1.0, diff 2.0}`; inscrição → médias `{0.0, 1.0, dif 1.0}`.
- **Desvio registrado** (`docs/rounds/…/deviations.md`): filtragem pelas colunas virtuais não é suportada pela ApiQuery (`PropertyDoesNotExists`; `@order` ignorado) — não exposta na UI; CA-11 exige exibição, não filtragem. Nota conhecida: usuários com colunas salvas em localStorage veem as novas desmarcadas até reativarem.

**Verificação:** `php -l` OK; `node --check` OK; `AppealScoreColumnsTest` **3 testes / 28 asserções OK** (inclui proof por API real); suites vizinhas sem regressão (falhas restantes provadas pré-existentes via stash).
