### PR TITLE
F8 — Tela do proponente (preliminar → recurso → final) (#21)

### DIFF
--- a/src/modules/Opportunities/components/registration-status/script.js
+++ b/src/modules/Opportunities/components/registration-status/script.js
@@ -22,9 +22,16 @@ app.component('registration-status', {
 
     data() {
         return {
-            processing: false, 
+            processing: false,
             entity: null,
+            // F8 (#21): notas do fluxo preliminar → recurso → final do próprio
+            // proponente (buscadas só quando publicado; leitura raw).
+            flowScores: null,
         }
+    },
+
+    mounted() {
+        this.loadAppealFlowScores();
     },
 
     computed: {
@@ -45,6 +52,61 @@ app.component('registration-status', {
             }
 
             return $MAPAS.registrationPhases[appealPhaseId] || this.entity;
+        },
+
+        /*
+         * F8 (#21) — fluxo preliminar → recurso → reavaliação → final.
+         * Gates espelham os server-side do PR3 (Opportunity::
+         * areRegistrationResultsPublished): o que não está publicado não é
+         * buscado nem exibido (critério de privacidade 5).
+         */
+        preliminaryPublished() {
+            return !!(this.opportunity.publishedRegistrations || this.opportunity.publishedPreliminaryRegistrations);
+        },
+
+        finalPublished() {
+            return !!this.opportunity.publishedRegistrations;
+        },
+
+        showAppealFlow() {
+            return !!this.appealPhase
+                && !this.opportunity.isAppealPhase
+                && (this.preliminaryPublished || !!this.appealRegistration?.id);
+        },
+
+        flowPreliminaryScore() {
+            return this.flowScores?.averageOriginalScore ?? null;
+        },
+
+        flowCorrectedScore() {
+            return this.flowScores?.averageCorrectedScore ?? null;
+        },
+
+        flowHasCorrection() {
+            return this.flowScores !== null
+                && this.flowScores.scoreDifference !== null
+                && this.flowScores.scoreDifference !== 0;
+        },
+
+        appealFlowStatusLabel() {
+            const appeal_registration = this.appealRegistration;
+            if (!appeal_registration?.id) {
+                return '';
+            }
+
+            if (appeal_registration.status == 0) {
+                return this.text('flow draft');
+            }
+
+            if (appeal_registration.status == 1) {
+                return this.text('flow sent awaiting');
+            }
+
+            // Veredito (deferido/indeferido/...) só quando o método expõe ao
+            // dono — mesmo gate server-side do bloco [Recurso] existente.
+            return this.shouldDisplayEvaluationResults(appeal_registration)
+                ? (this.appealPhase?.statusLabels?.[appeal_registration.status] ?? this.text('flow under analysis'))
+                : this.text('flow under analysis');
         },
 
         canShowAppeal() {
@@ -89,6 +151,39 @@ app.component('registration-status', {
     },
 
     methods: {
+        /**
+         * F8 (#21): notas do fluxo (médias original/corrigida da própria
+         * inscrição — propriedades computadas do módulo OpportunityAppealPhase,
+         * expostas ao dono pela API de registration).
+         *
+         * Privacidade: busca SÓ quando há resultado publicado (preliminar ou
+         * final — o mesmo gate server-side do status); leitura raw porque o
+         * populate do SDK descarta as chaves virtuais. Erros deixam o fluxo
+         * sem notas (passos exibem "—"), nunca bloqueiam a página.
+         */
+        async loadAppealFlowScores() {
+            if (!this.showAppealFlow || !this.preliminaryPublished || !this.registration?.id) {
+                return;
+            }
+
+            try {
+                const api = new API('registration');
+                const rows = await api.fetch('find', {
+                    '@select': 'id,averageOriginalScore,averageCorrectedScore,scoreDifference',
+                    'id': `EQ(${this.registration.id})`,
+                }, { raw: true, rawProcessor: data => data });
+
+                this.flowScores = rows?.[0] || null;
+            } catch (error) {
+                console.error('registration-status:loadAppealFlowScores', error);
+                this.flowScores = null;
+            }
+        },
+
+        flowScoreOrDash(value) {
+            return (value === null || value === undefined) ? '—' : this.formatNote(value);
+        },
+
         showPhaseDates() {
             const firstPhase = $MAPAS.opportunityPhases?.find((phase) => phase.isFirstPhase) || this.firstPhase;
             return !firstPhase?.hidePhaseDates;

--- a/src/modules/Opportunities/components/registration-status/style.css
+++ b/src/modules/Opportunities/components/registration-status/style.css
@@ -1,0 +1,63 @@
+/*
+ * registration-status (F8 #21)
+ *
+ * Estilo local no padrão do módulo (auto-enfileirado, sem build): apenas o
+ * fluxo preliminar → recurso → reavaliação → final do proponente; o restante
+ * usa as classes do tema (timeline/badges). Mobile: passos empilham.
+ */
+
+.registration-status__appeal-flow {
+    border: 1px solid var(--mc-gray-300);
+    border-radius: var(--mc-border-radius-sm);
+    display: flex;
+    flex-direction: column;
+    gap: .5rem;
+    margin-top: .75rem;
+    padding: .75rem;
+}
+
+.registration-status__appeal-flow-title {
+    margin: 0;
+}
+
+.registration-status__appeal-flow-steps {
+    display: flex;
+    flex-direction: column;
+    gap: .5rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.registration-status__appeal-flow-step {
+    align-items: flex-start;
+    display: flex;
+    flex-wrap: wrap;
+    font-size: .875rem;
+    gap: .5rem;
+}
+
+.registration-status__appeal-flow-label {
+    flex: 0 0 10rem;
+}
+
+.registration-status__appeal-flow-dot {
+    background-color: var(--mc-gray-300);
+    border-radius: var(--mc-border-radius-pill);
+    display: inline-block;
+    flex: 0 0 auto;
+    height: .5rem;
+    margin-top: .35rem;
+    width: .5rem;
+}
+
+.registration-status__appeal-flow-dot--final {
+    background-color: var(--mc-primary-500);
+}
+
+@media (max-width: 800px) {
+    .registration-status__appeal-flow-step {
+        flex-direction: column;
+        gap: .25rem;
+    }
+}

--- a/src/modules/Opportunities/components/registration-status/template.php
+++ b/src/modules/Opportunities/components/registration-status/template.php
@@ -72,3 +72,46 @@ $this->import('
 
     </div>
 </div>
+
+<!--
+    F8 (#21): fluxo do proponente — resultado preliminar → recurso →
+    reavaliação → resultado final. Cada passo só renderiza quando publicado
+    (gates espelhando o server-side do PR3); nada publicado → seção omitida.
+-->
+<section
+    v-if="showAppealFlow"
+    class="registration-status__appeal-flow"
+    :aria-label="text('flow title')">
+
+    <h4 class="semibold registration-status__appeal-flow-title"><?= i::__('Fluxo do recurso') ?></h4>
+
+    <ol class="registration-status__appeal-flow-steps">
+        <!-- 1. Resultado preliminar -->
+        <li v-if="preliminaryPublished" class="registration-status__appeal-flow-step">
+            <span class="registration-status__appeal-flow-dot" aria-hidden="true"></span>
+            <span class="semibold registration-status__appeal-flow-label"><?= i::__('Resultado preliminar') ?></span>
+            <span><?= i::__('Nota preliminar') ?>: <strong>{{ flowScoreOrDash(flowPreliminaryScore) }}</strong></span>
+        </li>
+
+        <!-- 2. Recurso (status do próprio proponente; veredito gated server-side) -->
+        <li v-if="appealRegistration?.id" class="registration-status__appeal-flow-step">
+            <span class="registration-status__appeal-flow-dot" aria-hidden="true"></span>
+            <span class="semibold registration-status__appeal-flow-label"><?= i::__('Recurso') ?></span>
+            <span :id="'appeal-flow-status-' + registration.id">{{ appealFlowStatusLabel }}</span>
+        </li>
+
+        <!-- 3. Reavaliação (nota pós-correção; só com resultado final publicado) -->
+        <li v-if="finalPublished && flowHasCorrection" class="registration-status__appeal-flow-step">
+            <span class="registration-status__appeal-flow-dot" aria-hidden="true"></span>
+            <span class="semibold registration-status__appeal-flow-label"><?= i::__('Reavaliação') ?></span>
+            <span><?= i::__('Nota após correção') ?>: <strong>{{ flowScoreOrDash(flowCorrectedScore) }}</strong></span>
+        </li>
+
+        <!-- 4. Resultado final -->
+        <li v-if="finalPublished" class="registration-status__appeal-flow-step">
+            <span class="registration-status__appeal-flow-dot registration-status__appeal-flow-dot--final" aria-hidden="true"></span>
+            <span class="semibold registration-status__appeal-flow-label"><?= i::__('Resultado final') ?></span>
+            <span><?= i::__('Nota final') ?>: <strong>{{ flowScoreOrDash(flowCorrectedScore) }}</strong></span>
+        </li>
+    </ol>
+</section>

--- a/src/modules/Opportunities/components/registration-status/texts.php
+++ b/src/modules/Opportunities/components/registration-status/texts.php
@@ -3,5 +3,11 @@ use MapasCulturais\i;
 
 return [
     'Solicitação de recurso criada com sucesso' => 'Solicitação de recurso criada com sucesso',
-    'Não enviada' => 'Não enviada'
+    'Não enviada' => 'Não enviada',
+
+    // F8 (#21): fluxo preliminar → recurso → reavaliação → final
+    'flow title' => i::__('Fluxo do recurso'),
+    'flow draft' => i::__('Rascunho — finalize o formulário do recurso'),
+    'flow sent awaiting' => i::__('Enviada — aguardando análise'),
+    'flow under analysis' => i::__('Em análise'),
 ];


### PR DESCRIPTION
A face do proponente do fluxo de recurso: o acompanhamento da inscrição (`registration-status`) passa a exibir a linha do tempo completa — resultado preliminar, recurso (status/veredito), nota pós-correção e resultado final — estritamente conforme os gates de publicação do PR3.

- **Preliminar** = `averageOriginalScore` (F4; fetch raw — populate descarta virtuais), gate `publishedRegistrations || publishedPreliminaryRegistrations`.
- **Recurso** = fase de recurso casada por `number` (`$MAPAS.registrationPhases`), veredito pelo gate server `shouldDisplayEvaluationResults` (`publishedRegistrations || allow_proponent_response`, `EvaluationMethodContinuous/Module.php:579-582`).
- **Reavaliação/Final** = `averageCorrectedScore` (F4), gates `publishedRegistrations` (+ diferença ≠ 0 para o passo de reavaliação).
- **Privacidade (critério 5)**: gates espelham `Opportunity::areRegistrationResultsPublished` (PR3); nada publicado → seção omitida; correção aplicada com só-preliminar publicado não vaza; notas buscadas apenas do próprio dono; zero endpoints de gestor.

**Verificação:** `php -l` ×2 + `node --check` OK; estados A–G simulados (nada publicado / rascunho / enviado / só preliminar / preliminar+correção (sem vazamento) / final com correção (−1 → Deferido → 1 → 1) / final sem correção); E2E dirigido no ambiente a seguir.
