### PR TITLE
R01 — Correção de notas após deferimento de recurso (#7)

### DIFF
--- a/docs/reference/prd.md
+++ b/docs/reference/prd.md
@@ -151,6 +151,8 @@ Extensão da fase de recurso (RF-A15) para permitir que gestores designem corret
 - o avaliador original daquele slot; ou
 - membro da Comissão de Recursos da fase de recurso.
 
+**Matriz de métodos (F6 / #49, Variante 3 — override registrado na #7 em 2026-09-09):** a designação é elegível para **todos** os métodos de avaliação. O seletor de escopo de critérios (`releasedScope`) existe somente para **avaliação técnica** (seções/critérios do EMC) e **qualificação documental** (campos e documentos exigidos); nos **demais métodos** (simples etc.) a correção é liberada integral (`releasedScope` nulo). Semântica: todos os critérios marcados → `null` (= sem restrição, compatível com `getReleasedCriteriaIds()`); subconjunto → `{criteria: [...]}`; lista vazia é rejeitada (400).
+
 A correção persiste in-place na `RegistrationEvaluation` original, mantendo seu dono (`user`) inalterado. A consolidação da inscrição recalcula automaticamente a partir das N avaliações (incluindo as corrigidas). O histórico fica em `EntityRevision` (mensagem customizada identificando corretor e slot) e na tabela `registration_appeal_review` (fonte primária para telas e exportações).
 
 **CA verificáveis:**
@@ -172,7 +174,7 @@ A correção persiste in-place na `RegistrationEvaluation` original, mantendo se
 | CA-13 | Gestor acompanha status individual de cada designação (designado / rascunho / enviado / reaberto), prazo e data de envio, podendo substituir corretor ou reabrir com novo prazo. |
 
 **Fora de escopo do MVP (fase 2):**
-- Métodos de avaliação além de `EvaluationMethodTechnical`.
+- ~~Métodos de avaliação além de `EvaluationMethodTechnical`~~ *(superado pelo F6/#49 — elegibilidade aberta a todos os métodos; seletor de critérios em técnica/documental, demais liberados integral — ver "Matriz de métodos" acima e em `Entities/RegistrationAppealReview.php::eligibleCorrectors`)*.
 - Criação de novas oportunidades/fases.
 - Reabertura da fase principal ou de seus prazos.
 - Mais de um recurso por inscrição.

--- a/docs/reference/prd.md
+++ b/docs/reference/prd.md
@@ -157,7 +157,7 @@ A correção persiste in-place na `RegistrationEvaluation` original, mantendo se
 
 | # | Critério de aceitação |
 |---|----------------------|
-| CA-1 | Gestor com `@control` na oportunidade vê, na lista de inscritos, ação de designação de correção **apenas** para inscrições com recurso deferido. |
+| CA-1 | Gestor com `@control` na oportunidade vê, na lista de inscritos **da fase de recurso**, ação de designação de correção **apenas** para inscrições com recurso deferido. |
 | CA-2 | Modal de designação lista apenas as `RegistrationEvaluation` da fase principal daquela inscrição, uma por avaliador. |
 | CA-3 | Por slot, o gestor só pode designar como corretor: (a) o dono daquele slot; ou (b) membro da Comissão de Recursos. Avaliadores de outros slots da mesma inscrição são rejeitados. |
 | CA-4 | Ao designar, o gestor define: corretor, prazo (início/fim), escopo de critérios liberados, `correction_type` (`official` ou `record`), e visibilidade do parecer da Comissão de Recursos. |

--- a/docs/rounds/R01-2026-08-correcao-notas-recurso/deviations.md
+++ b/docs/rounds/R01-2026-08-correcao-notas-recurso/deviations.md
@@ -1,3 +1,15 @@
 # Deviations — R01 (Correção de notas após deferimento de recurso)
 
-Nenhum desvio nesta rodada.
+### 2026-09-04 — F1 (#17): mecanismo de exposição da coluna na lista de inscritos
+- **Planejado:** expor a coluna via hook `component(opportunity-results-table).visibleColumns` (item 3 da issue #17).
+- **Implementado:** coluna no mecanismo nativo de colunas da `opportunity-registrations-table`; o hook citado alimenta a tabela de resultados (outra tabela) e segue disponível para o contexto de resultados.
+- **Razão:** o hook indicado na issue serve à tabela de resultados, não à lista de inscritos; o mecanismo nativo da tabela de inscritos atende todos os critérios de aceitação sem endpoint novo.
+- **Decisão registrada em:** relato do especialista ao facilitador na execução do F1 (2026-09-04).
+- **Documento de referência atualizado:** n/a — sem mudança de comportamento do produto (mecanismo interno de UI); o PRD não especifica o mecanismo.
+
+### 2026-09-08 — F1 (#17): lista onde a coluna de designação aparece
+- **Planejado:** coluna na lista de inscritos da fase principal (leitura da issue #17; casamento por número com recursos deferidos).
+- **Implementado:** coluna na lista de inscritos da fase de recurso, botão apenas nas linhas com status Deferido (10) — status nativo da lista.
+- **Razão:** "A coluna deve estar na lista de inscrição da fase de recurso" — decisão do revisor; CA-1/issue #17 eram ambíguos sobre qual lista.
+- **Decisão registrada em:** override na épica #7 (2026-09-08, por @israelmelo).
+- **Documento de referência atualizado:** docs/reference/prd.md (CA-1 esclarecido).

--- a/docs/rounds/R01-2026-08-correcao-notas-recurso/deviations.md
+++ b/docs/rounds/R01-2026-08-correcao-notas-recurso/deviations.md
@@ -1,0 +1,3 @@
+# Deviations — R01 (Correção de notas após deferimento de recurso)
+
+Nenhum desvio nesta rodada.

--- a/docs/rounds/R01-2026-08-correcao-notas-recurso/deviations.md
+++ b/docs/rounds/R01-2026-08-correcao-notas-recurso/deviations.md
@@ -13,3 +13,10 @@
 - **Razão:** "A coluna deve estar na lista de inscrição da fase de recurso" — decisão do revisor; CA-1/issue #17 eram ambíguos sobre qual lista.
 - **Decisão registrada em:** override na épica #7 (2026-09-08, por @israelmelo).
 - **Documento de referência atualizado:** docs/reference/prd.md (CA-1 esclarecido).
+
+### 2026-09-10 — F4 (#20): filtragem pelas colunas de nota
+- **Planejado:** "Tornar filtrável nas tabelas" (item 4 do "o que fazer" da #20).
+- **Implementado:** colunas selecionáveis via `@select` (propriedades virtuais nos hooks `ApiQuery(…).findResult`), mas **filtro** lança `PropertyDoesNotExists` na ApiQuery e `@order` pelas virtuais é ignorado — filtragem não exposta na UI; limitação documentada nos commits.
+- **Razão:** a ApiQuery não suporta filtrar/ordenar por propriedades virtuais computadas em hook; suportar exigiria estender o core da ApiQuery — fora do escopo da tarefa.
+- **Decisão registrada em:** relato do especialista ao facilitador na execução do F4 (2026-09-10).
+- **Documento de referência atualizado:** n/a — comportamento novo, sem contradição com PRD (CA-11 exige exibição, não filtragem); follow-up possível registrado na conversa da rodada.

--- a/docs/rounds/R01-2026-08-correcao-notas-recurso/scope.md
+++ b/docs/rounds/R01-2026-08-correcao-notas-recurso/scope.md
@@ -1,0 +1,12 @@
+# R01 — Correção de notas após deferimento de recurso
+
+> Registro da rodada (record) — imutável após o fechamento.
+> Pasta criada retroativamente em 2026-09-04: a rodada começou sem registro; criação combinada na inicialização de F1/F2.
+
+## Escopo (reconstruído da épica #7, do PRD vivo e da onda de tarefas)
+
+**Demanda:** permitir que gestores designem corretores para ajustar notas individuais de avaliadores (slots) em inscrições com recurso deferido, sem reabrir a fase avaliativa.
+
+- Épica: #7 (variante Condensed; override Full→Condensed registrado em 2026-08-21 por @cesardelucca)
+- PRD vivo: docs/reference/prd.md (RF-A15; CA-1..CA-13) — fonte dos requisitos
+- Onda de execução: PR1 #10, PR2 #11, PR3 #12, PR4 #13, PR4.5 #14 (backend — entregues no develop); F1 #17, F2 #18, F3 #19, F4 #20, PR5 #15 (interface — em curso)

--- a/src/core/Controllers/Opportunity.php
+++ b/src/core/Controllers/Opportunity.php
@@ -1092,7 +1092,10 @@ class Opportunity extends EntityController {
         sort($evaluation_ids);
 
         $edata = [
-            '@select' => 'id,result,evaluationData,registration,user,status,createTimestamp,updateTimestamp',
+            // F4 (#20): colunas computadas de nota por slot (CA-11), preenchidas
+            // pelo hook ApiQuery(registrationevaluation).findResult do módulo
+            // OpportunityAppealPhase quando há @select com essas chaves.
+            '@select' => 'id,result,evaluationData,registration,user,status,createTimestamp,updateTimestamp,originalScore,correctedScore,scoreDifference',
             'id' => API::IN($evaluation_ids),
             "status" => API::GTE(0),
             '@permissions' => 'view'

--- a/src/modules/Opportunities/components/opportunity-evaluations-table/init.php
+++ b/src/modules/Opportunities/components/opportunity-evaluations-table/init.php
@@ -160,6 +160,11 @@ $headers = [
     [ 'text' => i::__('ID agente avaliador', 'opportunity-evaluations-table'), 'value' => 'valuer?.id', 'slug' => 'valuerAgentId', 'visible' => true, 'width' => '120px' ],
     [ 'text' => i::__('avaliador', 'opportunity-evaluations-table'), 'value' =>  'valuer?.name', 'slug' => 'evaluator', 'visible' => true],
     [ 'text' => i::__('Resultado do avaliador', 'opportunity-evaluations-table'), 'value' => 'evaluation?.resultString', 'slug' => 'result'],
+    // F4 (#20) — CA-11: nota original/corrigida/diferença por slot, computadas
+    // pelo módulo OpportunityAppealPhase no findEvaluations (via hook ApiQuery).
+    [ 'text' => i::__('Nota original', 'opportunity-evaluations-table'), 'value' => 'evaluation?.originalScore', 'slug' => 'originalScore'],
+    [ 'text' => i::__('Nota corrigida', 'opportunity-evaluations-table'), 'value' => 'evaluation?.correctedScore', 'slug' => 'correctedScore'],
+    [ 'text' => i::__('Diferença', 'opportunity-evaluations-table'), 'value' => 'evaluation?.scoreDifference', 'slug' => 'scoreDifference'],
     [ 'text' => i::__('Tipo de proponente', 'opportunity-evaluations-table'), 'value' => 'proponentType', 'slug' => 'proponentType'],
     [ 'text' => i::__('Categoria', 'opportunity-evaluations-table'), 'value' => 'category', 'slug' => 'category'],
     [ 'text' => i::__('Faixa', 'opportunity-evaluations-table'), 'value' => 'range', 'slug' => 'range'],

--- a/src/modules/Opportunities/components/opportunity-evaluations-table/script.js
+++ b/src/modules/Opportunities/components/opportunity-evaluations-table/script.js
@@ -221,6 +221,13 @@ app.component('opportunity-evaluations-table', {
             // Campos de isenção por selos (spec §4.3). Atribuídos explicitamente
             // para garantir disponibilidade independentemente de serem colunas
             // ou campos derivados no Registration.
+
+            // F4 (#20): `evaluation` é atribuído CRU (sem Entity.populate) —
+            // por isso as colunas computadas por slot (originalScore/
+            // correctedScore/scoreDifference, hook ApiQuery do módulo
+            // OpportunityAppealPhase) sobrevivem aqui sem cópia manual. Se
+            // este processor algum dia popular o evaluation via SDK, copiar
+            // as chaves como o rawProcessor da opportunity-registrations-table.
             reg.sealExemptionStatus = rawData.registration?.sealExemptionStatus ?? null;
             reg.sealExemptionTimestamp = rawData.registration?.sealExemptionTimestamp ?? null;
 
@@ -323,6 +330,17 @@ app.component('opportunity-evaluations-table', {
         dateFormat(date) {
             let mcdate = new McDate (date);
             return mcdate.date('2-digit year');
+        },
+
+        // F4 (#20): colunas de nota — null vira "-", números sem zeros à direita.
+        formatScoreColumn(value) {
+            if (value === null || value === undefined) {
+                return '-';
+            }
+
+            const number = Number(value);
+
+            return Number.isFinite(number) ? String(parseFloat(number.toFixed(2))) : '-';
         },
 
         onChange(event, onInput, entities) {

--- a/src/modules/Opportunities/components/opportunity-evaluations-table/template.php
+++ b/src/modules/Opportunities/components/opportunity-evaluations-table/template.php
@@ -14,11 +14,12 @@ $opportunity = $this->getOpportunityFromEntity($entity);
 $has_seal_exemption_config = SealExemptionService::hasActiveConfig(
     $opportunity->evaluationMethodConfiguration?->sealExemptionConfig
 );
+// F4 (#20): colunas de nota por slot visíveis por padrão (CA-11)
 $required_fields = 'number,committeeSequentialNumber,valuerUserId,valuerAgentId,evaluator,result,status,delete';
-$visible_fields = "['agent', 'number', 'committeeSequentialNumber', 'valuerUserId', 'valuerAgentId', 'evaluator', 'result', 'status', 'coletivo', 'goalStatuses']";
+$visible_fields = "['agent', 'number', 'committeeSequentialNumber', 'valuerUserId', 'valuerAgentId', 'evaluator', 'result', 'originalScore', 'correctedScore', 'scoreDifference', 'status', 'coletivo', 'goalStatuses']";
 if ($has_seal_exemption_config) {
     $required_fields = 'number,committeeSequentialNumber,valuerUserId,valuerAgentId,evaluator,result,status,sealExemptionStatus,sealExemptionTimestamp,delete';
-    $visible_fields = "['agent', 'number', 'committeeSequentialNumber', 'valuerUserId', 'valuerAgentId', 'evaluator', 'result', 'status', 'sealExemption', 'coletivo', 'goalStatuses']";
+    $visible_fields = "['agent', 'number', 'committeeSequentialNumber', 'valuerUserId', 'valuerAgentId', 'evaluator', 'result', 'originalScore', 'correctedScore', 'scoreDifference', 'status', 'sealExemption', 'coletivo', 'goalStatuses']";
 }
 
 $this->import('
@@ -137,6 +138,27 @@ $this->import('
 
                 <template #result="{entity}">
                     {{getResultString(entity)}}
+                </template>
+
+                <!-- F4 (#20) — CA-11: nota original/corrigida/diferença por slot -->
+                <template #originalScore="{entity}">
+                    {{ formatScoreColumn(entity.evaluation?.originalScore) }}
+                </template>
+
+                <template #correctedScore="{entity}">
+                    {{ formatScoreColumn(entity.evaluation?.correctedScore) }}
+                </template>
+
+                <template #scoreDifference="{entity}">
+                    <span
+                        v-if="entity.evaluation?.scoreDifference !== null && entity.evaluation?.scoreDifference !== undefined"
+                        class="semibold"
+                        :class="entity.evaluation.scoreDifference > 0
+                            ? 'success__color'
+                            : (entity.evaluation.scoreDifference < 0 ? 'danger__color' : '')">
+                        {{ formatScoreColumn(entity.evaluation.scoreDifference) }}
+                    </span>
+                    <span v-else>-</span>
                 </template>
 
                 <template #coletivo="{entity}">

--- a/src/modules/Opportunities/components/opportunity-registrations-table/init.php
+++ b/src/modules/Opportunities/components/opportunity-registrations-table/init.php
@@ -92,6 +92,24 @@ $default_headers = [
         'text' => i::__('Divisão geográfica do responsável – País'),
         'value' => 'owner?.geoPais',
     ],
+    // F4 (#20) — CA-11: médias por inscrição (computadas pelo módulo
+    // OpportunityAppealPhase no findResult da ApiQuery; o slug entra no
+    // default_select pelo merge de headers abaixo).
+    [
+        'text' => i::__('Média original'),
+        'value' => 'averageOriginalScore',
+        'slug' => 'averageOriginalScore',
+    ],
+    [
+        'text' => i::__('Média corrigida'),
+        'value' => 'averageCorrectedScore',
+        'slug' => 'averageCorrectedScore',
+    ],
+    [
+        'text' => i::__('Diferença'),
+        'value' => 'scoreDifference',
+        'slug' => 'scoreDifference',
+    ],
 ];
 
 if($phase->isReportingPhase || $phase->isFinalReportingPhase) {

--- a/src/modules/Opportunities/components/opportunity-registrations-table/script.js
+++ b/src/modules/Opportunities/components/opportunity-registrations-table/script.js
@@ -94,6 +94,20 @@ app.component('opportunity-registrations-table', {
         let order = 'status DESC,consolidatedResult DESC';
         let consolidatedResultOrder = 'consolidatedResult';
 
+        /*
+            F1 (#17) — override 2026-09-08 (épica #7): a coluna vive na lista
+            de inscritos da FASE DE RECURSO. O contexto (appealContexts) é
+            injetado pelo init.php do componente
+            opportunity-appeal-correction-assignment SOMENTE quando a fase em
+            contexto é a própria fase de recurso ativa, com fase pai técnica,
+            e o usuário tem @control na fase pai (gates espelhados de
+            RegistrationAppealReview::eligibleCorrectors()) — a presença da
+            chave já carrega a checagem de permissão.
+        */
+        const appeal_correction_config = $MAPAS.config.appealCorrectionAssignment || {};
+        const appeal_context = appeal_correction_config.appealContexts?.[this.phase.id] ?? null;
+        const appeal_correction_enabled = appeal_context != null;
+
         const fieldTypes = ['select', 'boolean', 'checkbox', 'multiselect', 'checkboxes', 'agent-owner-field', 'agent-collective-field'];
 
         for(let key of Object.keys($DESC)) {
@@ -184,7 +198,12 @@ app.component('opportunity-registrations-table', {
                 visible += ',range';
             }
         }
-        
+
+        // F1 (#17): coluna de designação de correção visível apenas no contexto elegível
+        if(appeal_correction_enabled) {
+            visible += ',appealCorrection';
+        }
+
         return {
             sortOptions,
             filters: {},
@@ -202,6 +221,9 @@ app.component('opportunity-registrations-table', {
             order,
             avaliableFields,
             visible,
+            appealCorrectionEnabled: appeal_correction_enabled,
+            appealMainPhaseId: appeal_context?.mainPhaseId ?? null,
+            appealMainRegistrations: {},
             isAffirmativePoliciesActive,
             hadTechnicalEvaluationPhase,
             isTechnicalEvaluationPhase,
@@ -338,6 +360,17 @@ app.component('opportunity-registrations-table', {
                 itens.push({ text: __('Resultado final', 'opportunity-registrations-table'), value: "status", width: '250px', stickyRight: true})
             } else {
                 itens.push({ text: __('status', 'opportunity-registrations-table'), value: "status", width: '250px', stickyRight: true})
+            }
+
+            // F1 (#17): coluna de designação de correção (recurso deferido),
+            // imediatamente antes da coluna de status (sticky right). A coluna
+            // também pode ser exposta no contexto de resultados pelo hook
+            // component(opportunity-results-table).visibleColumns.
+            if(this.appealCorrectionEnabled && !itens.some(item => item.value === 'appealCorrection')) {
+                itens.splice(itens.length - 1, 0, {
+                    text: __('Designar correção', 'opportunity-registrations-table'),
+                    value: 'appealCorrection',
+                });
             }
 
             const type = this.phase.evaluationMethodConfiguration?.type?.id;
@@ -580,6 +613,77 @@ app.component('opportunity-registrations-table', {
         generateOrDownloadZip(entity) {
             const apiUrl = Utils.createUrl('registration', 'createZipFiles', { id: entity.id });
             window.open(apiUrl, '_blank');
+        },
+
+        /**
+         * F1 (#17) — override 2026-09-08: o botão vive na linha do recurso
+         * com status Deferido (10) da lista da fase de recurso. Abre o modal
+         * de designação (F2) pela interface pública documentada no init.php
+         * do componente opportunity-appeal-correction-assignment, com
+         * {opportunity: fase PRINCIPAL, registration: inscrição da fase
+         * PRINCIPAL} — ambos derivados da linha da fase de recurso. O modal
+         * decide o que exibir (designação ou acompanhamento).
+         */
+        async openAppealCorrectionAssignment(entity) {
+            const main_registration = await this.findMainPhaseRegistration(entity);
+
+            if (!main_registration) {
+                return;
+            }
+
+            window.dispatchEvent(new CustomEvent('opportunity-appeal-correction-assignment:open', {
+                detail: {
+                    opportunity: { id: this.appealMainPhaseId },
+                    registration: { id: main_registration.id, number: main_registration.number },
+                },
+            }));
+        },
+
+        /**
+         * F1 (#17): deriva a inscrição da fase principal a partir da
+         * inscrição da fase de recurso. A inscrição de recurso herda o
+         * `number` da inscrição principal (createAppealPhaseRegistration,
+         * OpportunityAppealPhase/Module.php:201) e não existe meta/relation
+         * armazenada ligando as duas — o casamento por `number` na fase pai
+         * é o mecanismo canônico do backend (Module.php:240-243). Uma
+         * chamada por inscrição, cacheada para cliques repetidos.
+         */
+        async findMainPhaseRegistration(appealRegistration) {
+            const appeal_registration_id = appealRegistration?.id;
+
+            if (!appeal_registration_id || !this.appealMainPhaseId) {
+                return null;
+            }
+
+            if (this.appealMainRegistrations[appeal_registration_id]) {
+                return this.appealMainRegistrations[appeal_registration_id];
+            }
+
+            const api = new API('registration');
+
+            try {
+                const found = await api.find({
+                    'opportunity': `EQ(${this.appealMainPhaseId})`,
+                    'number': `EQ(${appealRegistration.number})`,
+                    '@select': 'id,number',
+                    '@permissions': 'view',
+                });
+
+                const main_registration = (found || [])[0] || null;
+
+                if (!main_registration) {
+                    throw new Error(`inscrição da fase principal não encontrada (number=${appealRegistration.number})`);
+                }
+
+                this.appealMainRegistrations[appeal_registration_id] = main_registration;
+
+                return main_registration;
+            } catch (error) {
+                console.error('opportunity-registrations-table:findMainPhaseRegistration', error);
+                this.messages.error(this.text('inscrição da fase principal não encontrada'));
+
+                return null;
+            }
         }
     }
 });

--- a/src/modules/Opportunities/components/opportunity-registrations-table/script.js
+++ b/src/modules/Opportunities/components/opportunity-registrations-table/script.js
@@ -6,8 +6,9 @@ app.component('opportunity-registrations-table', {
             required: true
         },
         visibleColumns: {
+            // F4 (#20): médias de nota visíveis por padrão (CA-11)
             type: Array,
-            default: ["agent", "status", "category", "consolidatedResult", "editable","updateTimestamp","sentTimestamp","createTimestamp"],
+            default: ["agent", "status", "category", "consolidatedResult", "averageOriginalScore", "averageCorrectedScore", "scoreDifference", "editable","updateTimestamp","sentTimestamp","createTimestamp"],
         },
         identifier: {
             type: String,
@@ -431,8 +432,44 @@ app.component('opportunity-registrations-table', {
     },
 
     methods: {
+        /**
+         * Pipeline das linhas da lista de inscritos.
+         *
+         * F4 (#20): as colunas computadas de nota (averageOriginalScore,
+         * averageCorrectedScore, scoreDifference) vêm da API (hook
+         * ApiQuery(registration).findResult do OpportunityAppealPhase), mas o
+         * Entity.populate() do SDK DESCARTA propriedades fora de
+         * $PROPERTIES/$RELATIONS — com o pipeline padrão do mc-entities as
+         * chaves morriam entre a resposta HTTP e o render (célula "-").
+         * Com rawProcessor o fetch vira raw (mc-entities/script.js:137-140)
+         * e este método povoa a entidade e copia as chaves computadas da
+         * resposta bruta.
+         */
+        rawProcessor(rawData) {
+            const registrationApi = new API('registration');
+            const registration = registrationApi.getEntityInstance(rawData.id);
+            registration.populate(rawData, true);
+
+            registration.averageOriginalScore = rawData.averageOriginalScore ?? null;
+            registration.averageCorrectedScore = rawData.averageCorrectedScore ?? null;
+            registration.scoreDifference = rawData.scoreDifference ?? null;
+
+            return registration;
+        },
+
         getStatus(actualStatus) {
             return this.statusDict.find(status => status.value === actualStatus);
+        },
+
+        // F4 (#20): colunas de média/nota — null vira "-", números sem zeros à direita.
+        formatScoreColumn(value) {
+            if (value === null || value === undefined) {
+                return '-';
+            }
+
+            const number = Number(value);
+
+            return Number.isFinite(number) ? String(parseFloat(number.toFixed(2))) : '-';
         },
 
         setStatus(selected, entity) {

--- a/src/modules/Opportunities/components/opportunity-registrations-table/template.php
+++ b/src/modules/Opportunities/components/opportunity-registrations-table/template.php
@@ -184,6 +184,14 @@ $entity = $this->controller->requestedEntity;
                     <a v-if="entity.goalStatuses" :href="entity.singleUrl + '#ficha'" class="entity-table__goals">{{entity.goalStatuses['10']}}/{{entity.goalStatuses.numGoals}} <?= i::__('concluídas') ?></a>
                 </template>
 
+                <?php /* F1 (#17) — override 2026-09-08: ação de designação de correção na lista da FASE DE RECURSO — botão apenas nas linhas com status Deferido (10), valor nativo da lista (a coluna em si só existe em contexto elegível: fase de recurso ativa, pai técnico, gestor com @control na fase pai, via config do opportunity-appeal-correction-assignment). O clique deriva a inscrição da fase principal e abre o modal de designação (F2), que exibe acompanhamento quando já existem designações. */ ?>
+                <template #appealCorrection="{entity}">
+                    <button v-if="entity.status == 10" class="button button--icon button--sm button--text opportunity-registration-table__appeal-correction" @click="openAppealCorrectionAssignment(entity)">
+                        <mc-icon name="edit"></mc-icon> <?= i::__('Designar correção') ?>
+                    </button>
+                    <span v-else>&nbsp;</span>
+                </template>
+
             </entity-table>
         </div>
     </template>

--- a/src/modules/Opportunities/components/opportunity-registrations-table/template.php
+++ b/src/modules/Opportunities/components/opportunity-registrations-table/template.php
@@ -41,7 +41,7 @@ $entity = $this->controller->requestedEntity;
             <?php $this->applyTemplateHook('registration-list-actions', 'after', ['entity' => $entity]); ?>
         </template>
         <div class="col-12"> 
-            <entity-table controller="opportunity" endpoint="findRegistrations" :identifier="identifier" type="registration" :query="query" :limit="100" :sort-options="sortOptions" :order="order" :select="select" :headers="headers" phase:="phase" required="number,options" :visible="visible" @clear-filters="clearFilters" @remove-filter="removeFilter($event)" show-index :hide-filters="hideFilters" :hide-sort="hideSort" :hide-actions='hideActions' :hide-header="hideHeader">
+            <entity-table controller="opportunity" endpoint="findRegistrations" :identifier="identifier" type="registration" :query="query" :limit="100" :sort-options="sortOptions" :order="order" :select="select" :headers="headers" phase:="phase" required="number,options" :visible="visible" :raw-processor="rawProcessor" @clear-filters="clearFilters" @remove-filter="removeFilter($event)" show-index :hide-filters="hideFilters" :hide-sort="hideSort" :hide-actions='hideActions' :hide-header="hideHeader">
                 <template #title>
                     <slot name="title"></slot>
                 </template>
@@ -128,8 +128,29 @@ $entity = $this->controller->requestedEntity;
                     <span v-else>&nbsp;</span>
                 </template>
 
-                <template #consolidatedResult="{entity}"> 
+                <template #consolidatedResult="{entity}">
                     {{consolidatedResultToString(entity)}}
+                </template>
+
+                <!-- F4 (#20) — CA-11: médias por inscrição -->
+                <template #averageOriginalScore="{entity}">
+                    {{ formatScoreColumn(entity.averageOriginalScore) }}
+                </template>
+
+                <template #averageCorrectedScore="{entity}">
+                    {{ formatScoreColumn(entity.averageCorrectedScore) }}
+                </template>
+
+                <template #scoreDifference="{entity}">
+                    <span
+                        v-if="entity.scoreDifference !== null && entity.scoreDifference !== undefined"
+                        class="semibold"
+                        :class="entity.scoreDifference > 0
+                            ? 'success__color'
+                            : (entity.scoreDifference < 0 ? 'danger__color' : '')">
+                        {{ formatScoreColumn(entity.scoreDifference) }}
+                    </span>
+                    <span v-else>-</span>
                 </template>
 
                 <template #agent="{entity}">

--- a/src/modules/Opportunities/components/opportunity-registrations-table/texts.php
+++ b/src/modules/Opportunities/components/opportunity-registrations-table/texts.php
@@ -38,4 +38,6 @@ return [
     'aguardando desempate' => i::__('Aguardando desempate'),
     'Elegível para cotas' => i::__('Elegível para cotas'),
     'Elegível para as cotas' => i::__('Elegível para cotas'),
+    'Designar correção' => i::__('Designar correção'),
+    'inscrição da fase principal não encontrada' => i::__('Não foi possível localizar a inscrição da fase principal deste recurso'),
 ];

--- a/src/modules/Opportunities/components/registration-status/script.js
+++ b/src/modules/Opportunities/components/registration-status/script.js
@@ -22,9 +22,16 @@ app.component('registration-status', {
 
     data() {
         return {
-            processing: false, 
+            processing: false,
             entity: null,
+            // F8 (#21): notas do fluxo preliminar → recurso → final do próprio
+            // proponente (buscadas só quando publicado; leitura raw).
+            flowScores: null,
         }
+    },
+
+    mounted() {
+        this.loadAppealFlowScores();
     },
 
     computed: {
@@ -45,6 +52,61 @@ app.component('registration-status', {
             }
 
             return $MAPAS.registrationPhases[appealPhaseId] || this.entity;
+        },
+
+        /*
+         * F8 (#21) — fluxo preliminar → recurso → reavaliação → final.
+         * Gates espelham os server-side do PR3 (Opportunity::
+         * areRegistrationResultsPublished): o que não está publicado não é
+         * buscado nem exibido (critério de privacidade 5).
+         */
+        preliminaryPublished() {
+            return !!(this.opportunity.publishedRegistrations || this.opportunity.publishedPreliminaryRegistrations);
+        },
+
+        finalPublished() {
+            return !!this.opportunity.publishedRegistrations;
+        },
+
+        showAppealFlow() {
+            return !!this.appealPhase
+                && !this.opportunity.isAppealPhase
+                && (this.preliminaryPublished || !!this.appealRegistration?.id);
+        },
+
+        flowPreliminaryScore() {
+            return this.flowScores?.averageOriginalScore ?? null;
+        },
+
+        flowCorrectedScore() {
+            return this.flowScores?.averageCorrectedScore ?? null;
+        },
+
+        flowHasCorrection() {
+            return this.flowScores !== null
+                && this.flowScores.scoreDifference !== null
+                && this.flowScores.scoreDifference !== 0;
+        },
+
+        appealFlowStatusLabel() {
+            const appeal_registration = this.appealRegistration;
+            if (!appeal_registration?.id) {
+                return '';
+            }
+
+            if (appeal_registration.status == 0) {
+                return this.text('flow draft');
+            }
+
+            if (appeal_registration.status == 1) {
+                return this.text('flow sent awaiting');
+            }
+
+            // Veredito (deferido/indeferido/...) só quando o método expõe ao
+            // dono — mesmo gate server-side do bloco [Recurso] existente.
+            return this.shouldDisplayEvaluationResults(appeal_registration)
+                ? (this.appealPhase?.statusLabels?.[appeal_registration.status] ?? this.text('flow under analysis'))
+                : this.text('flow under analysis');
         },
 
         canShowAppeal() {
@@ -89,6 +151,39 @@ app.component('registration-status', {
     },
 
     methods: {
+        /**
+         * F8 (#21): notas do fluxo (médias original/corrigida da própria
+         * inscrição — propriedades computadas do módulo OpportunityAppealPhase,
+         * expostas ao dono pela API de registration).
+         *
+         * Privacidade: busca SÓ quando há resultado publicado (preliminar ou
+         * final — o mesmo gate server-side do status); leitura raw porque o
+         * populate do SDK descarta as chaves virtuais. Erros deixam o fluxo
+         * sem notas (passos exibem "—"), nunca bloqueiam a página.
+         */
+        async loadAppealFlowScores() {
+            if (!this.showAppealFlow || !this.preliminaryPublished || !this.registration?.id) {
+                return;
+            }
+
+            try {
+                const api = new API('registration');
+                const rows = await api.fetch('find', {
+                    '@select': 'id,averageOriginalScore,averageCorrectedScore,scoreDifference',
+                    'id': `EQ(${this.registration.id})`,
+                }, { raw: true, rawProcessor: data => data });
+
+                this.flowScores = rows?.[0] || null;
+            } catch (error) {
+                console.error('registration-status:loadAppealFlowScores', error);
+                this.flowScores = null;
+            }
+        },
+
+        flowScoreOrDash(value) {
+            return (value === null || value === undefined) ? '—' : this.formatNote(value);
+        },
+
         showPhaseDates() {
             const firstPhase = $MAPAS.opportunityPhases?.find((phase) => phase.isFirstPhase) || this.firstPhase;
             return !firstPhase?.hidePhaseDates;

--- a/src/modules/Opportunities/components/registration-status/style.css
+++ b/src/modules/Opportunities/components/registration-status/style.css
@@ -1,0 +1,63 @@
+/*
+ * registration-status (F8 #21)
+ *
+ * Estilo local no padrão do módulo (auto-enfileirado, sem build): apenas o
+ * fluxo preliminar → recurso → reavaliação → final do proponente; o restante
+ * usa as classes do tema (timeline/badges). Mobile: passos empilham.
+ */
+
+.registration-status__appeal-flow {
+    border: 1px solid var(--mc-gray-300);
+    border-radius: var(--mc-border-radius-sm);
+    display: flex;
+    flex-direction: column;
+    gap: .5rem;
+    margin-top: .75rem;
+    padding: .75rem;
+}
+
+.registration-status__appeal-flow-title {
+    margin: 0;
+}
+
+.registration-status__appeal-flow-steps {
+    display: flex;
+    flex-direction: column;
+    gap: .5rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.registration-status__appeal-flow-step {
+    align-items: flex-start;
+    display: flex;
+    flex-wrap: wrap;
+    font-size: .875rem;
+    gap: .5rem;
+}
+
+.registration-status__appeal-flow-label {
+    flex: 0 0 10rem;
+}
+
+.registration-status__appeal-flow-dot {
+    background-color: var(--mc-gray-300);
+    border-radius: var(--mc-border-radius-pill);
+    display: inline-block;
+    flex: 0 0 auto;
+    height: .5rem;
+    margin-top: .35rem;
+    width: .5rem;
+}
+
+.registration-status__appeal-flow-dot--final {
+    background-color: var(--mc-primary-500);
+}
+
+@media (max-width: 800px) {
+    .registration-status__appeal-flow-step {
+        flex-direction: column;
+        gap: .25rem;
+    }
+}

--- a/src/modules/Opportunities/components/registration-status/template.php
+++ b/src/modules/Opportunities/components/registration-status/template.php
@@ -72,3 +72,46 @@ $this->import('
 
     </div>
 </div>
+
+<!--
+    F8 (#21): fluxo do proponente — resultado preliminar → recurso →
+    reavaliação → resultado final. Cada passo só renderiza quando publicado
+    (gates espelhando o server-side do PR3); nada publicado → seção omitida.
+-->
+<section
+    v-if="showAppealFlow"
+    class="registration-status__appeal-flow"
+    :aria-label="text('flow title')">
+
+    <h4 class="semibold registration-status__appeal-flow-title"><?= i::__('Fluxo do recurso') ?></h4>
+
+    <ol class="registration-status__appeal-flow-steps">
+        <!-- 1. Resultado preliminar -->
+        <li v-if="preliminaryPublished" class="registration-status__appeal-flow-step">
+            <span class="registration-status__appeal-flow-dot" aria-hidden="true"></span>
+            <span class="semibold registration-status__appeal-flow-label"><?= i::__('Resultado preliminar') ?></span>
+            <span><?= i::__('Nota preliminar') ?>: <strong>{{ flowScoreOrDash(flowPreliminaryScore) }}</strong></span>
+        </li>
+
+        <!-- 2. Recurso (status do próprio proponente; veredito gated server-side) -->
+        <li v-if="appealRegistration?.id" class="registration-status__appeal-flow-step">
+            <span class="registration-status__appeal-flow-dot" aria-hidden="true"></span>
+            <span class="semibold registration-status__appeal-flow-label"><?= i::__('Recurso') ?></span>
+            <span :id="'appeal-flow-status-' + registration.id">{{ appealFlowStatusLabel }}</span>
+        </li>
+
+        <!-- 3. Reavaliação (nota pós-correção; só com resultado final publicado) -->
+        <li v-if="finalPublished && flowHasCorrection" class="registration-status__appeal-flow-step">
+            <span class="registration-status__appeal-flow-dot" aria-hidden="true"></span>
+            <span class="semibold registration-status__appeal-flow-label"><?= i::__('Reavaliação') ?></span>
+            <span><?= i::__('Nota após correção') ?>: <strong>{{ flowScoreOrDash(flowCorrectedScore) }}</strong></span>
+        </li>
+
+        <!-- 4. Resultado final -->
+        <li v-if="finalPublished" class="registration-status__appeal-flow-step">
+            <span class="registration-status__appeal-flow-dot registration-status__appeal-flow-dot--final" aria-hidden="true"></span>
+            <span class="semibold registration-status__appeal-flow-label"><?= i::__('Resultado final') ?></span>
+            <span><?= i::__('Nota final') ?>: <strong>{{ flowScoreOrDash(flowCorrectedScore) }}</strong></span>
+        </li>
+    </ol>
+</section>

--- a/src/modules/Opportunities/components/registration-status/texts.php
+++ b/src/modules/Opportunities/components/registration-status/texts.php
@@ -3,5 +3,11 @@ use MapasCulturais\i;
 
 return [
     'Solicitação de recurso criada com sucesso' => 'Solicitação de recurso criada com sucesso',
-    'Não enviada' => 'Não enviada'
+    'Não enviada' => 'Não enviada',
+
+    // F8 (#21): fluxo preliminar → recurso → reavaliação → final
+    'flow title' => i::__('Fluxo do recurso'),
+    'flow draft' => i::__('Rascunho — finalize o formulário do recurso'),
+    'flow sent awaiting' => i::__('Enviada — aguardando análise'),
+    'flow under analysis' => i::__('Em análise'),
 ];

--- a/src/modules/Opportunities/views/opportunity/registrations.php
+++ b/src/modules/Opportunities/views/opportunity/registrations.php
@@ -14,6 +14,7 @@ $this->import('
     entity-actions
     mc-breadcrumb
     mc-link
+    opportunity-appeal-correction-assignment
     opportunity-form-builder
     opportunity-header
     opportunity-registrations-table
@@ -33,4 +34,7 @@ $this->import('
 
         <opportunity-registrations-table identifier="registrationsList" :phase="entity"></opportunity-registrations-table>
     </div>
+
+    <?php /* F1 (#17): modal de designação de correção (F2), aberto por evento global pela tabela acima; renderizado uma única vez na view (o init.php dele também injeta o contexto de @control/fase de recurso consumido pela coluna) */ ?>
+    <opportunity-appeal-correction-assignment></opportunity-appeal-correction-assignment>
 </div>

--- a/src/modules/OpportunityAppealPhase/AppealReview/CorrectorEnvironment.php
+++ b/src/modules/OpportunityAppealPhase/AppealReview/CorrectorEnvironment.php
@@ -41,6 +41,11 @@ class CorrectorEnvironment
 
         $payload = [
             'assignmentId' => (int) $review->id,
+            'evaluationId' => (int) $slot->id,
+            'registrationId' => (int) $review->registration->id,
+            'registrationNumber' => $review->registration->number,
+            'opportunityName' => (string) $review->registration->opportunity->name,
+            'criteria' => $this->buildCriteriaMetadata($slot, $scope_ids),
             'targetEvaluatorName' => $this->resolveEvaluatorName($review),
             'deadline' => $review->endsAt ? $review->endsAt->format('c') : null,
             'status' => self::STATUS_LABELS[(int) $review->status] ?? (string) $review->status,
@@ -100,6 +105,72 @@ class CorrectorEnvironment
         }
 
         return $owner ? (string) $owner->email : '';
+    }
+
+    /**
+     * Metadata of the criteria released for correction, from the MAIN phase
+     * evaluation method configuration (not the appeal phase). Criteria ids in
+     * the scope that do not exist in the configuration are ignored.
+     *
+     * @param string[]|null $scope_ids null = all criteria
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildCriteriaMetadata(RegistrationEvaluation $slot, ?array $scope_ids): array
+    {
+        $emc = $slot->registration->opportunity->evaluationMethodConfiguration;
+        if (!$emc) {
+            return [];
+        }
+
+        $sections = $emc->sections ?? [];
+        $criteria = $emc->criteria ?? [];
+
+        // metadata may still be raw JSON strings before unserialize (same normalization
+        // as EvaluationMethodConfiguration::validateCriteriaSectionsIntegrity)
+        if (is_string($sections)) {
+            $sections = json_decode($sections);
+        }
+        if (is_string($criteria)) {
+            $criteria = json_decode($criteria);
+        }
+
+        $sections = (array) $sections;
+        $criteria = (array) $criteria;
+
+        $section_names = [];
+        foreach ($sections as $section) {
+            $section = (object) $section;
+            if (isset($section->id)) {
+                $section_names[(string) $section->id] = (string) ($section->name ?? '');
+            }
+        }
+
+        $out = [];
+        foreach ($criteria as $criterion) {
+            $criterion = (object) $criterion;
+            if (!isset($criterion->id)) {
+                continue;
+            }
+
+            $id = (string) $criterion->id;
+            if ($scope_ids !== null && !in_array($id, $scope_ids, true)) {
+                continue;
+            }
+
+            $sid = isset($criterion->sid) ? (string) $criterion->sid : null;
+
+            $out[] = [
+                'id' => $id,
+                'title' => (string) ($criterion->title ?? $id),
+                'min' => (float) ($criterion->min ?? 0),
+                'max' => (float) ($criterion->max ?? 0),
+                'weight' => (float) ($criterion->weight ?? 1),
+                'sectionId' => $sid,
+                'sectionName' => $sid !== null ? ($section_names[$sid] ?? '') : null,
+            ];
+        }
+
+        return $out;
     }
 
     /**

--- a/src/modules/OpportunityAppealPhase/AppealReview/CorrectorEnvironment.php
+++ b/src/modules/OpportunityAppealPhase/AppealReview/CorrectorEnvironment.php
@@ -39,12 +39,19 @@ class CorrectorEnvironment
             ? $this->filterEvaluationData((array) $review->correctedValue, $scope_ids)
             : null;
 
+        $main_emc = $slot->registration->opportunity->evaluationMethodConfiguration;
+        $method_id = $main_emc ? (string) $main_emc->type->id : '';
+
         $payload = [
             'assignmentId' => (int) $review->id,
             'evaluationId' => (int) $slot->id,
             'registrationId' => (int) $review->registration->id,
             'registrationNumber' => $review->registration->number,
             'opportunityName' => (string) $review->registration->opportunity->name,
+            // F7 (#51): método da fase principal — define como o frontend
+            // renderiza o formulário (critérios técnicos, campos documentais
+            // ou resultado global do simples).
+            'method' => $method_id,
             'criteria' => $this->buildCriteriaMetadata($slot, $scope_ids),
             'targetEvaluatorName' => $this->resolveEvaluatorName($review),
             'deadline' => $review->endsAt ? $review->endsAt->format('c') : null,
@@ -53,6 +60,12 @@ class CorrectorEnvironment
             'originalEvaluation' => (object) $original,
             'draft' => $draft !== null ? (object) $draft : null,
         ];
+
+        if ($method_id === 'documentary') {
+            $payload['fields'] = $this->buildDocumentaryFields($review, $scope_ids);
+        } elseif ($method_id === 'simple') {
+            $payload['statusOptions'] = $this->buildSimpleStatusOptions();
+        }
 
         if ($this->shouldShowAppealOpinion($review)) {
             $payload['committeeOpinion'] = $this->buildCommitteeOpinion($review);
@@ -171,6 +184,63 @@ class CorrectorEnvironment
         }
 
         return $out;
+    }
+
+    /**
+     * F7 (#51): campos exigidos pela qualificação documental (mesma fonte do
+     * formulário documentary-evaluation-form): configurações de campo e de
+     * anexo das fases da oportunidade, chaveadas por fieldName/fileGroupName
+     * — as mesmas chaves do evaluationData e do releasedScope. Filtrado pelo
+     * escopo liberado.
+     *
+     * @param string[]|null $scope_ids null = todos
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildDocumentaryFields(RegistrationAppealReview $review, ?array $scope_ids): array
+    {
+        $main_phase = $review->registration->opportunity;
+
+        $items = [];
+
+        foreach ($main_phase->allPhases as $phase) {
+            foreach ($phase->registrationFieldConfigurations as $field) {
+                $items[$field->getFieldName()] = (string) ($field->title ?? $field->getFieldName());
+            }
+
+            foreach ($phase->registrationFileConfigurations as $file) {
+                $items[$file->fileGroupName] = (string) ($file->title ?? $file->fileGroupName);
+            }
+        }
+
+        $out = [];
+        foreach ($items as $id => $title) {
+            if ($scope_ids !== null && !in_array((string) $id, $scope_ids, true)) {
+                continue;
+            }
+
+            $out[] = [
+                'id' => (string) $id,
+                'title' => $title,
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * F7 (#51): opções de resultado global do método simples — mesmas
+     * values/labels do formulário simple-evaluation-form.
+     *
+     * @return array<int, array<string, string>>
+     */
+    private function buildSimpleStatusOptions(): array
+    {
+        return [
+            ['value' => '2', 'label' => i::__('Inválida')],
+            ['value' => '3', 'label' => i::__('Não selecionada')],
+            ['value' => '8', 'label' => i::__('Suplente')],
+            ['value' => '10', 'label' => i::__('Selecionada')],
+        ];
     }
 
     /**

--- a/src/modules/OpportunityAppealPhase/AppealReview/Service.php
+++ b/src/modules/OpportunityAppealPhase/AppealReview/Service.php
@@ -47,7 +47,7 @@ class Service
         }
 
         $this->assertWithinWindow($review);
-        $this->assertTechnicalSlot($slot);
+        $this->assertEvaluationMethodResolvable($slot);
 
         if ($corrected_data !== null) {
             $review->correctedValue = (object) (array) $corrected_data;
@@ -208,6 +208,11 @@ class Service
         $revision->save(true);
     }
 
+    /**
+     * Resultado recalculado pelo método do slot (setEvaluationData delega ao
+     * EvaluationMethod::getEvaluationResult): technical = pontuação ponderada;
+     * simple = código do status global; documentary = 1/-1 (válida/inválida).
+     */
     private function computeScore(RegistrationEvaluation $slot, array $evaluation_data): ?float
     {
         $tmp = new RegistrationEvaluation();
@@ -244,10 +249,19 @@ class Service
         }
     }
 
-    private function assertTechnicalSlot(RegistrationEvaluation $slot): void
+    /**
+     * F7 (#51): a correção vale para TODOS os métodos de avaliação (antes
+     * restrita ao técnico). O que a aplicação exige do slot é apenas ter um
+     * método resolvível (EMC presente) — é o método que define o formato do
+     * evaluationData e o cálculo do resultado:
+     * - technical: critérios (ids) → pontuação ponderada;
+     * - documentary: fieldName/fileGroupName → {evaluation, obs} por campo;
+     * - simple: resultado global (status) + obs.
+     */
+    private function assertEvaluationMethodResolvable(RegistrationEvaluation $slot): void
     {
         $emc = $slot->registration->opportunity->evaluationMethodConfiguration;
-        if (!$emc || $emc->type->id !== 'technical') {
+        if (!$emc) {
             throw new PermissionDenied(App::i()->user, $slot, 'applyCorrection');
         }
     }
@@ -256,6 +270,10 @@ class Service
      * Mescla apenas chaves liberadas em released_scope.criteria (ou .fields).
      * Chaves fora do escopo com valor diferente do atual são rejeitadas;
      * chaves fora do escopo iguais ao atual (ex.: rascunho com snapshot completo) são ignoradas.
+     *
+     * Genérico por método (F7): as chaves são as do evaluationData — critérios
+     * (technical), fieldName/fileGroupName (documentary; o obs por campo viaja
+     * DENTRO do objeto do campo) ou status/obs (simple).
      */
     private function mergeWithinReleasedScope(RegistrationEvaluation $slot, RegistrationAppealReview $review, array $incoming): array
     {

--- a/src/modules/OpportunityAppealPhase/Controllers/AppealCorrector.php
+++ b/src/modules/OpportunityAppealPhase/Controllers/AppealCorrector.php
@@ -10,9 +10,11 @@ use OpportunityAppealPhase\AppealReview\CorrectorEnvironment;
 use OpportunityAppealPhase\Entities\RegistrationAppealReview;
 
 /**
- * Ambiente read-only do corretor designado (PR4.5).
+ * Ambiente do corretor designado (issue #19 / F3).
  *
- * GET /appealCorrector/environment/{assignmentId}
+ * GET /appealCorrector/environment/{assignmentId}  -> read-only JSON payload
+ * GET /appealCorrector/correction/{assignmentId}   -> correction page (dumb page:
+ *    permission/deadline/feature flag checks belong to the environment endpoint)
  */
 class AppealCorrector extends Controller
 {
@@ -44,5 +46,28 @@ class AppealCorrector extends Controller
         }
 
         $this->json($payload);
+    }
+
+    function GET_correction()
+    {
+        $this->requireAuthentication();
+
+        $app = App::i();
+
+        $assignment_id = (int) ($this->data['id'] ?? $this->urlData['id'] ?? 0);
+        if (!$assignment_id) {
+            $app->pass();
+        }
+
+        /** @var RegistrationAppealReview|null $review */
+        $review = $app->repo(RegistrationAppealReview::class)->find($assignment_id);
+        if (!$review) {
+            $app->pass();
+        }
+
+        $this->render('correction', [
+            'assignmentId' => (int) $review->id,
+            'assignment' => $review,
+        ]);
     }
 }

--- a/src/modules/OpportunityAppealPhase/Controllers/RegistrationAppealReview.php
+++ b/src/modules/OpportunityAppealPhase/Controllers/RegistrationAppealReview.php
@@ -352,7 +352,9 @@ class RegistrationAppealReview extends EntityController
             }
         }
 
-        if (isset($data['releasedScope'])) {
+        // F6: array_key_exists (não isset) para que releasedScope null LIMPE
+        // a restrição na substituição (todos os critérios liberados).
+        if (array_key_exists('releasedScope', $data)) {
             $review->releasedScope = $this->parseReleasedScope($data['releasedScope']);
             unset($data['releasedScope']);
         }
@@ -465,12 +467,17 @@ class RegistrationAppealReview extends EntityController
 
     /**
      * @param mixed $value array/objeto já decodificado ou string JSON.
+     *
+     * F6 (#49): escopo com lista de critérios explícita e vazia é rejeitado
+     * (null = sem restrição; ao menos um critério quando houver restrição).
      */
     private function parseReleasedScope(mixed $value): ?object
     {
         if ($value === null || $value === '') {
             return null;
         }
+
+        $scope = null;
 
         if (is_string($value)) {
             $decoded = json_decode($value);
@@ -479,10 +486,18 @@ class RegistrationAppealReview extends EntityController
                 $this->errorJson(i::__('releasedScope inválido: esperado objeto JSON.'), 400);
             }
 
-            return $decoded;
+            $scope = $decoded;
+        } else {
+            $scope = (object) (array) $value;
         }
 
-        return (object) (array) $value;
+        $criteria = $scope->criteria ?? $scope->fields ?? null;
+
+        if ($criteria !== null && count((array) $criteria) === 0) {
+            $this->errorJson(i::__('O escopo de critérios não pode ser vazio: selecione ao menos um critério ou envie a designação sem restrição (releasedScope nulo libera todos).'), 400);
+        }
+
+        return $scope;
     }
 
     private function parseDateParam(mixed $value): ?DateTime

--- a/src/modules/OpportunityAppealPhase/Controllers/RegistrationAppealReview.php
+++ b/src/modules/OpportunityAppealPhase/Controllers/RegistrationAppealReview.php
@@ -1,0 +1,502 @@
+<?php
+
+namespace OpportunityAppealPhase\Controllers;
+
+use DateTime;
+use MapasCulturais\App;
+use MapasCulturais\Controllers\EntityController;
+use MapasCulturais\Entities\Registration;
+use MapasCulturais\Entities\RegistrationEvaluation;
+use MapasCulturais\Entities\User;
+use MapasCulturais\i;
+use MapasCulturais\Traits;
+use OpportunityAppealPhase\Entities\RegistrationAppealReview as ReviewEntity;
+
+/**
+ * Controller da entidade RegistrationAppealReview: API de designação de
+ * corretores por slot (PR6 / issue #40).
+ *
+ * Contrato consumido pelo modal e pelo painel de acompanhamento do F2 (#18):
+ * - POST   /registrationappealreview                           → POST_index (designação pelo gestor)
+ * - GET    /api/registrationappealreview/find?registration=…   → API_find (listagem por inscrição, CA-13)
+ * - GET    /api/registrationappealreview/findOne?id=…          → API_findOne
+ * - PUT    /registrationappealreview/single/{id}               → PUT_single (substituir corretor/prazo)
+ * - PATCH  /registrationappealreview/single/{id}               → PATCH_single
+ * - DELETE /registrationappealreview/single/{id}               → DELETE_single (cancelar designação)
+ *
+ * Segurança: a entidade não usa owner nem permission cache, então o pseudo-owner
+ * das checagens genéricas é o próprio usuário logado e as ações canônicas herdadas
+ * de EntityController não restringem por si. Todos os pontos de leitura/escrita
+ * deste controller exigem autenticação e `@control` na oportunidade principal
+ * (fase avaliativa) da inscrição do slot — via checkPermission, nunca ad-hoc.
+ */
+class RegistrationAppealReview extends EntityController
+{
+    use Traits\ControllerAPI;
+
+    /**
+     * Campos da designação derivados do slot no servidor: nunca aceitos do payload.
+     */
+    private const DERIVED_FIELDS = ['registration', 'appealPhase', 'slotOwnerUser'];
+
+    /**
+     * Cria uma designação de correção para um slot de avaliação (CA-4).
+     *
+     * Somente gestores com `@control` na oportunidade principal. O corretor
+     * informado precisa estar entre `eligibleCorrectors()` do slot (CA-3).
+     * Os campos de vinculação (registration, appealPhase, slotOwnerUser) são
+     * derivados do slot no servidor; valores divergentes no payload são
+     * rejeitados. O status inicial é sempre STATUS_DESIGNATED.
+     */
+    function POST_index($data = null)
+    {
+        $this->requireAuthentication();
+        $this->assertFeatureEnabled();
+
+        $app = App::i();
+
+        if (is_null($data)) {
+            $data = $this->postData;
+        }
+
+        if (!is_array($data)) {
+            $this->errorJson(i::__('Corpo da requisição inválido: esperado objeto com os campos da designação.'), 400);
+        }
+
+        $app->applyHookBoundTo($this, "POST({$this->id}.index):data", ['data' => &$data]);
+
+        $slot_id = $this->resolveIdParam($data['originalEvaluation'] ?? null);
+        $corrector_id = $this->resolveIdParam($data['correctorUser'] ?? null);
+
+        if (!$slot_id) {
+            $this->errorJson(i::__('O ID da avaliação original (originalEvaluation) é obrigatório.'), 400);
+        }
+
+        if (!$corrector_id) {
+            $this->errorJson(i::__('O ID do corretor (correctorUser) é obrigatório.'), 400);
+        }
+
+        /** @var RegistrationEvaluation|null $slot */
+        $slot = $app->repo('RegistrationEvaluation')->find($slot_id);
+        if (!$slot) {
+            $this->errorJson(sprintf(i::__('Não existe avaliação com o ID %s.'), $slot_id), 404);
+        }
+
+        /** @var User|null $corrector */
+        $corrector = $app->repo('User')->find($corrector_id);
+        if (!$corrector) {
+            $this->errorJson(sprintf(i::__('Não existe usuário corretor com o ID %s.'), $corrector_id), 404);
+        }
+
+        $registration = $slot->registration;
+        $opportunity = $registration->opportunity;
+
+        // Permissão antes de qualquer validação de domínio: não-gestor recebe 403
+        // sem vencer informação sobre a inscrição, o slot ou a fase de recurso.
+        $opportunity->checkPermission('@control');
+
+        $appeal_phase = $opportunity->appealPhase;
+
+        if (!$appeal_phase) {
+            $this->errorJson(i::__('Não existe fase de recurso para esta oportunidade.'), 400);
+        }
+
+        // Campos derivados no servidor: divergência no payload é erro de contrato.
+        $derived = [
+            'registration' => [$registration->id, 'inscrição'],
+            'appealPhase' => [$appeal_phase->id, 'fase de recurso'],
+            'slotOwnerUser' => [$slot->user->id, 'dono do slot'],
+        ];
+
+        foreach ($derived as $key => [$expected_id, $label]) {
+            if (isset($data[$key]) && $this->resolveIdParam($data[$key]) !== (int) $expected_id) {
+                $this->errorJson(sprintf(i::__('O campo %s não corresponde ao valor derivado da avaliação original (%s).'), $key, $label), 400);
+            }
+        }
+
+        $review = new ReviewEntity();
+        $review->originalEvaluation = $slot;
+        $review->registration = $registration;
+        $review->appealPhase = $appeal_phase;
+        $review->slotOwnerUser = $slot->user;
+        $review->correctorUser = $corrector;
+
+        $this->assertCorrectorEligibility($review, $slot, $corrector);
+
+        // O índice único de designações ativas é a regra definitiva; aqui o erro fica claro.
+        $active_reviews = $app->repo(ReviewEntity::class)->findBy([
+            'originalEvaluation' => $slot->id,
+            'status' => ReviewEntity::getActiveStatuses(),
+        ]);
+
+        if ($active_reviews) {
+            $this->errorJson(i::__('Já existe uma designação ativa para este slot. Substitua ou conclua a designação existente antes de criar outra.'), 400);
+        }
+
+        $correction_type = (string) ($data['correctionType'] ?? ReviewEntity::CORRECTION_TYPE_OFFICIAL);
+        if (!in_array($correction_type, ReviewEntity::getCorrectionTypes(), true)) {
+            $this->errorJson(sprintf(i::__('Tipo de correção inválido (%s). Use "official" ou "record".'), $correction_type), 400);
+        }
+        $review->correctionType = $correction_type;
+
+        $review->releasedScope = $this->parseReleasedScope($data['releasedScope'] ?? null);
+        $review->startsAt = $this->parseDateParam($data['startsAt'] ?? null);
+        $review->endsAt = $this->parseDateParam($data['endsAt'] ?? null);
+        $review->status = ReviewEntity::STATUS_DESIGNATED;
+
+        $this->_finishRequest($review, true);
+    }
+
+    /**
+     * Listagem para o painel de acompanhamento do F2 (CA-13).
+     *
+     * Exige `registration` no query string e `@control` na oportunidade
+     * principal da inscrição; o resultado é sempre escopado à inscrição
+     * autorizada, independentemente dos filtros enviados.
+     */
+    function API_find()
+    {
+        $this->requireAuthentication();
+        $this->assertFeatureEnabled();
+
+        $registration = $this->getAuthorizedRegistrationFromQuery();
+
+        $this->getData['registration'] = 'EQ(' . $registration->id . ')';
+        $this->applyStatusDomainDefaults();
+
+        $data = $this->apiQuery($this->getData);
+        $this->apiResponse($data);
+    }
+
+    /**
+     * Busca unitária restrita: `@control` na oportunidade principal da
+     * inscrição da designação.
+     */
+    function API_findOne()
+    {
+        $this->requireAuthentication();
+        $this->assertFeatureEnabled();
+
+        $review = $this->getRequestedReviewFromQuery();
+        $review->registration->opportunity->checkPermission('@control');
+
+        $this->applyStatusDomainDefaults();
+
+        $data = $this->apiQuery($this->getData, ['findOne' => true]);
+        $this->apiItemResponse($data);
+    }
+
+    /**
+     * Escrita canônica (substituir corretor, novo prazo): restrita a gestores
+     * com `@control` na oportunidade principal. Substituição de corretor
+     * continua sujeita à elegibilidade do CA-3.
+     */
+    function PUT_single($data = null)
+    {
+        $this->requireAuthentication();
+        $this->assertFeatureEnabled();
+
+        $review = $this->getRequestedReview();
+        $review->registration->opportunity->checkPermission('@control');
+
+        if (is_null($data)) {
+            $data = $this->postData;
+        }
+
+        $this->guardMutableFields($review, $data);
+
+        parent::PUT_single($data);
+    }
+
+    function PATCH_single($data = null)
+    {
+        $this->requireAuthentication();
+        $this->assertFeatureEnabled();
+
+        $review = $this->getRequestedReview();
+        $review->registration->opportunity->checkPermission('@control');
+
+        if (is_null($data)) {
+            $data = $this->patchData;
+        }
+
+        $this->guardMutableFields($review, $data);
+
+        parent::PATCH_single($data);
+    }
+
+    /**
+     * Cancelamento de designação: restrito a gestores com `@control`
+     * (a entidade usa hard delete — sem mudança de status).
+     */
+    function DELETE_single()
+    {
+        $this->requireAuthentication();
+        $this->assertFeatureEnabled();
+
+        $this->getRequestedReview()->registration->opportunity->checkPermission('@control');
+
+        parent::DELETE_single();
+    }
+
+    // ============================================================ //
+    // Helpers
+    // ============================================================ //
+
+    private function assertFeatureEnabled(): void
+    {
+        if (!(bool) env('APPEAL_SCORE_CORRECTION', false)) {
+            $this->errorJson(i::__('Correção de notas por recurso desabilitada'), 404);
+        }
+    }
+
+    /**
+     * O domínio de status da designação (0=designada, 1=rascunho, 2=enviada,
+     * 3=reaberta) colide com a suposição do ApiQuery de que status<=0 é
+     * rascunho a esconder (filtro default `e.status > 0`), o que sumiria com
+     * as designações recém-criadas do painel do F2.
+     *
+     * Sem `status` informado, filtramos pelo domínio completo (comportamento
+     * equivalente a "sem filtro"); e sem `@permissions`, usamos `view`, que
+     * para esta entidade é um no-op (ela não usa permission cache) e serve
+     * apenas para desativar o filtro default de status do core. Em conjunto,
+     * os dois parâmetros fazem o core pular o `e.status > 0`.
+     */
+    private function applyStatusDomainDefaults(): void
+    {
+        if (!isset($this->getData['status'])) {
+            $this->getData['status'] = 'IN(' . implode(',', [
+                ReviewEntity::STATUS_DESIGNATED,
+                ReviewEntity::STATUS_DRAFT,
+                ReviewEntity::STATUS_SENT,
+                ReviewEntity::STATUS_REOPENED,
+            ]) . ')';
+        }
+
+        if (!isset($this->getData['@permissions'])) {
+            $this->getData['@permissions'] = 'view';
+        }
+    }
+
+    /**
+     * CA-3: por slot, o gestor só pode designar o dono do slot ou membro da
+     * Comissão de Recursos da fase de recurso. Avaliadores de outros slots da
+     * mesma inscrição são rejeitados.
+     */
+    private function assertCorrectorEligibility(ReviewEntity $review, RegistrationEvaluation $slot, User $corrector): void
+    {
+        $eligible_ids = array_map(
+            static fn (User $user): int => (int) $user->id,
+            $review->eligibleCorrectors($slot)
+        );
+
+        if (!$eligible_ids) {
+            $this->errorJson(i::__('Este slot não admite designação de correção: exige fase principal com método técnico e fase de recurso ativa com Comissão de Recursos.'), 400);
+        }
+
+        if (!in_array((int) $corrector->id, $eligible_ids, true)) {
+            $this->errorJson(i::__('Corretor inelegível para este slot (CA-3): apenas o dono da avaliação original ou membros da Comissão de Recursos podem ser designados.'), 400);
+        }
+    }
+
+    /**
+     * Valida os campos mutáveis via PUT/PATCH antes de delegar ao core:
+     * - campos derivados do slot são imutáveis;
+     * - substituição de corretor exige elegibilidade (CA-3) e é atribuída
+     *   como entidade resolvida (não como ID cru);
+     * - correctionType válidos;
+     * - status restrito ao domínio da designação e aplicado diretamente, para
+     *   não colidir com o changeStatusMap do ciclo padrão de Entity.
+     */
+    private function guardMutableFields(ReviewEntity $review, array &$data): void
+    {
+        $app = App::i();
+
+        foreach (self::DERIVED_FIELDS as $field) {
+            if (array_key_exists($field, $data) && $this->resolveIdParam($data[$field]) !== (int) $review->$field->id) {
+                $this->errorJson(sprintf(i::__('O campo %s é derivado da avaliação original e não pode ser alterado.'), $field), 400);
+            }
+
+            unset($data[$field]);
+        }
+
+        if (array_key_exists('originalEvaluation', $data)) {
+            if ($this->resolveIdParam($data['originalEvaluation']) !== (int) $review->originalEvaluation->id) {
+                $this->errorJson(i::__('O campo originalEvaluation identifica o slot e não pode ser alterado. Crie uma nova designação.'), 400);
+            }
+
+            unset($data['originalEvaluation']);
+        }
+
+        if (array_key_exists('correctorUser', $data)) {
+            $corrector_id = $this->resolveIdParam($data['correctorUser']);
+
+            if ($corrector_id !== (int) $review->correctorUser->id) {
+                /** @var User|null $corrector */
+                $corrector = $app->repo('User')->find($corrector_id);
+
+                if (!$corrector) {
+                    $this->errorJson(sprintf(i::__('Não existe usuário corretor com o ID %s.'), $corrector_id), 404);
+                }
+
+                $this->assertCorrectorEligibility($review, $review->originalEvaluation, $corrector);
+                $review->correctorUser = $corrector;
+            }
+
+            unset($data['correctorUser']);
+        }
+
+        if (isset($data['correctionType'])) {
+            if (!in_array((string) $data['correctionType'], ReviewEntity::getCorrectionTypes(), true)) {
+                $this->errorJson(sprintf(i::__('Tipo de correção inválido (%s). Use "official" ou "record".'), (string) $data['correctionType']), 400);
+            }
+        }
+
+        if (isset($data['releasedScope'])) {
+            $review->releasedScope = $this->parseReleasedScope($data['releasedScope']);
+            unset($data['releasedScope']);
+        }
+
+        if (isset($data['startsAt'])) {
+            $review->startsAt = $this->parseDateParam($data['startsAt']);
+            unset($data['startsAt']);
+        }
+
+        if (isset($data['endsAt'])) {
+            $review->endsAt = $this->parseDateParam($data['endsAt']);
+            unset($data['endsAt']);
+        }
+
+        if (array_key_exists('status', $data)) {
+            $status = (int) $data['status'];
+
+            $valid_statuses = [
+                ReviewEntity::STATUS_DESIGNATED,
+                ReviewEntity::STATUS_DRAFT,
+                ReviewEntity::STATUS_SENT,
+                ReviewEntity::STATUS_REOPENED,
+            ];
+
+            if (!in_array($status, $valid_statuses, true)) {
+                $this->errorJson(i::__('Status inválido para designação de correção.'), 400);
+            }
+
+            $review->status = $status;
+            unset($data['status']);
+        }
+    }
+
+    /**
+     * Extrai e valida a inscrição do parâmetro `registration` (aceita `EQ(n)`
+     * ou inteiro) e exige `@control` na oportunidade principal.
+     */
+    private function getAuthorizedRegistrationFromQuery(): Registration
+    {
+        $app = App::i();
+
+        $raw_value = trim((string) ($this->getData['registration'] ?? ''));
+
+        if (!preg_match('/\d+/', $raw_value, $matches)) {
+            $this->errorJson(i::__('O parâmetro registration (ID da inscrição) é obrigatório.'), 400);
+        }
+
+        /** @var Registration|null $registration */
+        $registration = $app->repo('Registration')->find((int) $matches[0]);
+
+        if (!$registration) {
+            $this->errorJson(sprintf(i::__('Não existe inscrição com o ID %s.'), $matches[0]), 404);
+        }
+
+        $registration->opportunity->checkPermission('@control');
+
+        return $registration;
+    }
+
+    /**
+     * Entidade da requisição para ações single (PUT/PATCH/DELETE).
+     */
+    private function getRequestedReview(): ReviewEntity
+    {
+        $app = App::i();
+
+        $review = $this->requestedEntity;
+
+        if (!$review) {
+            $app->pass();
+        }
+
+        return $review;
+    }
+
+    /**
+     * Carrega a designação referenciada por `id` (formato API `EQ(n)`).
+     */
+    private function getRequestedReviewFromQuery(): ReviewEntity
+    {
+        $app = App::i();
+
+        $raw_value = trim((string) ($this->getData['id'] ?? ''));
+
+        if (!preg_match('/\d+/', $raw_value, $matches)) {
+            $this->errorJson(i::__('O parâmetro id é obrigatório.'), 400);
+        }
+
+        /** @var ReviewEntity|null $review */
+        $review = $app->repo(ReviewEntity::class)->find((int) $matches[0]);
+
+        if (!$review) {
+            $app->pass();
+        }
+
+        return $review;
+    }
+
+    /**
+     * Aceita int, string numérica ou objeto/array com chave `id`.
+     */
+    private function resolveIdParam(mixed $value): int
+    {
+        if (is_array($value) || is_object($value)) {
+            $value = ((array) $value)['id'] ?? null;
+        }
+
+        return (int) $value;
+    }
+
+    /**
+     * @param mixed $value array/objeto já decodificado ou string JSON.
+     */
+    private function parseReleasedScope(mixed $value): ?object
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_string($value)) {
+            $decoded = json_decode($value);
+
+            if (!is_object($decoded)) {
+                $this->errorJson(i::__('releasedScope inválido: esperado objeto JSON.'), 400);
+            }
+
+            return $decoded;
+        }
+
+        return (object) (array) $value;
+    }
+
+    private function parseDateParam(mixed $value): ?DateTime
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        try {
+            return new DateTime((string) $value);
+        } catch (\Exception) {
+            $this->errorJson(i::__('Data inválida: use o formato AAAA-MM-DD HH:MM.'), 400);
+
+            return null;
+        }
+    }
+}

--- a/src/modules/OpportunityAppealPhase/Entities/RegistrationAppealReview.php
+++ b/src/modules/OpportunityAppealPhase/Entities/RegistrationAppealReview.php
@@ -230,8 +230,10 @@ class RegistrationAppealReview extends Entity
     /**
      * Retorna os usuários elegíveis para corrigir o slot vinculado a esta designação.
      *
-     * No MVP, a correção é restrita a oportunidades cuja fase principal usa
-     * `EvaluationMethodTechnical`.
+     * Elegibilidade aberta a todos os métodos de avaliação (F6 / #49,
+     * Variante 3 — override registrado na #7 em 2026-09-09): a escolha de
+     * critérios existe para `technical` e `documentary`; nos demais métodos
+     * a correção liberada é integral (releasedScope nulo).
      *
      * @return User[]
      */
@@ -246,7 +248,7 @@ class RegistrationAppealReview extends Entity
         $main_phase = $slot->registration->opportunity;
         $main_emc = $main_phase->evaluationMethodConfiguration;
 
-        if (!$main_emc || $main_emc->type->id !== 'technical') {
+        if (!$main_emc) {
             return [];
         }
 

--- a/src/modules/OpportunityAppealPhase/Module.php
+++ b/src/modules/OpportunityAppealPhase/Module.php
@@ -48,6 +48,23 @@ class Module extends \MapasCulturais\Module {
             $result = $self->canDesignatedCorrectorAccessSlot($this, $user);
         });
 
+        /*
+         * F4 (#20) — CA-11: colunas de nota original/corrigida/diferença.
+         *
+         * Propriedades computadas, expostas ao @select da ApiQuery (o parse
+         * aceita chaves virtuais: processEntities as preenche com null e o
+         * hook abaixo computa os valores). Sem persistência e sem schema.
+         * A ordenação por essas colunas é ignorada pela ApiQuery (sem erro);
+         * filtragem por elas não é suportada (PropertyDoesNotExists).
+         */
+        $app->hook('ApiQuery(registrationevaluation).findResult', function (&$result) use ($self) {
+            $self->enrichEvaluationScoreColumns($result);
+        });
+
+        $app->hook('ApiQuery(registration).findResult', function (&$result) use ($self) {
+            $self->enrichRegistrationScoreColumns($result);
+        });
+
         /* Endpoint de criação de fase de recurso na oportunidade */
         $app->hook('POST(opportunity.createAppealPhase)', function() use ($app) {
             /** @var Controllers\Opportunity $this  */
@@ -439,6 +456,240 @@ class Module extends \MapasCulturais\Module {
         }
 
         return false;
+    }
+
+    // ============================================================ //
+    // F4 (#20) — CA-11: propriedades computadas de nota
+    // ============================================================ //
+
+    /**
+     * Colunas por slot (avaliação), computadas no findResult da ApiQuery:
+     *
+     * - originalScore: nota do slot ANTES da primeira correção aplicada
+     *   (registration_appeal_review com status SENT, menor id); sem correção,
+     *   é a própria nota vigente (snapshot originalScore da designação);
+     * - correctedScore: nota vigente (result pós-correção in-place);
+     * - scoreDifference: correctedScore − originalScore.
+     *
+     * Formato por método, derivado do `result` como as listas já exibem:
+     * técnico = pontuação ponderada; documental = 1/−1 (válida/inválida);
+     * simples = código do status. Resultados não numéricos → null.
+     *
+     * Só computa quando as chaves foram pedidas no @select (a chave existe,
+     * null, nas linhas); queries que não pedem não pagam o custo.
+     *
+     * @param array<int, array<string, mixed>> $result
+     */
+    public function enrichEvaluationScoreColumns(array &$result): void
+    {
+        if (!$result) {
+            return;
+        }
+
+        $wants_original = array_key_exists('originalScore', $result[0]);
+        $wants_corrected = array_key_exists('correctedScore', $result[0]);
+        $wants_difference = array_key_exists('scoreDifference', $result[0]);
+
+        if (!$wants_original && !$wants_corrected && !$wants_difference) {
+            return;
+        }
+
+        $evaluation_ids = [];
+        foreach ($result as $row) {
+            if (!empty($row['id'])) {
+                $evaluation_ids[] = (int) $row['id'];
+            }
+        }
+
+        $snapshot = $this->fetchCurrentAndOriginalScores($evaluation_ids);
+
+        foreach ($result as &$row) {
+            $id = (int) ($row['id'] ?? 0);
+            $current = $snapshot[$id]['current'] ?? null;
+            $original = $snapshot[$id]['original'] ?? null;
+
+            // Sem correção aplicada: original é a nota vigente.
+            $original = $original ?? $current;
+
+            if ($wants_original) {
+                $row['originalScore'] = $original;
+            }
+            if ($wants_corrected) {
+                $row['correctedScore'] = $current;
+            }
+            if ($wants_difference) {
+                $row['scoreDifference'] = ($original !== null && $current !== null)
+                    ? $current - $original
+                    : null;
+            }
+        }
+    }
+
+    /**
+     * Colunas por inscrição (lista de inscritos), computadas no findResult:
+     *
+     * - averageCorrectedScore: média das notas vigentes dos slots ENVIADOS
+     *   (mesma base do getSentEvaluations — consolidação vigente);
+     * - averageOriginalScore: média recomputada trocando, em cada slot
+     *   corrigido, a nota vigente pela originalScore da designação aplicada;
+     * - scoreDifference: média corrigida − média original (sem nenhuma
+     *   correção: médias iguais, diferença 0; sem notas numéricas: null).
+     *
+     * @param array<int, array<string, mixed>> $result
+     */
+    public function enrichRegistrationScoreColumns(array &$result): void
+    {
+        if (!$result) {
+            return;
+        }
+
+        $wants_original = array_key_exists('averageOriginalScore', $result[0]);
+        $wants_corrected = array_key_exists('averageCorrectedScore', $result[0]);
+        $wants_difference = array_key_exists('scoreDifference', $result[0]);
+
+        if (!$wants_original && !$wants_corrected && !$wants_difference) {
+            return;
+        }
+
+        $registration_ids = [];
+        foreach ($result as $row) {
+            if (!empty($row['id'])) {
+                $registration_ids[] = (int) $row['id'];
+            }
+        }
+
+        $rows = $this->fetchScoresByRegistration($registration_ids);
+
+        $by_registration = [];
+        foreach ($rows as $row) {
+            $by_registration[(int) $row['registration_id']][] = $row;
+        }
+
+        $average = static function (array $values): ?float {
+            $numeric = array_values(array_filter($values, static fn ($v) => $v !== null));
+
+            return $numeric ? round(array_sum($numeric) / count($numeric), 4) : null;
+        };
+
+        foreach ($result as &$row) {
+            $registration_id = (int) ($row['id'] ?? 0);
+            $evaluations = $by_registration[$registration_id] ?? [];
+
+            $corrected_values = [];
+            $original_values = [];
+
+            foreach ($evaluations as $evaluation) {
+                $current = $evaluation['current'];
+                $original = $evaluation['original'] ?? $current;
+
+                $corrected_values[] = $current;
+                $original_values[] = $original;
+            }
+
+            $average_corrected = $average($corrected_values);
+            $average_original = $average($original_values);
+
+            if ($wants_original) {
+                $row['averageOriginalScore'] = $average_original;
+            }
+            if ($wants_corrected) {
+                $row['averageCorrectedScore'] = $average_corrected;
+            }
+            if ($wants_difference) {
+                $row['scoreDifference'] = ($average_original !== null && $average_corrected !== null)
+                    ? round($average_corrected - $average_original, 4)
+                    : null;
+            }
+        }
+    }
+
+    /**
+     * Nota vigente e nota original (primeira correção aplicada) por avaliação.
+     *
+     * @param int[] $evaluation_ids
+     * @return array<int, array{current: ?float, original: ?float}>
+     */
+    private function fetchCurrentAndOriginalScores(array $evaluation_ids): array
+    {
+        if (!$evaluation_ids) {
+            return [];
+        }
+
+        $app = App::i();
+        $ids = implode(',', array_map('intval', $evaluation_ids));
+
+        // r.status = 2 = RegistrationAppealReview::STATUS_SENT (correção aplicada);
+        // menor id = primeira correção do slot.
+        $rows = $app->em->getConnection()->fetchAllAssociative("
+            SELECT
+                ev.id,
+                ev.result,
+                (
+                    SELECT r.original_score
+                    FROM registration_appeal_review r
+                    WHERE r.original_evaluation_id = ev.id AND r.status = 2
+                    ORDER BY r.id ASC
+                    LIMIT 1
+                ) AS original_score
+            FROM registration_evaluation ev
+            WHERE ev.id IN ({$ids})
+        ");
+
+        $snapshot = [];
+        foreach ($rows as $row) {
+            $snapshot[(int) $row['id']] = [
+                'current' => $this->toNumericScore($row['result']),
+                'original' => $this->toNumericScore($row['original_score']),
+            ];
+        }
+
+        return $snapshot;
+    }
+
+    /**
+     * Notas por inscrição, apenas avaliações ENVIADAS (ev.status = 2 =
+     * RegistrationEvaluation::STATUS_SENT — mesma base de getSentEvaluations).
+     *
+     * @param int[] $registration_ids
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchScoresByRegistration(array $registration_ids): array
+    {
+        if (!$registration_ids) {
+            return [];
+        }
+
+        $app = App::i();
+        $ids = implode(',', array_map('intval', $registration_ids));
+
+        return $app->em->getConnection()->fetchAllAssociative("
+            SELECT
+                ev.registration_id,
+                ev.result AS current,
+                (
+                    SELECT r.original_score
+                    FROM registration_appeal_review r
+                    WHERE r.original_evaluation_id = ev.id AND r.status = 2
+                    ORDER BY r.id ASC
+                    LIMIT 1
+                ) AS original
+            FROM registration_evaluation ev
+            WHERE ev.registration_id IN ({$ids})
+                AND ev.status = 2
+        ");
+    }
+
+    /**
+     * Resultado do slot como número (técnico: pontuação; documental: 1/−1;
+     * simples: código do status). Não numérico → null.
+     */
+    private function toNumericScore(mixed $value): ?float
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return is_numeric($value) ? (float) $value : null;
     }
 
     private function isAppealScoreCorrectionEnabled(): bool

--- a/src/modules/OpportunityAppealPhase/Module.php
+++ b/src/modules/OpportunityAppealPhase/Module.php
@@ -413,9 +413,16 @@ class Module extends \MapasCulturais\Module {
         return (bool) env('APPEAL_TWO_STAGE_PUBLISH', $this->config['featureFlag.appealTwoStagePublish']);
     }
 
+    /**
+     * F7 (#51): o acesso do corretor designado ao slot vale para TODOS os
+     * métodos de avaliação (antes restrito ao técnico). Guardas mantidos:
+     * feature flag, designação ativa do corretor para o slot (com inscrição,
+     * fase de recurso e dono conferidos por findActiveForEvaluationAndUser),
+     * janela de prazo e elegibilidade (eligibleCorrectors).
+     */
     public function canDesignatedCorrectorAccessSlot(RegistrationEvaluation $slot, $user): bool
     {
-        if (!$this->isAppealScoreCorrectionEnabled() || !$this->isTechnicalEvaluationSlot($slot)) {
+        if (!$this->isAppealScoreCorrectionEnabled()) {
             return false;
         }
 
@@ -432,14 +439,6 @@ class Module extends \MapasCulturais\Module {
         }
 
         return false;
-    }
-
-    private function isTechnicalEvaluationSlot(RegistrationEvaluation $slot): bool
-    {
-        $opportunity = $slot->registration->opportunity;
-        $emc = $opportunity->evaluationMethodConfiguration;
-
-        return (bool) $emc && $emc->type->id === 'technical';
     }
 
     private function isAppealScoreCorrectionEnabled(): bool

--- a/src/modules/OpportunityAppealPhase/Module.php
+++ b/src/modules/OpportunityAppealPhase/Module.php
@@ -364,6 +364,9 @@ class Module extends \MapasCulturais\Module {
 
         $app->registerController('appealCorrector', \OpportunityAppealPhase\Controllers\AppealCorrector::class);
 
+        // PR6 (#40): API de designação de corretores por slot (criação + listagem do painel do F2).
+        $app->registerController('registrationappealreview', \OpportunityAppealPhase\Controllers\RegistrationAppealReview::class);
+
         $this->registerOpportunityMetadata('appealPhase', [
             'label' => i::__('Fase de recurso'),
             'type'  => 'entity'

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/README.md
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/README.md
@@ -41,12 +41,35 @@ window.dispatchEvent(new CustomEvent(
 |----------|---------|--------|
 | `saved`  | `{registrationId}` | Após criar todas as designações marcadas com sucesso |
 
+## Integração F1 (#17) — botão na lista de inscritos da fase de recurso
+
+Override 2026-09-08 (épica #7): a coluna "Designar correção" vive na lista de
+inscritos **da fase de recurso** (`opportunity-registrations-table`), não na da
+fase principal. Cada linha é um recurso; o botão aparece **somente nas linhas
+com status Deferido (10)** — valor nativo da lista, sem fetch extra.
+
+O `init.php` popula o config quando a oportunidade em contexto **é a própria
+fase de recurso** (ativa, com EMC, fase pai técnica, `@control` na fase pai):
+
+- `appealContexts[appealPhaseId] = {mainPhaseId}` — gate da coluna na tabela;
+- `appealPhases[mainPhaseId]`, `committees[mainPhaseId]` e
+  `evaluators[mainPhaseId]` — consumo do modal, que recebe a fase principal
+  no evento de abertura e a usa como chave.
+
+No clique, o F1 deriva `{opportunity: fase principal, registration: inscrição
+da fase principal}` a partir da linha do recurso: a inscrição de recurso herda
+o `number` da inscrição principal (`createAppealPhaseRegistration`,
+`OpportunityAppealPhase/Module.php:201`) e não há meta/relation armazenada
+ligando as duas — o casamento por `number` na fase pai é o mecanismo canônico
+do backend (`Module.php:240-243`), replicado aqui em 1 chamada cacheada por
+inscrição.
+
 ## Fontes de dados (somente endpoints existentes)
 
 | Dado | Fonte | Observação |
 |------|-------|------------|
 | Slots da inscrição | `GET /api/registrationevaluation/find` (`registration=EQ(id)`) | API filtra por permissão de visão; leitura **raw** obrigatória (`raw: true` — `rawProcessor` sozinho não ativa o modo raw e o `populate` do SDK descarta relações escalares); a relação `user` volta sempre ESCALAR (não expande) |
-| Comissão de Recursos (`committees`) + avaliadores da fase principal (`evaluators`, mapa `{userId: name}`) + fase de recurso (`appealPhases`) | Injeção do `init.php` (`$MAPAS.config.appealCorrectionAssignment`) | Espelha os gates de `eligibleCorrectors()`; exige `@control`; `evaluators` é a fonte dos nomes dos donos de slot (a API de avaliação não expõe nome) |
+| Comissão de Recursos (`committees`) + avaliadores da fase principal (`evaluators`, mapa `{userId: name}`) + fase de recurso (`appealPhases`) + contexto da coluna (`appealContexts`) | Injeção do `init.php` (`$MAPAS.config.appealCorrectionAssignment`) | Espelha os gates de `eligibleCorrectors()`; exige `@control` na fase pai; `evaluators` é a fonte dos nomes dos donos de slot (a API de avaliação não expõe nome) |
 | Criação/leitura de designações | API canônica de `registrationappealreview` | **Disponível somente quando `endpointAvailable`** — requer controller registrado para a entidade no backend |
 
 ### Estado bloqueado (`endpointAvailable = false`)

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/README.md
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/README.md
@@ -107,6 +107,28 @@ atual e duas ações:
 
 Slot com status **enviado** (2) não exibe ações.
 
+## Escopo de critérios (F6 / #49, Variante 3)
+
+Elegibilidade aberta a **todos** os métodos de avaliação (gate técnico
+removido de `eligibleCorrectors()` e do `init.php`). O seletor de escopo
+(`criteriaCatalogs` do config, injetado por `init.php`) existe somente para:
+
+| Método | Seletor | Fonte dos itens |
+|--------|---------|-----------------|
+| Técnica | Sim — seções/critérios do EMC principal | `EvaluationMethodTechnical` (chave do evaluationData = id do critério) |
+| Qualificação documental | Sim — campos e documentos das fases | `EvaluationMethodDocumentary` (chave = `fieldName`/`fileGroupName`) |
+| Demais (simples etc.) | Não — nada renderiza | `releasedScope` nulo ("abre tudo") |
+
+**Semântica persistida em `releasedScope`**: TODOS os critérios marcados →
+`null` (= sem restrição, compatível com `getReleasedCriteriaIds()` do
+`AppealReview\Service`); subconjunto → `{criteria: [...]}`; seleção VAZIA é
+rejeitada — no cliente (salvar bloqueado com aviso) e no backend
+(`parseReleasedScope` → 400 "O escopo de critérios não pode ser vazio…").
+Na substituição (F5) a checklist vem pré-preenchida com o escopo vigente e o
+PATCH envia `releasedScope` junto (`null` LIMPA a restrição — o controller
+usa `array_key_exists`). O painel de acompanhamento exibe "X de Y critérios"
+(restrito) ou "todos liberados" (nulo).
+
 ## Defaults de criação
 
 Por linha marcada cria-se: `status=DESIGNATED`, `correctionType=official`

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/README.md
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/README.md
@@ -89,6 +89,24 @@ utilitárias do tema (`.semibold`, `.{primary|success|warning|danger}__color`,
 `.warning__background`) e o `style.css` local do componente (auto-enfileirado,
 sem passo de build — mesmo padrão do `mc-modal`), com tokens `--mc-*`.
 
+## Gestão de designação ativa (F5 / #45, CA-13)
+
+No painel de acompanhamento, slot com designação **ativa** (status
+designado/rascunho/reaberto — `activeStatuses` do config) exibe o corretor
+atual e duas ações:
+
+- **Substituir corretor** — select inline com os elegíveis daquele slot
+  (mesma fonte do fluxo de designação) → `PATCH
+  /registrationappealreview/single/{id}` com `{correctorUser}`; o backend
+  revalida CA-3 (inelegível → 400 com mensagem exibida via
+  `backendErrorMessage`). Sucesso → toast + `fetchReviews()` reflete o novo
+  corretor sem reload.
+- **Cancelar designação** — confirmação com `mc-confirm-button` → `DELETE
+  /registrationappealreview/single/{id}`; o slot volta ao estado designável
+  (checkbox destravado, "sem designação").
+
+Slot com status **enviado** (2) não exibe ações.
+
 ## Defaults de criação
 
 Por linha marcada cria-se: `status=DESIGNATED`, `correctionType=official`

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/README.md
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/README.md
@@ -1,0 +1,74 @@
+# Componente `<opportunity-appeal-correction-assignment>`
+
+Modal de designação de corretores por slot (F2 / issue #18, épica #7 — RF-A30).
+Lista as avaliações da fase principal de uma inscrição com recurso deferido,
+uma por avaliador, e permite ao gestor marcar quais notas serão corrigidas e
+designar **1 corretor por slot** — restrito ao dono do slot e aos membros da
+Comissão de Recursos (mesma composição de `RegistrationAppealReview::eligibleCorrectors()`).
+
+Também exibe o acompanhamento por slot (designado / rascunho / enviado /
+reaberto, prazo e data de envio), somente leitura. Substituição de corretor e
+reabertura não fazem parte do componente.
+
+## Uso
+
+Não recebe props: é aberto programaticamente por evento global (interface
+pública consumida pelo F1). A view só precisa importá-lo e renderizá-lo uma
+única vez:
+
+```php
+<?php $this->import('opportunity-appeal-correction-assignment'); ?>
+<opportunity-appeal-correction-assignment></opportunity-appeal-correction-assignment>
+```
+
+Abertura (assinatura documentada também no `init.php`):
+
+```js
+window.dispatchEvent(new CustomEvent(
+    'opportunity-appeal-correction-assignment:open',
+    {
+        detail: {
+            opportunity: Entity|{id},   // fase principal (avaliativa) da inscrição
+            registration: Entity|{id, number?}, // inscrição da fase principal (não a da fase de recurso)
+        }
+    }
+));
+```
+
+## Eventos emitidos
+
+| Evento   | Payload | Quando |
+|----------|---------|--------|
+| `saved`  | `{registrationId}` | Após criar todas as designações marcadas com sucesso |
+
+## Fontes de dados (somente endpoints existentes)
+
+| Dado | Fonte | Observação |
+|------|-------|------------|
+| Slots da inscrição | `GET /api/registrationevaluation/find` (`registration=EQ(id)`) | API filtra por permissão de visão; leitura **raw** obrigatória (`raw: true` — `rawProcessor` sozinho não ativa o modo raw e o `populate` do SDK descarta relações escalares); a relação `user` volta sempre ESCALAR (não expande) |
+| Comissão de Recursos (`committees`) + avaliadores da fase principal (`evaluators`, mapa `{userId: name}`) + fase de recurso (`appealPhases`) | Injeção do `init.php` (`$MAPAS.config.appealCorrectionAssignment`) | Espelha os gates de `eligibleCorrectors()`; exige `@control`; `evaluators` é a fonte dos nomes dos donos de slot (a API de avaliação não expõe nome) |
+| Criação/leitura de designações | API canônica de `registrationappealreview` | **Disponível somente quando `endpointAvailable`** — requer controller registrado para a entidade no backend |
+
+### Estado bloqueado (`endpointAvailable = false`)
+
+Enquanto a entidade `RegistrationAppealReview` não tiver controller registrado
+no backend (criação é backend de out of scope da F2), salvar e acompanhar
+ficam desabilitados: o modal exibe aviso explícito e o botão de salvar fica
+inativo. O restante da interface (lista de slots e opções de corretor) opera
+normalmente. Quando o controller existir, os fluxos ativam-se sem alteração
+neste componente.
+
+## Estilo
+
+A estrutura do diálogo vem do `mc-modal` (`.modal-content`/`.modal__*` + botões
+`.button--primary`/`.button--text`, responsivo). O conteúdo interno usa classes
+utilitárias do tema (`.semibold`, `.{primary|success|warning|danger}__color`,
+`.warning__background`) e o `style.css` local do componente (auto-enfileirado,
+sem passo de build — mesmo padrão do `mc-modal`), com tokens `--mc-*`.
+
+## Defaults de criação
+
+Por linha marcada cria-se: `status=DESIGNATED`, `correctionType=official`
+(correção oficial), prazo e escopo de critérios livres (`null`). A
+parametrização completa (prazo, escopo, `record`, visibilidade do parecer) é
+tratada em outra onda da épica (CA-4).

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/init.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/init.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Componente: opportunity-appeal-correction-assignment (F2 / issue #18).
+ *
+ * Interface pública para abrir o modal de designação de corretores por slot
+ * (consumida pelo F1 — botão na lista de inscritos — e por qualquer outra
+ * integração):
+ *
+ *     window.dispatchEvent(new CustomEvent(
+ *         'opportunity-appeal-correction-assignment:open',
+ *         {
+ *             detail: {
+ *                 // fase principal (avaliativa) da inscrição.
+ *                 // Entity do SDK ou objeto com ao menos {id}.
+ *                 opportunity: Entity|{id},
+ *
+ *                 // inscrição da fase principal com recurso deferido
+ *                 // (NÃO a inscrição da fase de recurso).
+ *                 // Entity do SDK ou objeto com ao menos {id, number?}.
+ *                 registration: Entity|{id, number?},
+ *             }
+ *         }
+ *     ));
+ *
+ * Requisitos:
+ * - A view deve importar e renderizar o componente uma única vez:
+ *   `$this->import('opportunity-appeal-correction-assignment');`
+ *   seguido de `<opportunity-appeal-correction-assignment></opportunity-appeal-correction-assignment>`
+ *   (o listener do evento é registrado no mounted() do Vue).
+ * - A designação só fica habilitada quando a oportunidade em contexto é uma
+ *   fase técnica com fase de recurso ativa e o usuário tem `@control`.
+ *
+ * Fontes de dados (somente endpoints existentes):
+ * - Slots: GET /api/registrationevaluation/find (uma avaliação por avaliador;
+ *   a relação `user` volta ESCALAR — o nome do avaliador não vem da API).
+ * - Comissão de Recursos (`committees`) e avaliadores da fase principal
+ *   (`evaluators`, mapa {userId: name}): injetados aqui a partir dos comitês
+ *   das EMCs (mesma origem de RegistrationAppealReview::eligibleCorrectors()
+ *   e da lista de avaliações da oportunidade).
+ * - Criação/leitura de RegistrationAppealReview: API canônica da entidade,
+ *   disponível somente quando houver controller registrado para ela
+ *   (`endpointAvailable` abaixo). Sem controller, salvar e acompanhar ficam
+ *   desabilitados na interface — backend é out of scope da F2.
+ *
+ * @var MapasCulturais\App $app
+ * @var MapasCulturais\Themes\BaseV2\Theme $this
+ */
+
+use MapasCulturais\Entities\Opportunity;
+use OpportunityAppealPhase\Entities\RegistrationAppealReview;
+
+$config = [
+    // Verdadeiro somente quando a entidade possui controller registrado
+    // (sem controller não existe /api/registrationappealreview).
+    'endpointAvailable' => (bool) $app->getControllerIdByEntity(RegistrationAppealReview::class),
+
+    // Defaults de criação derivados da entidade/PRD (CA-4 é tratado em outra
+    // onda; F2 usa correção oficial e janela/escopo livres).
+    'statusDesignated' => RegistrationAppealReview::STATUS_DESIGNATED,
+    'statusSent' => RegistrationAppealReview::STATUS_SENT,
+    'correctionTypeDefault' => RegistrationAppealReview::CORRECTION_TYPE_OFFICIAL,
+    'activeStatuses' => RegistrationAppealReview::getActiveStatuses(),
+
+    // opportunityId (fase principal) => id da fase de recurso.
+    'appealPhases' => new stdClass(),
+
+    // opportunityId (fase principal) => membros da Comissão de Recursos:
+    // [{userId, name}]. Presente somente em contexto elegível.
+    'committees' => new stdClass(),
+
+    // opportunityId (fase principal) => {userId: name} dos avaliadores da
+    // fase principal (comitê do EMC principal). Necessário porque a API de
+    // RegistrationEvaluation não expõe o nome do avaliador (a relação user
+    // não expande no @select — volta sempre escalar).
+    'evaluators' => new stdClass(),
+];
+
+$requested_entity = $this->controller->requestedEntity ?? null;
+$opportunity = $requested_entity ? $this->getOpportunityFromEntity($requested_entity) : null;
+
+if ($opportunity instanceof Opportunity && $opportunity->canUser('@control')) {
+    $appeal_phase = $opportunity->appealPhase ?? null;
+    $main_emc = $opportunity->evaluationMethodConfiguration;
+
+    // Espelha os gates de RegistrationAppealReview::eligibleCorrectors():
+    // fase principal com método técnico + fase de recurso ativa com EMC.
+    $is_eligible_context = $appeal_phase
+        && $appeal_phase->status === Opportunity::STATUS_APPEAL_PHASE
+        && $appeal_phase->evaluationMethodConfiguration
+        && $main_emc
+        && $main_emc->type->id === 'technical';
+
+    if ($is_eligible_context) {
+        $committee = [];
+        $evaluators = new stdClass();
+
+        foreach ($appeal_phase->evaluationMethodConfiguration->getCommittee(false) as $agent) {
+            $user = $agent->user ?? null;
+            if (!$user) {
+                continue;
+            }
+
+            $committee[$user->id] = [
+                'userId' => (int) $user->id,
+                'name' => (string) $agent->name,
+            ];
+        }
+
+        // Avaliadores da fase principal (donos de slot): comitê do EMC principal.
+        // Mesma fonte de nomes usada pela lista de avaliações da oportunidade.
+        foreach ($main_emc->getCommittee(false) as $agent) {
+            $user = $agent->user ?? null;
+            if (!$user) {
+                continue;
+            }
+
+            $evaluators->{$user->id} = (string) $agent->name;
+        }
+
+        $opportunity_id = (int) $opportunity->id;
+        $config['appealPhases']->{$opportunity_id} = (int) $appeal_phase->id;
+        $config['committees']->{$opportunity_id} = array_values($committee);
+        $config['evaluators']->{$opportunity_id} = $evaluators;
+    }
+}
+
+$app->applyHook('component(opportunity-appeal-correction-assignment).config', [&$config]);
+
+$this->jsObject['config']['appealCorrectionAssignment'] = $config;

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/init.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/init.php
@@ -27,8 +27,25 @@
  *   `$this->import('opportunity-appeal-correction-assignment');`
  *   seguido de `<opportunity-appeal-correction-assignment></opportunity-appeal-correction-assignment>`
  *   (o listener do evento é registrado no mounted() do Vue).
- * - A designação só fica habilitada quando a oportunidade em contexto é uma
- *   fase técnica com fase de recurso ativa e o usuário tem `@control`.
+ * - A designação só fica habilitada quando a oportunidade em contexto é a
+ *   fase de recurso ativa de uma fase técnica e o usuário tem `@control`
+ *   na fase pai (onde @control cascateia para a fase de recurso).
+ *
+ * Contexto F1 (#17) — override 2026-09-08 (épica #7, @israelmelo):
+ * a coluna "Designar correção" vive na lista de inscritos da FASE DE
+ * RECURSO (cada linha É um recurso; botão somente nas linhas com status
+ * Deferido = 10). Por isso o gate abaixo exige que a oportunidade em
+ * contexto SEJA a própria fase de recurso, e o config expose:
+ * - `appealContexts[appealPhaseId] = {mainPhaseId}` — consumido pela tabela
+ *   (opportunity-registrations-table) para decidir se a coluna aparece;
+ * - `appealPhases[mainPhaseId] = appealPhaseId`, `committees[mainPhaseId]`
+ *   e `evaluators[mainPhaseId]` — consumidos pelo modal, que recebe a fase
+ *   PRINCIPAL no evento de abertura e a usa como chave.
+ * Da linha da fase de recurso, o F1 deriva a inscrição da fase principal
+ * pelo `number` herdado (createAppealPhaseRegistration,
+ * OpportunityAppealPhase/Module.php:201) — mesmo mecanismo canônico do
+ * backend (Module.php:240-243); não existe meta/relation armazenada
+ * ligando recurso → inscrição principal.
  *
  * Fontes de dados (somente endpoints existentes):
  * - Slots: GET /api/registrationevaluation/find (uma avaliação por avaliador;
@@ -68,6 +85,12 @@ $config = [
     // [{userId, name}]. Presente somente em contexto elegível.
     'committees' => new stdClass(),
 
+    // F1 (#17) — override 2026-09-08: id da FASE DE RECURSO =>
+    // {mainPhaseId: int}. Consumido pela opportunity-registrations-table
+    // para exibir a coluna de designação na lista de inscritos da fase de
+    // recurso; presente somente em contexto elegível.
+    'appealContexts' => new stdClass(),
+
     // opportunityId (fase principal) => {userId: name} dos avaliadores da
     // fase principal (comitê do EMC principal). Necessário porque a API de
     // RegistrationEvaluation não expõe o nome do avaliador (a relação user
@@ -78,17 +101,24 @@ $config = [
 $requested_entity = $this->controller->requestedEntity ?? null;
 $opportunity = $requested_entity ? $this->getOpportunityFromEntity($requested_entity) : null;
 
-if ($opportunity instanceof Opportunity && $opportunity->canUser('@control')) {
-    $appeal_phase = $opportunity->appealPhase ?? null;
-    $main_emc = $opportunity->evaluationMethodConfiguration;
+/*
+    F1 (#17) — override 2026-09-08 (épica #7): a coluna "Designar correção"
+    pertence à lista de inscritos da FASE DE RECURSO, não à da fase
+    principal. Contexto elegível: a oportunidade em contexto É a fase de
+    recurso ativa (STATUS_APPEAL_PHASE), com EMC, cuja fase pai é técnica
+    com EMC, e o usuário tem @control na fase pai (onde @control cascateia
+    para a fase de recurso). Gates espelhados de
+    RegistrationAppealReview::eligibleCorrectors().
+*/
+if ($opportunity instanceof Opportunity && $opportunity->status === Opportunity::STATUS_APPEAL_PHASE) {
+    $appeal_phase = $opportunity;
+    $main_phase = $appeal_phase->parent ?? null;
 
-    // Espelha os gates de RegistrationAppealReview::eligibleCorrectors():
-    // fase principal com método técnico + fase de recurso ativa com EMC.
-    $is_eligible_context = $appeal_phase
-        && $appeal_phase->status === Opportunity::STATUS_APPEAL_PHASE
+    $is_eligible_context = $main_phase
         && $appeal_phase->evaluationMethodConfiguration
-        && $main_emc
-        && $main_emc->type->id === 'technical';
+        && $main_phase->evaluationMethodConfiguration
+        && $main_phase->evaluationMethodConfiguration->type->id === 'technical'
+        && $main_phase->canUser('@control');
 
     if ($is_eligible_context) {
         $committee = [];
@@ -106,9 +136,10 @@ if ($opportunity instanceof Opportunity && $opportunity->canUser('@control')) {
             ];
         }
 
-        // Avaliadores da fase principal (donos de slot): comitê do EMC principal.
-        // Mesma fonte de nomes usada pela lista de avaliações da oportunidade.
-        foreach ($main_emc->getCommittee(false) as $agent) {
+        // Avaliadores da fase principal (donos de slot): comitê do EMC
+        // principal (na árvore do parent, pois o contexto é a fase de
+        // recurso). Mesma fonte de nomes usada pela lista de avaliações.
+        foreach ($main_phase->evaluationMethodConfiguration->getCommittee(false) as $agent) {
             $user = $agent->user ?? null;
             if (!$user) {
                 continue;
@@ -117,10 +148,16 @@ if ($opportunity instanceof Opportunity && $opportunity->canUser('@control')) {
             $evaluators->{$user->id} = (string) $agent->name;
         }
 
-        $opportunity_id = (int) $opportunity->id;
-        $config['appealPhases']->{$opportunity_id} = (int) $appeal_phase->id;
-        $config['committees']->{$opportunity_id} = array_values($committee);
-        $config['evaluators']->{$opportunity_id} = $evaluators;
+        $appeal_phase_id = (int) $appeal_phase->id;
+        $main_phase_id = (int) $main_phase->id;
+
+        // Modal (chaveado pela fase principal, recebida no evento de abertura)
+        $config['appealPhases']->{$main_phase_id} = $appeal_phase_id;
+        $config['committees']->{$main_phase_id} = array_values($committee);
+        $config['evaluators']->{$main_phase_id} = $evaluators;
+
+        // Tabela da fase de recurso (chaveada pela própria fase de recurso)
+        $config['appealContexts']->{$appeal_phase_id} = ['mainPhaseId' => $main_phase_id];
     }
 }
 

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/init.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/init.php
@@ -96,6 +96,12 @@ $config = [
     // RegistrationEvaluation não expõe o nome do avaliador (a relação user
     // não expande no @select — volta sempre escalar).
     'evaluators' => new stdClass(),
+
+    // F6 (#49): opportunityId (fase principal) => catálogo de critérios
+    // selecionáveis {method, sections: [{id, name, items: [{id, label, max}]}],
+    // total} — presente somente para technical/documentary com itens. Demais
+    // métodos: null (designação sem seletor; releasedScope nulo = tudo).
+    'criteriaCatalogs' => new stdClass(),
 ];
 
 $requested_entity = $this->controller->requestedEntity ?? null;
@@ -105,10 +111,14 @@ $opportunity = $requested_entity ? $this->getOpportunityFromEntity($requested_en
     F1 (#17) — override 2026-09-08 (épica #7): a coluna "Designar correção"
     pertence à lista de inscritos da FASE DE RECURSO, não à da fase
     principal. Contexto elegível: a oportunidade em contexto É a fase de
-    recurso ativa (STATUS_APPEAL_PHASE), com EMC, cuja fase pai é técnica
-    com EMC, e o usuário tem @control na fase pai (onde @control cascateia
-    para a fase de recurso). Gates espelhados de
-    RegistrationAppealReview::eligibleCorrectors().
+    recurso ativa (STATUS_APPEAL_PHASE), com EMC, cuja fase pai tem EMC, e o
+    usuário tem @control na fase pai (onde @control cascateia para a fase de
+    recurso). Gates espelhados de RegistrationAppealReview::eligibleCorrectors().
+
+    F6 (#49) — override 2026-09-09 (Variante 3): elegibilidade aberta a TODOS
+    os métodos de avaliação (removida a exigência de método técnico); o
+    seletor de escopo de critérios existe apenas para technical e documentary
+    (criteriaCatalogs abaixo); nos demais, a correção é liberada integral.
 */
 if ($opportunity instanceof Opportunity && $opportunity->status === Opportunity::STATUS_APPEAL_PHASE) {
     $appeal_phase = $opportunity;
@@ -117,7 +127,6 @@ if ($opportunity instanceof Opportunity && $opportunity->status === Opportunity:
     $is_eligible_context = $main_phase
         && $appeal_phase->evaluationMethodConfiguration
         && $main_phase->evaluationMethodConfiguration
-        && $main_phase->evaluationMethodConfiguration->type->id === 'technical'
         && $main_phase->canUser('@control');
 
     if ($is_eligible_context) {
@@ -155,6 +164,95 @@ if ($opportunity instanceof Opportunity && $opportunity->status === Opportunity:
         $config['appealPhases']->{$main_phase_id} = $appeal_phase_id;
         $config['committees']->{$main_phase_id} = array_values($committee);
         $config['evaluators']->{$main_phase_id} = $evaluators;
+
+        /*
+            F6 (#49): catálogo de critérios por método da fase principal.
+            - technical: seções/critérios do EMC principal; a chave do
+              evaluationData é o id do critério
+              (technical-evaluation-form/template.php:16-21).
+            - documentary: campos e documentos exigidos das fases da
+              oportunidade; a chave é fieldName/fileGroupName
+              (documentary-evaluation-form/init.php:43-60).
+            - demais métodos: sem catálogo → designação sem seletor
+              (releasedScope nulo = correção integral).
+        */
+        $criteria_catalog = null;
+        $method_id = (string) $main_phase->evaluationMethodConfiguration->type->id;
+
+        if ($method_id === 'technical') {
+            $sections = is_array($main_phase->evaluationMethodConfiguration->sections) ? $main_phase->evaluationMethodConfiguration->sections : [];
+            $criteria = is_array($main_phase->evaluationMethodConfiguration->criteria) ? $main_phase->evaluationMethodConfiguration->criteria : [];
+
+            $catalog_sections = [];
+            $total = 0;
+
+            foreach ($sections as $section) {
+                $section_items = [];
+
+                foreach ($criteria as $criterion) {
+                    if (($criterion->sid ?? null) === ($section->id ?? null)) {
+                        $section_items[] = [
+                            'id' => (string) $criterion->id,
+                            'label' => (string) ($criterion->title ?? $criterion->id),
+                            'max' => $criterion->max ?? null,
+                        ];
+                    }
+                }
+
+                if ($section_items) {
+                    $catalog_sections[] = [
+                        'id' => (string) $section->id,
+                        'name' => (string) ($section->name ?? ''),
+                        'items' => $section_items,
+                    ];
+                    $total += count($section_items);
+                }
+            }
+
+            if ($total > 0) {
+                $criteria_catalog = [
+                    'method' => $method_id,
+                    'sections' => $catalog_sections,
+                    'total' => $total,
+                ];
+            }
+        } elseif ($method_id === 'documentary') {
+            $items = [];
+
+            foreach ($main_phase->allPhases as $phase) {
+                foreach ($phase->registrationFieldConfigurations as $field) {
+                    $items[$field->fieldName] = [
+                        'id' => (string) $field->fieldName,
+                        'label' => (string) ($field->title ?? $field->fieldName),
+                        'max' => null,
+                    ];
+                }
+
+                foreach ($phase->registrationFileConfigurations as $file) {
+                    $items[$file->fileGroupName] = [
+                        'id' => (string) $file->fileGroupName,
+                        'label' => (string) ($file->title ?? $file->fileGroupName),
+                        'max' => null,
+                    ];
+                }
+            }
+
+            if ($items) {
+                $criteria_catalog = [
+                    'method' => $method_id,
+                    'sections' => [
+                        [
+                            'id' => '',
+                            'name' => '',
+                            'items' => array_values($items),
+                        ],
+                    ],
+                    'total' => count($items),
+                ];
+            }
+        }
+
+        $config['criteriaCatalogs']->{$main_phase_id} = $criteria_catalog;
 
         // Tabela da fase de recurso (chaveada pela própria fase de recurso)
         $config['appealContexts']->{$appeal_phase_id} = ['mainPhaseId' => $main_phase_id];

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/script.js
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/script.js
@@ -79,6 +79,24 @@ app.component('opportunity-appeal-correction-assignment', {
                 : null;
         },
 
+        /**
+         * F6 (#49): catálogo de critérios selecionáveis da fase principal
+         * (injetado no init.php; presente só para technical/documentary).
+         */
+        criteriaCatalog() {
+            const catalogs = this.config.criteriaCatalogs || {};
+            return this.opportunityId != null
+                ? catalogs[this.opportunityId] ?? null
+                : null;
+        },
+
+        hasCriteriaSelector() {
+            const catalog = this.criteriaCatalog;
+            return !!catalog
+                && (catalog.total ?? 0) > 0
+                && this.allCriteriaIds().length > 0;
+        },
+
         markedSlots() {
             return this.slots.filter(slot => slot.checked);
         },
@@ -87,13 +105,23 @@ app.component('opportunity-appeal-correction-assignment', {
             return this.markedSlots.some(slot => !this.normalizeId(slot.correctorUserId));
         },
 
+        /**
+         * F6: seleção de escopo vazia (nenhum critério) invalida o salvar
+         * quando o seletor existe para o método da fase principal.
+         */
+        hasInvalidScopeSelection() {
+            return this.hasCriteriaSelector
+                && this.markedSlots.some(slot => this.scopeInvalidFrom(slot.scopeCriteria));
+        },
+
         canSave() {
             return this.endpointAvailable
                 && this.correctionEligible
                 && !this.loading
                 && !this.saving
                 && this.markedSlots.length > 0
-                && !this.hasInvalidSelection;
+                && !this.hasInvalidSelection
+                && !this.hasInvalidScopeSelection;
         },
 
         designatedCount() {
@@ -199,6 +227,9 @@ app.component('opportunity-appeal-correction-assignment', {
                 registration: evaluation.registration,
                 checked: false,
                 correctorUserId: null,
+                // F6: escopo inicia com TODOS os critérios (persiste null)
+                scopeCriteria: this.hasCriteriaSelector ? this.allCriteriaIds() : null,
+                scopeOpen: false,
             }));
 
             this.preSelectCorrectors();
@@ -218,7 +249,7 @@ app.component('opportunity-appeal-correction-assignment', {
 
             const api = new API('registrationappealreview');
             const reviews = await api.fetch('find', {
-                '@select': 'id,originalEvaluation.id,status,correctionType,endsAt,sentTimestamp,correctorUser',
+                '@select': 'id,originalEvaluation.id,status,correctionType,endsAt,sentTimestamp,correctorUser,releasedScope',
                 'registration': `EQ(${this.registrationId})`,
                 '@order': 'id ASC',
             }, { raw: true, rawProcessor: data => data });
@@ -234,6 +265,7 @@ app.component('opportunity-appeal-correction-assignment', {
                 endsAt: review.endsAt,
                 sentTimestamp: review.sentTimestamp,
                 correctorUserId: this.normalizeId(review.correctorUser),
+                releasedScope: this.normalizeScope(review.releasedScope),
             }));
         },
 
@@ -366,6 +398,96 @@ app.component('opportunity-appeal-correction-assignment', {
                 : this.text('committee tag');
         },
 
+        // ============================================================ //
+        // F6 (#49): seletor de escopo de critérios (Variante 3)
+        // Semântica persistida: TODOS marcados → releasedScope null (sem
+        // restrição, compatível com getReleasedCriteriaIds); subconjunto →
+        // {criteria: [...]}; vazio → inválido (cliente bloqueia, backend 400).
+        // ============================================================ //
+
+        allCriteriaIds() {
+            const catalog = this.criteriaCatalog;
+            if (!catalog) {
+                return [];
+            }
+
+            const ids = [];
+            for (const section of catalog.sections || []) {
+                for (const item of section.items || []) {
+                    ids.push(item.id);
+                }
+            }
+
+            return ids;
+        },
+
+        scopePayloadFrom(selected) {
+            if (!this.hasCriteriaSelector) {
+                return null;
+            }
+
+            if (!selected || selected.length >= this.allCriteriaIds().length) {
+                return null;
+            }
+
+            return { criteria: [...selected] };
+        },
+
+        scopeInvalidFrom(selected) {
+            return this.hasCriteriaSelector && (!selected || selected.length === 0);
+        },
+
+        slotScopeCount(slot) {
+            if (!this.hasCriteriaSelector) {
+                return 0;
+            }
+
+            return slot?.scopeCriteria?.length ?? this.criteriaCatalog.total;
+        },
+
+        /**
+         * Escopo vigente da designação para o painel: "todos liberados"
+         * (null) ou "X de Y critérios".
+         */
+        reviewScopeLabel(review) {
+            const ids = this.scopeCriteriaIds(review);
+
+            if (ids == null) {
+                return this.text('all criteria released');
+            }
+
+            const total = this.criteriaCatalog?.total ?? ids.length;
+            return this.text('scope count')
+                .replace('%s', ids.length)
+                .replace('%s', total);
+        },
+
+        scopeCriteriaIds(review) {
+            const scope = this.normalizeScope(review?.releasedScope);
+            if (!scope) {
+                return null;
+            }
+
+            const criteria = scope.criteria ?? scope.fields ?? null;
+            return criteria ? criteria.map(id => String(id)) : null;
+        },
+
+        normalizeScope(value) {
+            if (value == null) {
+                return null;
+            }
+
+            if (typeof value === 'string') {
+                try {
+                    value = JSON.parse(value);
+                } catch (error) {
+                    return null;
+                }
+            }
+
+            return value && typeof value === 'object' ? value : null;
+        },
+
         /**
          * Designação ATIVA (status 0/1/3) com API disponível pode ser
          * gerenciada da tela (substituir/cancelar). ENVIADO (2) não tem ações.
@@ -396,6 +518,10 @@ app.component('opportunity-appeal-correction-assignment', {
             slot.substitutionOpen = true;
             // Default: o corretor atual (PATCH só é enviado se mudar).
             slot.substituteUserId = review.correctorUserId ?? this.slotUserId(slot);
+            // F6: checklist pré-preenchida com o escopo vigente (todos quando
+            // null); trocar para "todos marcados" volta a liberar integral.
+            slot.substituteScopeCriteria = this.scopeCriteriaIds(review) ?? (this.hasCriteriaSelector ? this.allCriteriaIds() : null);
+            slot.substituteScopeOpen = this.hasCriteriaSelector;
         },
 
         cancelSubstitution(slot) {
@@ -404,7 +530,8 @@ app.component('opportunity-appeal-correction-assignment', {
 
         canConfirmSubstitution(slot) {
             return !slot.substituting
-                && this.normalizeId(slot.substituteUserId) != null;
+                && this.normalizeId(slot.substituteUserId) != null
+                && !this.scopeInvalidFrom(slot.substituteScopeCriteria);
         },
 
         /**
@@ -428,6 +555,7 @@ app.component('opportunity-appeal-correction-assignment', {
             try {
                 const response = await api.PATCH(url, {
                     correctorUser: this.normalizeId(slot.substituteUserId),
+                    releasedScope: this.scopePayloadFrom(slot.substituteScopeCriteria),
                 });
 
                 if (!response.ok) {
@@ -625,6 +753,8 @@ app.component('opportunity-appeal-correction-assignment', {
                 correctorUser: this.normalizeId(slot.correctorUserId),
                 status: this.config.statusDesignated ?? 0,
                 correctionType: this.config.correctionTypeDefault || 'official',
+                // F6: null = correção integral (todos ou método sem critérios)
+                releasedScope: this.scopePayloadFrom(slot.scopeCriteria),
             };
         },
 

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/script.js
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/script.js
@@ -1,11 +1,16 @@
 /**
- * opportunity-appeal-correction-assignment (F2 / issue #18)
+ * opportunity-appeal-correction-assignment (F2 #18 + F5 #45)
  *
  * Modal de designação de corretores por slot: lista as avaliações da fase
  * principal da inscrição (uma por avaliador), permite marcar quais notas serão
  * corrigidas e designar 1 corretor por slot marcado (dono do slot ou membro
  * da Comissão de Recursos — mesma regra de
  * RegistrationAppealReview::eligibleCorrectors()).
+ *
+ * F5: no painel de acompanhamento, designação ATIVA (status 0/1/3) ganha
+ * "Substituir corretor" (PATCH single com {correctorUser}, CA-3 revalidado
+ * server-side pelo PR6) e "Cancelar designação" (DELETE single — slot volta
+ * a ser designável). Status ENVIADO (2) não tem ações.
  *
  * Abertura: ver docblock do init.php deste componente (evento global
  * 'opportunity-appeal-correction-assignment:open' com {opportunity, registration}).
@@ -15,6 +20,8 @@
  * - /registrationappealreview (API canônica da entidade) → criação e
  *   acompanhamento; habilitada somente quando 'endpointAvailable' (controller
  *   da entidade registrado no backend).
+ * - PATCH/DELETE /registrationappealreview/single/{id} → substituição e
+ *   cancelamento de designação (PR6 / issue #40).
  */
 
 app.component('opportunity-appeal-correction-assignment', {
@@ -211,13 +218,14 @@ app.component('opportunity-appeal-correction-assignment', {
 
             const api = new API('registrationappealreview');
             const reviews = await api.fetch('find', {
-                '@select': 'id,originalEvaluation.id,status,correctionType,endsAt,sentTimestamp',
+                '@select': 'id,originalEvaluation.id,status,correctionType,endsAt,sentTimestamp,correctorUser',
                 'registration': `EQ(${this.registrationId})`,
                 '@order': 'id ASC',
             }, { raw: true, rawProcessor: data => data });
 
             // normalizeId aceita escalar OU objeto — o join com os slots
-            // compara ids normalizados nos dois lados.
+            // compara ids normalizados nos dois lados. correctorUser (escalar)
+            // alimenta o painel e o default da substituição (F5).
             this.reviews = (reviews || []).map(review => ({
                 id: this.normalizeId(review.id),
                 originalEvaluationId: this.normalizeId(review.originalEvaluation),
@@ -225,6 +233,7 @@ app.component('opportunity-appeal-correction-assignment', {
                 correctionType: review.correctionType,
                 endsAt: review.endsAt,
                 sentTimestamp: review.sentTimestamp,
+                correctorUserId: this.normalizeId(review.correctorUser),
             }));
         },
 
@@ -331,6 +340,143 @@ app.component('opportunity-appeal-correction-assignment', {
 
         reviewSentAt(review) {
             return this.formatDate(review?.sentTimestamp);
+        },
+
+        // ============================================================ //
+        // F5 (#45): substituição e cancelamento de designação (CA-13)
+        // ============================================================ //
+
+        /**
+         * Linha "trancada" (visual de inércia, cinza): somente designação
+         * ENVIADA — realmente sem ações. Designação ATIVA não usa esse estado:
+         * tem ações de gestão e deve parecer viva.
+         */
+        isSlotLocked(slot) {
+            const review = this.reviewForSlot(slot);
+            return !!review && !this.canManageReview(review);
+        },
+
+        /**
+         * Papel do corretor designado para exibição estática na coluna
+         * "Corretor designado": dono do slot ou Comissão de Recursos.
+         */
+        correctorRoleLabel(slot, review) {
+            return this.normalizeId(review?.correctorUserId) === this.slotUserId(slot)
+                ? this.text('slot owner tag')
+                : this.text('committee tag');
+        },
+
+        /**
+         * Designação ATIVA (status 0/1/3) com API disponível pode ser
+         * gerenciada da tela (substituir/cancelar). ENVIADO (2) não tem ações.
+         */
+        canManageReview(review) {
+            if (!this.endpointAvailable || !review) {
+                return false;
+            }
+
+            const active_statuses = this.config.activeStatuses || [0, 1, 3];
+            return active_statuses.includes(this.statusNumber(review));
+        },
+
+        /**
+         * Nome do corretor atual da designação (mesma resolução de nomes do
+         * painel: evaluators → Comissão de Recursos → null).
+         */
+        reviewCorrectorName(review) {
+            return this.evaluatorName(review?.correctorUserId);
+        },
+
+        startSubstitution(slot) {
+            const review = this.activeReviewForSlot(slot);
+            if (!review || !this.canManageReview(review)) {
+                return;
+            }
+
+            slot.substitutionOpen = true;
+            // Default: o corretor atual (PATCH só é enviado se mudar).
+            slot.substituteUserId = review.correctorUserId ?? this.slotUserId(slot);
+        },
+
+        cancelSubstitution(slot) {
+            slot.substitutionOpen = false;
+        },
+
+        canConfirmSubstitution(slot) {
+            return !slot.substituting
+                && this.normalizeId(slot.substituteUserId) != null;
+        },
+
+        /**
+         * Substitui o corretor da designação ativa do slot:
+         * PATCH /registrationappealreview/single/{id} com {correctorUser}.
+         * O backend revalida CA-3 (corretor inelegível → 400 com mensagem).
+         * Sucesso → mensagem + fetchReviews() reflete o novo corretor sem reload.
+         */
+        async confirmSubstitution(slot) {
+            const review = this.activeReviewForSlot(slot);
+            if (!review || !this.canConfirmSubstitution(slot)) {
+                return;
+            }
+
+            const messages = useMessages();
+            slot.substituting = true;
+
+            const api = new API('registrationappealreview');
+            const url = Utils.createUrl('registrationappealreview', 'single', { id: review.id });
+
+            try {
+                const response = await api.PATCH(url, {
+                    correctorUser: this.normalizeId(slot.substituteUserId),
+                });
+
+                if (!response.ok) {
+                    throw await response.json().catch(() => ({}));
+                }
+
+                messages.success(this.text('corrector replaced'));
+                slot.substitutionOpen = false;
+                await this.fetchReviews();
+            } catch (error) {
+                console.error('opportunity-appeal-correction-assignment:confirmSubstitution', error);
+                messages.error(this.backendErrorMessage(error) || this.text('replace error'));
+            } finally {
+                slot.substituting = false;
+            }
+        },
+
+        /**
+         * Cancela (DELETE /registrationappealreview/single/{id}) a designação
+         * do slot: volta ao estado designável — checkbox destravado pelo
+         * recomputo de slotSelectable() após o fetchReviews().
+         */
+        async cancelAssignment(slot) {
+            const review = this.activeReviewForSlot(slot) || this.reviewForSlot(slot);
+            if (!review || !this.endpointAvailable) {
+                return;
+            }
+
+            const messages = useMessages();
+            slot.canceling = true;
+
+            const api = new API('registrationappealreview');
+            const url = Utils.createUrl('registrationappealreview', 'single', { id: review.id });
+
+            try {
+                const response = await api.DELETE(url);
+
+                if (!response.ok) {
+                    throw await response.json().catch(() => ({}));
+                }
+
+                messages.success(this.text('designation canceled'));
+                await this.fetchReviews();
+            } catch (error) {
+                console.error('opportunity-appeal-correction-assignment:cancelAssignment', error);
+                messages.error(this.backendErrorMessage(error) || this.text('cancel designation error'));
+            } finally {
+                slot.canceling = false;
+            }
         },
 
         formatDate(value) {

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/script.js
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/script.js
@@ -1,0 +1,499 @@
+/**
+ * opportunity-appeal-correction-assignment (F2 / issue #18)
+ *
+ * Modal de designação de corretores por slot: lista as avaliações da fase
+ * principal da inscrição (uma por avaliador), permite marcar quais notas serão
+ * corrigidas e designar 1 corretor por slot marcado (dono do slot ou membro
+ * da Comissão de Recursos — mesma regra de
+ * RegistrationAppealReview::eligibleCorrectors()).
+ *
+ * Abertura: ver docblock do init.php deste componente (evento global
+ * 'opportunity-appeal-correction-assignment:open' com {opportunity, registration}).
+ *
+ * Backend consumido (somente endpoints existentes):
+ * - GET /api/registrationevaluation/find  → slots da inscrição.
+ * - /registrationappealreview (API canônica da entidade) → criação e
+ *   acompanhamento; habilitada somente quando 'endpointAvailable' (controller
+ *   da entidade registrado no backend).
+ */
+
+app.component('opportunity-appeal-correction-assignment', {
+    template: $TEMPLATES['opportunity-appeal-correction-assignment'],
+
+    emits: ['saved'],
+
+    setup() {
+        // os textos estão localizados no arquivo texts.php deste componente
+        const text = Utils.getTexts('opportunity-appeal-correction-assignment');
+        return { text };
+    },
+
+    data() {
+        return {
+            opportunityId: null,
+            registrationId: null,
+            registrationNumber: null,
+            slots: [],
+            reviews: [],
+            loading: false,
+            saving: false,
+        };
+    },
+
+    computed: {
+        config() {
+            return $MAPAS.config.appealCorrectionAssignment || {};
+        },
+
+        endpointAvailable() {
+            return this.config.endpointAvailable === true;
+        },
+
+        /**
+         * Contexto elegível: fase técnica com fase de recurso ativa e Comissão
+         * de Recursos injetada para a oportunidade recebida (espelha os gates
+         * de RegistrationAppealReview::eligibleCorrectors()).
+         */
+        correctionEligible() {
+            return this.appealPhaseId != null && Array.isArray(this.committee);
+        },
+
+        appealPhaseId() {
+            const appeal_phases = this.config.appealPhases || {};
+            return this.opportunityId != null
+                ? appeal_phases[this.opportunityId] ?? null
+                : null;
+        },
+
+        committee() {
+            const committees = this.config.committees || {};
+            return this.opportunityId != null
+                ? committees[this.opportunityId] ?? null
+                : null;
+        },
+
+        markedSlots() {
+            return this.slots.filter(slot => slot.checked);
+        },
+
+        hasInvalidSelection() {
+            return this.markedSlots.some(slot => !this.normalizeId(slot.correctorUserId));
+        },
+
+        canSave() {
+            return this.endpointAvailable
+                && this.correctionEligible
+                && !this.loading
+                && !this.saving
+                && this.markedSlots.length > 0
+                && !this.hasInvalidSelection;
+        },
+
+        designatedCount() {
+            return this.slots.filter(slot => this.reviewForSlot(slot) != null).length;
+        },
+
+        sentCount() {
+            const sent_status = this.config.statusSent ?? 2;
+            return this.reviews.filter(review => this.statusNumber(review) === sent_status).length;
+        },
+
+        progressSummary() {
+            return this.text('progress summary')
+                .replace('%s', this.designatedCount)
+                .replace('%s', this.slots.length)
+                .replace('%s', this.sentCount);
+        },
+
+        subtitle() {
+            const number = this.registrationNumber || this.slots[0]?.registration?.number || null;
+            return number ? `${this.text('registration')} ${number}` : '';
+        },
+    },
+
+    mounted() {
+        window.addEventListener('opportunity-appeal-correction-assignment:open', this.handleOpenEvent);
+    },
+
+    beforeUnmount() {
+        window.removeEventListener('opportunity-appeal-correction-assignment:open', this.handleOpenEvent);
+    },
+
+    methods: {
+        /**
+         * Interface pública (F1): detail = {opportunity, registration}.
+         * Aceita instâncias Entity do SDK ou objetos com ao menos {id}.
+         */
+        handleOpenEvent(event) {
+            const { opportunity, registration } = event?.detail || {};
+
+            const opportunity_id = this.normalizeId(opportunity);
+            const registration_id = this.normalizeId(registration);
+
+            if (!opportunity_id || !registration_id) {
+                console.error('opportunity-appeal-correction-assignment: evento requer {opportunity, registration} com id válido');
+                return;
+            }
+
+            this.opportunityId = opportunity_id;
+            this.registrationId = registration_id;
+            this.registrationNumber = registration?.number || null;
+            this.slots = [];
+            this.reviews = [];
+
+            this.$refs.modal?.open();
+            this.loadData();
+        },
+
+        async loadData() {
+            this.loading = true;
+
+            try {
+                await Promise.all([
+                    this.fetchSlots(),
+                    this.endpointAvailable ? this.fetchReviews() : Promise.resolve(),
+                ]);
+            } catch (error) {
+                console.error('opportunity-appeal-correction-assignment:', error);
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        /**
+         * Lista as N avaliações da fase principal da inscrição (uma por avaliador),
+         * via API de RegistrationEvaluation (a API filtra por permissão de visão).
+         *
+         * LEITURA RAW OBRIGATÓRIA: `fetch()` só ativa o modo raw com `raw: true`
+         * nas options (rawProcessor sozinho é ignorado) — sem isso o payload
+         * passa por Entity.populate(), que DESCARTA relações escalares
+         * (user:35 vira undefined) e campos computados (resultString).
+         *
+         * Shapes reais da ApiQuery (evidência de rede): `user` volta ESCALAR
+         * mesmo com select aninhado (expansão não suportada nesta entidade);
+         * `registration` expande como objeto. Nomes de avaliadores vêm do mapa
+         * `evaluators` injetado no init.php, não deste select.
+         */
+        async fetchSlots() {
+            const api = new API('registrationevaluation');
+            const evaluations = await api.fetch('find', {
+                '@select': 'id,user,status,result,resultString,registration.{id,number}',
+                'registration': `EQ(${this.registrationId})`,
+                '@order': 'id ASC',
+            }, { raw: true, rawProcessor: data => data });
+
+            this.slots = (evaluations || []).map(evaluation => ({
+                id: this.normalizeId(evaluation.id),
+                user: evaluation.user,
+                userId: this.normalizeId(evaluation.user),
+                status: evaluation.status,
+                result: evaluation.result,
+                resultString: evaluation.resultString,
+                registration: evaluation.registration,
+                checked: false,
+                correctorUserId: null,
+            }));
+
+            this.preSelectCorrectors();
+        },
+
+        /**
+         * Acompanhamento: designações existentes da inscrição. Disponível
+         * somente quando a API da entidade existe (endpointAvailable).
+         * Leitura raw pelo mesmo motivo de fetchSlots: `originalEvaluation`
+         * vem ACHATADO para escalar pela ApiQuery (evidência:
+         * {"originalEvaluation":1}) e o populate do SDK o descartaria.
+         */
+        async fetchReviews() {
+            if (!this.endpointAvailable) {
+                return;
+            }
+
+            const api = new API('registrationappealreview');
+            const reviews = await api.fetch('find', {
+                '@select': 'id,originalEvaluation.id,status,correctionType,endsAt,sentTimestamp',
+                'registration': `EQ(${this.registrationId})`,
+                '@order': 'id ASC',
+            }, { raw: true, rawProcessor: data => data });
+
+            // normalizeId aceita escalar OU objeto — o join com os slots
+            // compara ids normalizados nos dois lados.
+            this.reviews = (reviews || []).map(review => ({
+                id: this.normalizeId(review.id),
+                originalEvaluationId: this.normalizeId(review.originalEvaluation),
+                status: review.status,
+                correctionType: review.correctionType,
+                endsAt: review.endsAt,
+                sentTimestamp: review.sentTimestamp,
+            }));
+        },
+
+        /**
+         * Opções de corretor do slot: dono do slot + Comissão de Recursos,
+         * sem duplicatas (mesma composição de eligibleCorrectors()).
+         */
+        correctorOptions(slot) {
+            if (!this.correctionEligible) {
+                return [];
+            }
+
+            const options = [];
+            const seen = new Set();
+
+            const owner_id = this.slotUserId(slot);
+            if (owner_id != null) {
+                options.push({
+                    value: owner_id,
+                    label: `${this.slotAgentName(slot)} (${this.text('slot owner tag')})`,
+                });
+                seen.add(owner_id);
+            }
+
+            for (const member of this.committee) {
+                if (seen.has(member.userId)) {
+                    continue;
+                }
+
+                options.push({
+                    value: member.userId,
+                    label: `${member.name} (${this.text('committee tag')})`,
+                });
+                seen.add(member.userId);
+            }
+
+            return options;
+        },
+
+        /**
+         * Slot pode ser marcado: contexto elegível, sem designação ativa
+         * (o índice único de slots ativos impõe a mesma regra no backend).
+         */
+        slotSelectable(slot) {
+            return this.correctionEligible && !this.activeReviewForSlot(slot);
+        },
+
+        preSelectCorrectors() {
+            for (const slot of this.slots) {
+                slot.correctorUserId = this.slotUserId(slot);
+            }
+        },
+
+        activeReviewForSlot(slot) {
+            const active_statuses = this.config.activeStatuses || [0, 1, 3];
+            return this.reviews.find(review =>
+                review.originalEvaluationId != null
+                && review.originalEvaluationId === this.normalizeId(slot.id)
+                && active_statuses.includes(this.statusNumber(review))
+            ) || null;
+        },
+
+        reviewForSlot(slot) {
+            return this.reviews.find(review =>
+                review.originalEvaluationId != null
+                && review.originalEvaluationId === this.normalizeId(slot.id)
+            ) || null;
+        },
+
+        statusNumber(review) {
+            return parseInt(review?.status, 10);
+        },
+
+        statusLabel(review) {
+            const status_key = {
+                0: 'status designated',
+                1: 'status draft',
+                2: 'status sent',
+                3: 'status reopened',
+            }[this.statusNumber(review)];
+
+            return status_key ? this.text(status_key) : String(review?.status ?? '');
+        },
+
+        /**
+         * Classes utilitárias de cor do tema (0.settings/_atoms.scss) para o
+         * rótulo e o ícone de status — mesmo padrão do appeal-phase-chat
+         * (mc-icon "circle" + .{primary|success|warning|danger}__color):
+         * designado=pendente (primary), rascunho=em andamento (warning),
+         * enviado=concluído (success), reaberto=exige ação (danger).
+         */
+        statusClass(review) {
+            return {
+                0: 'primary__color',
+                1: 'warning__color',
+                2: 'success__color',
+                3: 'danger__color',
+            }[this.statusNumber(review)] || '';
+        },
+
+        reviewDeadline(review) {
+            return this.formatDate(review?.endsAt);
+        },
+
+        reviewSentAt(review) {
+            return this.formatDate(review?.sentTimestamp);
+        },
+
+        formatDate(value) {
+            if (!value) {
+                return '';
+            }
+
+            const raw = typeof value === 'object' ? (value.date ?? null) : value;
+            if (!raw) {
+                return '';
+            }
+
+            try {
+                const mcdate = new McDate(new Date(raw));
+                return `${mcdate.date('2-digit year')} ${mcdate.time()}`;
+            } catch (error) {
+                return String(raw).slice(0, 16).replace('T', ' ');
+            }
+        },
+
+        slotUserId(slot) {
+            return slot?.userId ?? this.normalizeId(slot?.user);
+        },
+
+        /**
+         * Nome do avaliador pelo mapa `evaluators` injetado no init.php —
+         * chaveado por opportunityId (mesma estrutura de `committees`):
+         * {opportunityId: {userId: name}}. A API de avaliação não expõe
+         * nome (relação user não expande). Fallback: Comissão de Recursos
+         * da fase de recurso (config.committees, também por oportunidade).
+         */
+        evaluatorName(userId) {
+            if (userId == null) {
+                return null;
+            }
+
+            const evaluators = this.config.evaluators || {};
+            const name = this.opportunityId != null
+                ? evaluators[this.opportunityId]?.[userId] ?? null
+                : null;
+
+            if (name) {
+                return name;
+            }
+
+            const committee_member = (this.committee || []).find(member => member.userId === userId);
+            return committee_member?.name || null;
+        },
+
+        slotAgentName(slot) {
+            return this.evaluatorName(this.slotUserId(slot))
+                || slot?.agent?.name
+                || slot?.user?.profile?.name
+                || slot?.user?.name
+                || slot?.agent?.email
+                || slot?.user?.profile?.email
+                || this.text('slot owner tag');
+        },
+
+        /**
+         * Cria 1 RegistrationAppealReview por nota marcada, via API canônica
+         * da entidade. Defaults: status=DESIGNATED, correction_type=official,
+         * prazo e escopo livres (CA-4 fica para a onda de parametrização).
+         */
+        async saveDesignations(close) {
+            if (!this.canSave) {
+                return;
+            }
+
+            const messages = useMessages();
+            this.saving = true;
+
+            const api = new API('registrationappealreview');
+            const url = api.createUrl('index');
+
+            try {
+                for (const slot of this.markedSlots) {
+                    const response = await api.POST(url, this.buildAssignmentPayload(slot));
+
+                    if (!response.ok) {
+                        const error = await response.json().catch(() => ({}));
+                        throw error;
+                    }
+                }
+
+                messages.success(this.text('saved'));
+                this.$emit('saved', { registrationId: this.registrationId });
+
+                await this.fetchReviews();
+
+                close();
+            } catch (error) {
+                console.error('opportunity-appeal-correction-assignment:saveDesignations', error);
+                messages.error(this.backendErrorMessage(error) || this.text('save error'));
+            } finally {
+                this.saving = false;
+            }
+        },
+
+        /**
+         * Extrai a mensagem de erro devolvida pelo backend para exibição.
+         *
+         * Shapes reais: Controller::errorJson responde
+         * {error: true, data: "mensagem"} ou {error: true, data: {campo: msg}}
+         * (validação); aceita também {error: "mensagem"} por defesa.
+         * Retorna null quando não há texto utilizável (caller usa o genérico).
+         */
+        backendErrorMessage(error) {
+            const candidates = [
+                error?.data,
+                error?.error,
+                error?.data?.error,
+            ];
+
+            for (const candidate of candidates) {
+                if (typeof candidate === 'string' && candidate.trim()) {
+                    return candidate.trim();
+                }
+
+                if (candidate && typeof candidate === 'object') {
+                    const messages = Object.values(candidate)
+                        .flat()
+                        .map(value => (typeof value === 'string' ? value.trim() : ''))
+                        .filter(Boolean);
+
+                    if (messages.length) {
+                        return messages.join(' ');
+                    }
+                }
+            }
+
+            return null;
+        },
+
+        /**
+         * Payload de criação de 1 designação (RegistrationAppealReview) para o
+         * slot informado. Defaults: status=DESIGNATED, correction_type=official,
+         * prazo e escopo livres (CA-4 fica para a onda de parametrização).
+         */
+        buildAssignmentPayload(slot) {
+            return {
+                originalEvaluation: slot.id,
+                registration: this.registrationId,
+                appealPhase: this.appealPhaseId,
+                slotOwnerUser: this.slotUserId(slot),
+                correctorUser: this.normalizeId(slot.correctorUserId),
+                status: this.config.statusDesignated ?? 0,
+                correctionType: this.config.correctionTypeDefault || 'official',
+            };
+        },
+
+        normalizeId(value) {
+            if (value == null) {
+                return null;
+            }
+
+            const raw_id = typeof value === 'object' ? (value.id ?? null) : value;
+            if (raw_id == null) {
+                return null;
+            }
+
+            const parsed = parseInt(raw_id, 10);
+            return Number.isNaN(parsed) ? null : parsed;
+        },
+    },
+});

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/style.css
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/style.css
@@ -73,6 +73,44 @@
     gap: .25rem;
 }
 
+/* F5: slot designado — dono como leitura estática viva (não controle desabilitado).
+   Sem checkbox na linha, os recuos pensados para o layout com checkbox zeram. */
+.opportunity-appeal-correction-assignment__slot-owner {
+    align-items: center;
+    display: flex;
+    gap: .5rem;
+}
+
+.opportunity-appeal-correction-assignment__slot-owner .iconify {
+    font-size: .75rem;
+    min-width: .75rem;
+}
+
+.opportunity-appeal-correction-assignment__slot--assigned .opportunity-appeal-correction-assignment__slot-result,
+.opportunity-appeal-correction-assignment__slot--assigned .opportunity-appeal-correction-assignment__tag {
+    margin-left: 0;
+}
+
+/* F5: corretor designado como leitura estática com tag de papel */
+.opportunity-appeal-correction-assignment__assigned {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: .25rem;
+}
+
+.opportunity-appeal-correction-assignment__assigned .iconify {
+    font-size: 1rem;
+    min-width: 1rem;
+}
+
+.opportunity-appeal-correction-assignment__tag--role {
+    background-color: #fff;
+    border: 1px solid var(--mc-primary-500);
+    color: var(--mc-primary-500);
+    margin: 0;
+}
+
 .opportunity-appeal-correction-assignment__slot-check input {
     margin-right: .25rem;
 }
@@ -144,6 +182,36 @@
 .opportunity-appeal-correction-assignment__status-detail--empty {
     font-size: .75rem;
     opacity: .5;
+}
+
+/* F5 (#45): ações de gestão (substituir/cancelar) e substituição inline */
+.opportunity-appeal-correction-assignment__actions {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: .25rem;
+    margin-top: .5rem;
+}
+
+.opportunity-appeal-correction-assignment__actions .button {
+    padding-block: .25rem;
+}
+
+.opportunity-appeal-correction-assignment__substitution {
+    background-color: #fff;
+    border: 1px dashed var(--mc-gray-300);
+    border-radius: var(--mc-border-radius-xs);
+    display: flex;
+    flex-direction: column;
+    gap: .5rem;
+    margin-top: .5rem;
+    padding: .5rem;
+}
+
+.opportunity-appeal-correction-assignment__substitution-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem;
 }
 
 /* Mesmo breakpoint do mc-modal/.grid-12 (800px): linhas empilham. */

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/style.css
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/style.css
@@ -214,6 +214,46 @@
     gap: .5rem;
 }
 
+/* F6 (#49): seletor de escopo de critérios */
+.opportunity-appeal-correction-assignment__scope {
+    display: flex;
+    flex-direction: column;
+    gap: .25rem;
+    margin-top: .25rem;
+}
+
+.opportunity-appeal-correction-assignment__scope-list {
+    background-color: var(--mc-gray-100);
+    border: 1px solid var(--mc-gray-300);
+    border-radius: var(--mc-border-radius-xs);
+    display: flex;
+    flex-direction: column;
+    gap: .5rem;
+    margin-top: .25rem;
+    max-height: 16rem;
+    overflow-y: auto;
+    padding: .5rem;
+}
+
+.opportunity-appeal-correction-assignment__scope-section {
+    display: flex;
+    flex-direction: column;
+    gap: .25rem;
+    font-size: .875rem;
+}
+
+.opportunity-appeal-correction-assignment__scope-item {
+    align-items: center;
+    cursor: pointer;
+    display: flex;
+    gap: .5rem;
+    padding-left: .25rem;
+}
+
+.opportunity-appeal-correction-assignment__scope-item input {
+    margin: 0;
+}
+
 /* Mesmo breakpoint do mc-modal/.grid-12 (800px): linhas empilham. */
 @media (max-width: 800px) {
     .opportunity-appeal-correction-assignment__header {

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/style.css
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/style.css
@@ -1,0 +1,158 @@
+/*
+ * opportunity-appeal-correction-assignment (F2 / issue #18)
+ *
+ * Estilo local no padrão do mc-modal (style.css do componente é enfileirado
+ * automaticamente pelo AssetManager — sem passo de build). Estrutura visual:
+ * estrutura do diálogo vem do mc-modal (.modal-content/.modal__*); aqui só o
+ * conteúdo interno — linhas de slot, badges e estados — usando tokens e
+ * classes utilitárias do tema BaseV2 (--mc-*, .semibold, .warning__background,
+ * .primary__color, .success__color, .warning__color, .danger__color).
+ */
+
+.opportunity-appeal-correction-assignment .modal-content {
+    min-width: 0;
+}
+
+@media (min-width: 801px) {
+    .opportunity-appeal-correction-assignment .modal-content {
+        min-width: 45rem;
+        max-width: 45rem;
+    }
+}
+
+.opportunity-appeal-correction-assignment__content {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding-bottom: .75rem;
+}
+
+.opportunity-appeal-correction-assignment__empty,
+.opportunity-appeal-correction-assignment__progress {
+    align-items: center;
+    display: flex;
+    gap: .5rem;
+}
+
+.opportunity-appeal-correction-assignment__empty {
+    opacity: .7;
+}
+
+.opportunity-appeal-correction-assignment__header {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) minmax(0, 1fr);
+    font-size: .75rem;
+    font-weight: 600;
+    letter-spacing: .02em;
+    opacity: .7;
+    padding: 0 .75rem;
+    text-transform: uppercase;
+}
+
+.opportunity-appeal-correction-assignment__slot {
+    align-items: start;
+    background-color: var(--mc-gray-100);
+    border: 1px solid var(--mc-gray-300);
+    border-radius: var(--mc-border-radius-sm);
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) minmax(0, 1fr);
+    padding: .75rem;
+}
+
+.opportunity-appeal-correction-assignment__slot--disabled {
+    opacity: .5;
+}
+
+.opportunity-appeal-correction-assignment__slot-check {
+    align-items: flex-start;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: .25rem;
+}
+
+.opportunity-appeal-correction-assignment__slot-check input {
+    margin-right: .25rem;
+}
+
+.opportunity-appeal-correction-assignment__slot-valuer {
+    display: block;
+    margin-left: 1.5rem;
+}
+
+.opportunity-appeal-correction-assignment__slot-result {
+    font-size: .875rem;
+    margin: .25rem 0 0 1.5rem;
+    opacity: .7;
+}
+
+.opportunity-appeal-correction-assignment__tag {
+    border-radius: var(--mc-border-radius-pill);
+    display: inline-block;
+    font-size: .75rem;
+    font-weight: 600;
+    line-height: 1;
+    margin: .5rem 0 0 1.5rem;
+    padding: .4rem .75rem;
+}
+
+.opportunity-appeal-correction-assignment__select {
+    background-color: #fff;
+    border: 1px solid var(--mc-low-500);
+    border-radius: var(--mc-border-radius-xs);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: .875rem;
+    min-height: 2.75rem;
+    padding: .5rem .75rem;
+    width: 100%;
+}
+
+.opportunity-appeal-correction-assignment__select:disabled {
+    cursor: default;
+    opacity: .5;
+}
+
+.opportunity-appeal-correction-assignment__slot-hint {
+    font-size: .75rem;
+    margin-top: .25rem;
+}
+
+.opportunity-appeal-correction-assignment__status {
+    align-items: center;
+    display: flex;
+    gap: .5rem;
+}
+
+.opportunity-appeal-correction-assignment__status .iconify,
+.opportunity-appeal-correction-assignment__status-detail .iconify {
+    font-size: .75rem;
+    min-width: .75rem;
+}
+
+.opportunity-appeal-correction-assignment__status-detail {
+    align-items: center;
+    display: flex;
+    font-size: .75rem;
+    gap: .5rem;
+    margin-top: .25rem;
+    opacity: .7;
+}
+
+.opportunity-appeal-correction-assignment__status-detail--empty {
+    font-size: .75rem;
+    opacity: .5;
+}
+
+/* Mesmo breakpoint do mc-modal/.grid-12 (800px): linhas empilham. */
+@media (max-width: 800px) {
+    .opportunity-appeal-correction-assignment__header {
+        display: none;
+    }
+
+    .opportunity-appeal-correction-assignment__slot {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/template.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/template.php
@@ -120,6 +120,48 @@ $this->import('
                             class="opportunity-appeal-correction-assignment__slot-hint danger__color">
                             <?= i::__('Selecione o corretor para salvar esta designação') ?>
                         </div>
+
+                        <!-- F6 (#49): seletor de escopo (só para métodos com critérios) -->
+                        <div v-if="slot.checked && hasCriteriaSelector" class="opportunity-appeal-correction-assignment__scope">
+                            <button
+                                type="button"
+                                class="button button--sm button--text primary__color"
+                                @click="slot.scopeOpen = !slot.scopeOpen">
+
+                                <mc-icon :name="slot.scopeOpen ? 'arrow-up' : 'arrow-down'"></mc-icon>
+                                {{ text('criteria scope') }} ({{ slotScopeCount(slot) }}/{{ criteriaCatalog.total }})
+                            </button>
+
+                            <div v-if="slot.scopeOpen" class="opportunity-appeal-correction-assignment__scope-list">
+                                <div
+                                    v-for="section in criteriaCatalog.sections"
+                                    :key="section.id || section.name"
+                                    class="opportunity-appeal-correction-assignment__scope-section">
+
+                                    <div v-if="section.name" class="semibold">{{ section.name }}</div>
+
+                                    <label
+                                        v-for="item in section.items"
+                                        :key="item.id"
+                                        class="opportunity-appeal-correction-assignment__scope-item"
+                                        :for="'scope-' + slot.id + '-' + item.id">
+
+                                        <input
+                                            type="checkbox"
+                                            :id="'scope-' + slot.id + '-' + item.id"
+                                            :name="'scope-' + slot.id + '[]'"
+                                            :value="item.id"
+                                            v-model="slot.scopeCriteria">
+
+                                        <span>{{ item.label }}</span>
+                                    </label>
+                                </div>
+
+                                <div v-if="scopeInvalidFrom(slot.scopeCriteria)" class="opportunity-appeal-correction-assignment__slot-hint danger__color">
+                                    {{ text('select at least one criterion') }}
+                                </div>
+                            </div>
+                        </div>
                     </template>
                 </div>
 
@@ -146,6 +188,12 @@ $this->import('
                         <div v-if="reviewSentAt(reviewForSlot(slot))" class="opportunity-appeal-correction-assignment__status-detail">
                             <mc-icon name="send"></mc-icon>
                             <span><?= i::__('Enviada em') ?>: {{ reviewSentAt(reviewForSlot(slot)) }}</span>
+                        </div>
+
+                        <!-- F6: escopo da designação (todos liberados / X de Y) -->
+                        <div class="opportunity-appeal-correction-assignment__status-detail">
+                            <mc-icon name="list"></mc-icon>
+                            <span>{{ reviewScopeLabel(reviewForSlot(slot)) }}</span>
                         </div>
 
                         <!-- F5 (#45): gestão de designação ativa (substituir/cancelar) — únicos controles ativos da linha -->
@@ -197,6 +245,48 @@ $this->import('
 
                             <div v-if="slot.substituteUserId == null" class="opportunity-appeal-correction-assignment__slot-hint danger__color">
                                 <?= i::__('Selecione o novo corretor para confirmar') ?>
+                            </div>
+
+                            <!-- F6: escopo pré-preenchido com o vigente na substituição -->
+                            <div v-if="hasCriteriaSelector" class="opportunity-appeal-correction-assignment__scope">
+                                <button
+                                    type="button"
+                                    class="button button--sm button--text primary__color"
+                                    @click="slot.substituteScopeOpen = !slot.substituteScopeOpen">
+
+                                    <mc-icon :name="slot.substituteScopeOpen ? 'arrow-up' : 'arrow-down'"></mc-icon>
+                                    {{ text('criteria scope') }} ({{ (slot.substituteScopeCriteria || []).length }}/{{ criteriaCatalog.total }})
+                                </button>
+
+                                <div v-if="slot.substituteScopeOpen" class="opportunity-appeal-correction-assignment__scope-list">
+                                    <div
+                                        v-for="section in criteriaCatalog.sections"
+                                        :key="section.id || section.name"
+                                        class="opportunity-appeal-correction-assignment__scope-section">
+
+                                        <div v-if="section.name" class="semibold">{{ section.name }}</div>
+
+                                        <label
+                                            v-for="item in section.items"
+                                            :key="item.id"
+                                            class="opportunity-appeal-correction-assignment__scope-item"
+                                            :for="'substitute-scope-' + slot.id + '-' + item.id">
+
+                                            <input
+                                                type="checkbox"
+                                                :id="'substitute-scope-' + slot.id + '-' + item.id"
+                                                :name="'substitute-scope-' + slot.id + '[]'"
+                                                :value="item.id"
+                                                v-model="slot.substituteScopeCriteria">
+
+                                            <span>{{ item.label }}</span>
+                                        </label>
+                                    </div>
+
+                                    <div v-if="scopeInvalidFrom(slot.substituteScopeCriteria)" class="opportunity-appeal-correction-assignment__slot-hint danger__color">
+                                        {{ text('select at least one criterion') }}
+                                    </div>
+                                </div>
                             </div>
 
                             <div class="opportunity-appeal-correction-assignment__substitution-actions">

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/template.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/template.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * @var MapasCulturais\App $app
+ * @var MapasCulturais\Themes\BaseV2\Theme $this
+ */
+
+use MapasCulturais\i;
+
+$this->import('
+    mc-alert
+    mc-icon
+    mc-loading
+    mc-modal
+');
+?>
+
+<mc-modal ref="modal" classes="opportunity-appeal-correction-assignment" :title="text('title')" :subtitle="subtitle">
+    <template #default="{ close }">
+        <div class="opportunity-appeal-correction-assignment__content">
+            <mc-alert v-if="!endpointAvailable" type="warning">{{ text('endpoint unavailable') }}</mc-alert>
+
+            <mc-alert v-if="!correctionEligible" type="warning">{{ text('eligible context required') }}</mc-alert>
+
+            <mc-loading :condition="loading">{{ text('loading') }}</mc-loading>
+
+            <div v-if="!loading && !slots.length" class="opportunity-appeal-correction-assignment__empty">
+                {{ text('empty slots') }}
+            </div>
+
+            <div v-if="!loading && slots.length" class="opportunity-appeal-correction-assignment__progress semibold">
+                <mc-icon name="circle" class="primary__color"></mc-icon>
+                {{ progressSummary }}
+            </div>
+
+            <div v-if="!loading && slots.length" class="opportunity-appeal-correction-assignment__header">
+                <div><?= i::__('Avaliação (slot)') ?></div>
+                <div><?= i::__('Corretor designado') ?></div>
+                <div><?= i::__('Acompanhamento') ?></div>
+            </div>
+
+            <div
+                v-for="slot in slots"
+                :key="slot.id"
+                class="opportunity-appeal-correction-assignment__slot"
+                :class="{ 'opportunity-appeal-correction-assignment__slot--disabled': !slotSelectable(slot) }">
+
+                <div class="opportunity-appeal-correction-assignment__slot-score">
+                    <label
+                        class="opportunity-appeal-correction-assignment__slot-check"
+                        :class="{ 'semibold': slot.checked }"
+                        :for="'correct-slot-' + slot.id">
+
+                        <input
+                            type="checkbox"
+                            :id="'correct-slot-' + slot.id"
+                            :name="'correct-slot-' + slot.id"
+                            v-model="slot.checked"
+                            :disabled="!slotSelectable(slot)">
+
+                        <span>
+                            <span class="semibold">{{ text('correct this score') }}</span>
+                            <span class="opportunity-appeal-correction-assignment__slot-valuer">
+                                {{ slotAgentName(slot) }}
+                            </span>
+                        </span>
+                    </label>
+
+                    <div class="opportunity-appeal-correction-assignment__slot-result">
+                        {{ slot.resultString }}
+                    </div>
+
+                    <span
+                        v-if="activeReviewForSlot(slot)"
+                        class="opportunity-appeal-correction-assignment__tag warning__background">
+                        {{ text('already designated') }}
+                    </span>
+                </div>
+
+                <div class="opportunity-appeal-correction-assignment__slot-corrector">
+                    <select
+                        class="opportunity-appeal-correction-assignment__select"
+                        :id="'corrector-select-' + slot.id"
+                        :name="'corrector-select-' + slot.id"
+                        :aria-label="text('select corrector') + ' — ' + slotAgentName(slot)"
+                        v-model="slot.correctorUserId"
+                        :disabled="!slot.checked || !slotSelectable(slot)">
+
+                        <option :value="null" disabled>{{ text('select corrector') }}</option>
+                        <option
+                            v-for="option in correctorOptions(slot)"
+                            :key="option.value"
+                            :value="option.value">
+                            {{ option.label }}
+                        </option>
+                    </select>
+
+                    <div
+                        v-if="slot.checked && !slot.correctorUserId"
+                        class="opportunity-appeal-correction-assignment__slot-hint danger__color">
+                        <?= i::__('Selecione o corretor para salvar esta designação') ?>
+                    </div>
+                </div>
+
+                <div class="opportunity-appeal-correction-assignment__slot-status">
+                    <template v-if="reviewForSlot(slot)">
+                        <div
+                            class="opportunity-appeal-correction-assignment__status semibold"
+                            :class="statusClass(reviewForSlot(slot))">
+
+                            <mc-icon name="circle" :class="statusClass(reviewForSlot(slot))"></mc-icon>
+                            {{ statusLabel(reviewForSlot(slot)) }}
+                        </div>
+
+                        <div v-if="reviewDeadline(reviewForSlot(slot))" class="opportunity-appeal-correction-assignment__status-detail">
+                            <mc-icon name="clock"></mc-icon>
+                            <span><?= i::__('Prazo') ?>: {{ reviewDeadline(reviewForSlot(slot)) }}</span>
+                        </div>
+
+                        <div v-if="reviewSentAt(reviewForSlot(slot))" class="opportunity-appeal-correction-assignment__status-detail">
+                            <mc-icon name="send"></mc-icon>
+                            <span><?= i::__('Enviada em') ?>: {{ reviewSentAt(reviewForSlot(slot)) }}</span>
+                        </div>
+                    </template>
+
+                    <span v-else class="opportunity-appeal-correction-assignment__status-detail--empty">
+                        {{ text('no designation') }}
+                    </span>
+                </div>
+            </div>
+        </div>
+    </template>
+
+    <template #actions="{ close }">
+        <button class="button button--text" @click="close()">
+            <?= i::__('Cancelar') ?>
+        </button>
+
+        <button
+            class="button button--md button--primary"
+            :class="{ 'disabled': !canSave }"
+            :disabled="!canSave"
+            @click="saveDesignations(close)">
+
+            {{ saving ? text('saving') : text('save') }}
+        </button>
+    </template>
+</mc-modal>

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/template.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/template.php
@@ -8,6 +8,7 @@ use MapasCulturais\i;
 
 $this->import('
     mc-alert
+    mc-confirm-button
     mc-icon
     mc-loading
     mc-modal
@@ -42,10 +43,20 @@ $this->import('
                 v-for="slot in slots"
                 :key="slot.id"
                 class="opportunity-appeal-correction-assignment__slot"
-                :class="{ 'opportunity-appeal-correction-assignment__slot--disabled': !slotSelectable(slot) }">
+                :class="{
+                    'opportunity-appeal-correction-assignment__slot--disabled': isSlotLocked(slot),
+                    'opportunity-appeal-correction-assignment__slot--assigned': !!reviewForSlot(slot),
+                }">
 
                 <div class="opportunity-appeal-correction-assignment__slot-score">
+                    <!-- Slot designado: leitura estática do dono (sem controle desabilitado) -->
+                    <div v-if="reviewForSlot(slot)" class="opportunity-appeal-correction-assignment__slot-owner semibold">
+                        <mc-icon name="circle" :class="statusClass(reviewForSlot(slot))"></mc-icon>
+                        <span>{{ slotAgentName(slot) }}</span>
+                    </div>
+
                     <label
+                        v-else
                         class="opportunity-appeal-correction-assignment__slot-check"
                         :class="{ 'semibold': slot.checked }"
                         :for="'correct-slot-' + slot.id">
@@ -77,28 +88,39 @@ $this->import('
                 </div>
 
                 <div class="opportunity-appeal-correction-assignment__slot-corrector">
-                    <select
-                        class="opportunity-appeal-correction-assignment__select"
-                        :id="'corrector-select-' + slot.id"
-                        :name="'corrector-select-' + slot.id"
-                        :aria-label="text('select corrector') + ' — ' + slotAgentName(slot)"
-                        v-model="slot.correctorUserId"
-                        :disabled="!slot.checked || !slotSelectable(slot)">
-
-                        <option :value="null" disabled>{{ text('select corrector') }}</option>
-                        <option
-                            v-for="option in correctorOptions(slot)"
-                            :key="option.value"
-                            :value="option.value">
-                            {{ option.label }}
-                        </option>
-                    </select>
-
-                    <div
-                        v-if="slot.checked && !slot.correctorUserId"
-                        class="opportunity-appeal-correction-assignment__slot-hint danger__color">
-                        <?= i::__('Selecione o corretor para salvar esta designação') ?>
+                    <!-- Slot designado: corretor como leitura estática com papel -->
+                    <div v-if="reviewForSlot(slot)" class="opportunity-appeal-correction-assignment__assigned">
+                        <mc-icon name="agent" class="primary__color"></mc-icon>
+                        <span class="semibold">{{ reviewCorrectorName(reviewForSlot(slot)) || '—' }}</span>
+                        <span class="opportunity-appeal-correction-assignment__tag opportunity-appeal-correction-assignment__tag--role">
+                            {{ correctorRoleLabel(slot, reviewForSlot(slot)) }}
+                        </span>
                     </div>
+
+                    <template v-else>
+                        <select
+                            class="opportunity-appeal-correction-assignment__select"
+                            :id="'corrector-select-' + slot.id"
+                            :name="'corrector-select-' + slot.id"
+                            :aria-label="text('select corrector') + ' — ' + slotAgentName(slot)"
+                            v-model="slot.correctorUserId"
+                            :disabled="!slot.checked || !slotSelectable(slot)">
+
+                            <option :value="null" disabled>{{ text('select corrector') }}</option>
+                            <option
+                                v-for="option in correctorOptions(slot)"
+                                :key="option.value"
+                                :value="option.value">
+                                {{ option.label }}
+                            </option>
+                        </select>
+
+                        <div
+                            v-if="slot.checked && !slot.correctorUserId"
+                            class="opportunity-appeal-correction-assignment__slot-hint danger__color">
+                            <?= i::__('Selecione o corretor para salvar esta designação') ?>
+                        </div>
+                    </template>
                 </div>
 
                 <div class="opportunity-appeal-correction-assignment__slot-status">
@@ -111,6 +133,11 @@ $this->import('
                             {{ statusLabel(reviewForSlot(slot)) }}
                         </div>
 
+                        <div v-if="reviewCorrectorName(reviewForSlot(slot))" class="opportunity-appeal-correction-assignment__status-detail">
+                            <mc-icon name="agent"></mc-icon>
+                            <span><?= i::__('Corretor') ?>: {{ reviewCorrectorName(reviewForSlot(slot)) }}</span>
+                        </div>
+
                         <div v-if="reviewDeadline(reviewForSlot(slot))" class="opportunity-appeal-correction-assignment__status-detail">
                             <mc-icon name="clock"></mc-icon>
                             <span><?= i::__('Prazo') ?>: {{ reviewDeadline(reviewForSlot(slot)) }}</span>
@@ -119,6 +146,78 @@ $this->import('
                         <div v-if="reviewSentAt(reviewForSlot(slot))" class="opportunity-appeal-correction-assignment__status-detail">
                             <mc-icon name="send"></mc-icon>
                             <span><?= i::__('Enviada em') ?>: {{ reviewSentAt(reviewForSlot(slot)) }}</span>
+                        </div>
+
+                        <!-- F5 (#45): gestão de designação ativa (substituir/cancelar) — únicos controles ativos da linha -->
+                        <div v-if="canManageReview(reviewForSlot(slot))" class="opportunity-appeal-correction-assignment__actions">
+                            <button
+                                class="button button--sm button--text primary__color"
+                                :class="{ 'disabled': slot.substituting || slot.canceling }"
+                                :disabled="slot.substituting || slot.canceling"
+                                @click="startSubstitution(slot)">
+
+                                <?= i::__('Substituir corretor') ?>
+                            </button>
+
+                            <mc-confirm-button :loading="slot.canceling || false" @confirm="cancelAssignment(slot)">
+                                <template #button="modal">
+                                    <button
+                                        class="button button--sm button--text-danger"
+                                        :class="{ 'disabled': slot.substituting || slot.canceling }"
+                                        :disabled="slot.substituting || slot.canceling"
+                                        @click="modal.open()">
+
+                                        <?= i::__('Cancelar designação') ?>
+                                    </button>
+                                </template>
+                                <template #message>
+                                    <?= i::__('Tem certeza que deseja cancelar esta designação? O slot voltará a ficar disponível para nova designação.') ?>
+                                </template>
+                            </mc-confirm-button>
+                        </div>
+
+                        <!-- F5: substituição inline -->
+                        <div v-if="slot.substitutionOpen" class="opportunity-appeal-correction-assignment__substitution">
+                            <select
+                                class="opportunity-appeal-correction-assignment__select"
+                                :id="'substitute-corrector-' + slot.id"
+                                :name="'substitute-corrector-' + slot.id"
+                                :aria-label="text('select substitute') + ' — ' + slotAgentName(slot)"
+                                v-model="slot.substituteUserId"
+                                :disabled="slot.substituting">
+
+                                <option :value="null" disabled>{{ text('select substitute') }}</option>
+                                <option
+                                    v-for="option in correctorOptions(slot)"
+                                    :key="option.value"
+                                    :value="option.value">
+                                    {{ option.label }}
+                                </option>
+                            </select>
+
+                            <div v-if="slot.substituteUserId == null" class="opportunity-appeal-correction-assignment__slot-hint danger__color">
+                                <?= i::__('Selecione o novo corretor para confirmar') ?>
+                            </div>
+
+                            <div class="opportunity-appeal-correction-assignment__substitution-actions">
+                                <button
+                                    class="button button--sm button--primary"
+                                    :class="{ 'disabled': !canConfirmSubstitution(slot) }"
+                                    :disabled="!canConfirmSubstitution(slot)"
+                                    @click="confirmSubstitution(slot)">
+
+                                    {{ slot.substituting ? text('substituting') : text('confirm substitution') }}
+                                </button>
+
+                                <button
+                                    class="button button--sm button--text"
+                                    :class="{ 'disabled': slot.substituting }"
+                                    :disabled="slot.substituting"
+                                    @click="cancelSubstitution(slot)">
+
+                                    <?= i::__('Cancelar') ?>
+                                </button>
+                            </div>
                         </div>
                     </template>
 

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/texts.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/texts.php
@@ -1,0 +1,43 @@
+<?php
+
+use MapasCulturais\App;
+use MapasCulturais\i;
+
+$app = App::i();
+
+$texts = [
+    // título e cabeçalho
+    'title' => i::__('Designar corretores de nota'),
+    'registration' => i::__('Inscrição'),
+    'empty slots' => i::__('Nenhuma avaliação encontrada para esta inscrição.'),
+
+    // linha por slot
+    'correct this score' => i::__('Corrigir esta nota'),
+    'select corrector' => i::__('Selecione o corretor'),
+    'slot owner tag' => i::__('avaliador do slot'),
+    'committee tag' => i::__('Comissão de Recursos'),
+    'already designated' => i::__('Já designado'),
+    'eligible context required' => i::__('A designação de corretores exige uma fase de avaliação técnica com fase de recurso ativa e comissão configurada.'),
+
+    // acompanhamento
+    'status designated' => i::__('Designado'),
+    'status draft' => i::__('Rascunho'),
+    'status sent' => i::__('Enviado'),
+    'status reopened' => i::__('Reaberto'),
+    'deadline' => i::__('Prazo'),
+    'sent at' => i::__('Enviada em'),
+    'no designation' => i::__('sem designação'),
+    'progress summary' => i::__('%s de %s slots com designação · %s enviadas'),
+
+    // ações e mensagens
+    'save' => i::__('Salvar designações'),
+    'saving' => i::__('Salvando designações...'),
+    'saved' => i::__('Designações criadas com sucesso.'),
+    'save error' => i::__('Não foi possível criar as designações.'),
+    'loading' => i::__('Carregando avaliações...'),
+    'endpoint unavailable' => i::__('A criação e o acompanhamento de designações estão temporariamente indisponíveis: a API da entidade de designação (RegistrationAppealReview) ainda não está registrada no backend.'),
+];
+
+$app->applyHook('component(opportunity-appeal-correction-assignment).texts', [&$texts]);
+
+return $texts;

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/texts.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/texts.php
@@ -35,6 +35,15 @@ $texts = [
     'saved' => i::__('Designações criadas com sucesso.'),
     'save error' => i::__('Não foi possível criar as designações.'),
     'loading' => i::__('Carregando avaliações...'),
+
+    // F5 (#45): substituição e cancelamento de designação
+    'select substitute' => i::__('Selecione o novo corretor'),
+    'confirm substitution' => i::__('Confirmar'),
+    'substituting' => i::__('Substituindo...'),
+    'corrector replaced' => i::__('Corretor substituído com sucesso.'),
+    'replace error' => i::__('Não foi possível substituir o corretor.'),
+    'designation canceled' => i::__('Designação cancelada com sucesso.'),
+    'cancel designation error' => i::__('Não foi possível cancelar a designação.'),
     'endpoint unavailable' => i::__('A criação e o acompanhamento de designações estão temporariamente indisponíveis: a API da entidade de designação (RegistrationAppealReview) ainda não está registrada no backend.'),
 ];
 

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/texts.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-assignment/texts.php
@@ -44,6 +44,12 @@ $texts = [
     'replace error' => i::__('Não foi possível substituir o corretor.'),
     'designation canceled' => i::__('Designação cancelada com sucesso.'),
     'cancel designation error' => i::__('Não foi possível cancelar a designação.'),
+
+    // F6 (#49): seletor de escopo de critérios
+    'criteria scope' => i::__('Escopo de critérios'),
+    'all criteria released' => i::__('todos liberados'),
+    'scope count' => i::__('%s de %s critérios'),
+    'select at least one criterion' => i::__('Selecione ao menos um critério'),
     'endpoint unavailable' => i::__('A criação e o acompanhamento de designações estão temporariamente indisponíveis: a API da entidade de designação (RegistrationAppealReview) ainda não está registrada no backend.'),
 ];
 

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/script.js
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/script.js
@@ -1,0 +1,255 @@
+app.component('opportunity-appeal-correction-evaluation', {
+    template: $TEMPLATES['opportunity-appeal-correction-evaluation'],
+
+    props: {
+        assignmentId: {
+            type: [Number, String],
+            required: true,
+        },
+    },
+
+    setup() {
+        const messages = useMessages();
+        const text = Utils.getTexts('opportunity-appeal-correction-evaluation');
+
+        return { messages, text };
+    },
+
+    data() {
+        return {
+            loading: true,
+            environment: null,
+            error: null,
+            formData: {},
+            savingDraft: false,
+            sending: false,
+            submitted: false,
+        };
+    },
+
+    computed: {
+        isLocked() {
+            if (this.submitted) {
+                return true;
+            }
+
+            if (!this.environment) {
+                return false;
+            }
+
+            if (this.environment.status === 'sent') {
+                return true;
+            }
+
+            if (this.environment.deadline) {
+                return new Date(this.environment.deadline) < new Date();
+            }
+
+            return false;
+        },
+
+        formattedDeadline() {
+            if (!this.environment?.deadline) {
+                return '';
+            }
+
+            return new Date(this.environment.deadline).toLocaleString('pt-BR');
+        },
+
+        criteriaList() {
+            return this.environment?.criteria || [];
+        },
+
+        totalScore() {
+            let result = 0;
+
+            for (const criterion of this.criteriaList) {
+                const value = this.formData.data?.[criterion.id];
+
+                if (value === null || value === undefined || value === '') {
+                    continue;
+                }
+
+                result += this.toNumber(value) * this.toNumber(criterion.weight);
+            }
+
+            return parseFloat(result.toFixed(2));
+        },
+
+        statusLabel() {
+            const labels = {
+                designated: this.text('status-designated'),
+                draft: this.text('status-draft'),
+                sent: this.text('status-sent'),
+                reopened: this.text('status-reopened'),
+            };
+
+            return labels[this.environment?.status] || this.environment?.status || '';
+        },
+
+        correctionTypeLabel() {
+            const labels = {
+                official: this.text('correction-type-official'),
+                record: this.text('correction-type-record'),
+            };
+
+            return labels[this.environment?.correctionType] || this.environment?.correctionType || '';
+        },
+    },
+
+    mounted() {
+        this.fetchEnvironment();
+    },
+
+    methods: {
+        toNumber(value) {
+            const number = Number(value);
+
+            return Number.isFinite(number) ? number : 0;
+        },
+
+        originalNote(criterion) {
+            const value = this.environment?.originalEvaluation?.[criterion.id];
+
+            return (value === null || value === undefined || value === '') ? '-' : value;
+        },
+
+        async fetchEnvironment() {
+            this.loading = true;
+            this.error = null;
+
+            try {
+                const api = new API();
+                const url = Utils.createUrl('appealCorrector', 'environment', [this.assignmentId]);
+                const res = await api.GET(url);
+
+                if (res.ok) {
+                    this.environment = await res.json();
+                    this.formData.data = {
+                        ...this.environment.originalEvaluation,
+                        ...(this.environment.draft || {}),
+                    };
+                } else {
+                    this.error = {
+                        status: res.status,
+                        message: this.environmentErrorMessage(res.status),
+                    };
+                }
+            } catch (e) {
+                this.error = { status: 0, message: this.text('error-generic') };
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        environmentErrorMessage(status) {
+            if (status === 403) {
+                return this.text('error-forbidden');
+            }
+
+            if (status === 404) {
+                return this.text('error-not-found');
+            }
+
+            return this.text('error-generic');
+        },
+
+        handleInput(criterion) {
+            if (this.isLocked) {
+                return;
+            }
+
+            const value = this.formData.data[criterion.id];
+
+            if (value === '' || value === null || value === undefined) {
+                return;
+            }
+
+            const max = this.toNumber(criterion.max);
+
+            if (this.toNumber(value) > max) {
+                this.messages.error(this.text('note-higher-configured'));
+                this.formData.data[criterion.id] = max;
+            } else if (value < 0) {
+                this.formData.data[criterion.id] = 0;
+            }
+        },
+
+        async extractErrorMessage(res) {
+            try {
+                const data = await res.json();
+
+                if (data?.message) {
+                    return data.message;
+                }
+
+                // errorJson() responds {error: true, data: <message>}
+                if (data?.data) {
+                    return typeof data.data === 'string' ? data.data : JSON.stringify(data.data);
+                }
+            } catch (e) {
+                // body is not JSON, fall through to generic message
+            }
+
+            return this.text('error-generic');
+        },
+
+        async saveDraft() {
+            if (this.savingDraft || this.isLocked) {
+                return;
+            }
+
+            this.savingDraft = true;
+
+            try {
+                const api = new API('registrationevaluation');
+                const url = api.createUrl('applyAppealCorrection', { id: this.environment.evaluationId });
+                const res = await api.POST(url, {
+                    evaluationData: { ...this.formData.data },
+                    draft: true,
+                });
+
+                if (res.ok) {
+                    const data = await res.json();
+                    this.environment.draft = data.review?.correctedValue || { ...this.formData.data };
+                    this.messages.success(this.text('draft-saved'));
+                } else {
+                    this.messages.error(await this.extractErrorMessage(res));
+                }
+            } catch (e) {
+                this.messages.error(this.text('error-generic'));
+            } finally {
+                this.savingDraft = false;
+            }
+        },
+
+        async sendCorrection() {
+            if (this.sending || this.isLocked) {
+                return;
+            }
+
+            this.sending = true;
+
+            try {
+                const api = new API('registrationevaluation');
+                const url = api.createUrl('applyAppealCorrection', { id: this.environment.evaluationId });
+                const res = await api.POST(url, {
+                    evaluationData: { ...this.formData.data },
+                    draft: false,
+                });
+
+                if (res.ok) {
+                    this.submitted = true;
+                    this.environment.status = 'sent';
+                    this.messages.success(this.text('correction-sent'));
+                } else {
+                    this.messages.error(await this.extractErrorMessage(res));
+                }
+            } catch (e) {
+                this.messages.error(this.text('error-generic'));
+            } finally {
+                this.sending = false;
+            }
+        },
+    },
+});

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/script.js
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/script.js
@@ -60,6 +60,31 @@ app.component('opportunity-appeal-correction-evaluation', {
             return this.environment?.criteria || [];
         },
 
+        // F7 (#51): método da fase principal define o formulário renderizado
+        method() {
+            return this.environment?.method || 'technical';
+        },
+
+        isTechnical() {
+            return this.method === 'technical';
+        },
+
+        isDocumentary() {
+            return this.method === 'documentary';
+        },
+
+        isSimple() {
+            return this.method === 'simple';
+        },
+
+        fieldsList() {
+            return this.environment?.fields || [];
+        },
+
+        statusOptions() {
+            return this.environment?.statusOptions || [];
+        },
+
         totalScore() {
             let result = 0;
 
@@ -108,10 +133,56 @@ app.component('opportunity-appeal-correction-evaluation', {
             return Number.isFinite(number) ? number : 0;
         },
 
+        /**
+         * F7: garante a forma do formData por método — documental precisa de
+         * {evaluation, obs} por campo liberado; simples precisa de status/obs.
+         */
+        initFormDataByMethod() {
+            if (this.isDocumentary) {
+                for (const field of this.fieldsList) {
+                    const current = this.formData.data[field.id];
+
+                    this.formData.data[field.id] = {
+                        evaluation: '',
+                        obs: '',
+                        ...(current && typeof current === 'object' ? current : {}),
+                    };
+                }
+            } else if (this.isSimple) {
+                this.formData.data.status = this.formData.data.status ?? '';
+                this.formData.data.obs = this.formData.data.obs ?? '';
+            }
+        },
+
         originalNote(criterion) {
             const value = this.environment?.originalEvaluation?.[criterion.id];
 
             return (value === null || value === undefined || value === '') ? '-' : value;
+        },
+
+        originalFieldEvaluation(field) {
+            const value = this.environment?.originalEvaluation?.[field.id]?.evaluation;
+
+            return this.fieldEvaluationLabel(value);
+        },
+
+        fieldEvaluationLabel(value) {
+            if (value === 'valid') {
+                return this.text('field-valid');
+            }
+
+            if (value === 'invalid') {
+                return this.text('field-invalid');
+            }
+
+            return this.text('field-not-evaluated');
+        },
+
+        originalStatus() {
+            const value = this.environment?.originalEvaluation?.status;
+            const option = this.statusOptions.find(option => option.value === String(value ?? ''));
+
+            return option ? option.label : (value ?? '—');
         },
 
         async fetchEnvironment() {
@@ -129,6 +200,7 @@ app.component('opportunity-appeal-correction-evaluation', {
                         ...this.environment.originalEvaluation,
                         ...(this.environment.draft || {}),
                     };
+                    this.initFormDataByMethod();
                 } else {
                     this.error = {
                         status: res.status,

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/style.css
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/style.css
@@ -1,0 +1,28 @@
+/*
+ * opportunity-appeal-correction-evaluation (F3 #19 + F7 #51)
+ *
+ * Estilo local no padrão do módulo (auto-enfileirado, sem build — mesmo
+ * precedente do mc-modal): apenas o layout das opções por campo do método
+ * documental; o restante usa as classes do tema (grid-12, card, button).
+ */
+
+.opportunity-appeal-correction-evaluation__field-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .75rem;
+}
+
+.opportunity-appeal-correction-evaluation__field-option {
+    align-items: center;
+    cursor: pointer;
+    display: inline-flex;
+    gap: .25rem;
+}
+
+.opportunity-appeal-correction-evaluation__field-option input {
+    margin: 0;
+}
+
+.opportunity-appeal-correction-evaluation__criterion textarea {
+    width: 100%;
+}

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/template.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/template.php
@@ -67,7 +67,8 @@ $this->import('
             </div>
         </section>
 
-        <section class="grid-12 section">
+        <!-- F7 (#51): formulário conforme o método do slot -->
+        <section v-if="isTechnical" class="grid-12 section">
             <h3 class="col-12"><?= i::__('Critérios liberados para correção') ?></h3>
             <div class="section__content col-12">
                 <div class="card">
@@ -91,6 +92,81 @@ $this->import('
                     <div class="opportunity-appeal-correction-evaluation__results">
                         <h4><?= i::__('Pontuação total') ?>: <strong>{{ totalScore }}</strong></h4>
                     </div>
+                </div>
+            </div>
+        </section>
+
+        <section v-else-if="isDocumentary" class="grid-12 section">
+            <h3 class="col-12"><?= i::__('Campos liberados para correção') ?></h3>
+            <div class="section__content col-12">
+                <div class="card">
+                    <div class="opportunity-appeal-correction-evaluation__criterion" v-for="field in fieldsList" :key="field.id">
+                        <label><strong>{{ field.title }}</strong></label>
+                        <div class="grid-12">
+                            <div class="col-6">
+                                <label><?= i::__('Avaliação original') ?></label>
+                                <p class="semibold">{{ originalFieldEvaluation(field) }}</p>
+                            </div>
+                            <div class="col-6">
+                                <label :for="'corrected-field-' + field.id"><?= i::__('Avaliação corrigida') ?></label>
+                                <div class="opportunity-appeal-correction-evaluation__field-options">
+                                    <label class="opportunity-appeal-correction-evaluation__field-option">
+                                        <input type="radio" value="" v-model="formData.data[field.id].evaluation" :disabled="isLocked" :name="'corrected-field-' + field.id">
+                                        <?= i::__('Não avaliada') ?>
+                                    </label>
+                                    <label class="opportunity-appeal-correction-evaluation__field-option">
+                                        <input type="radio" value="valid" v-model="formData.data[field.id].evaluation" :disabled="isLocked" :name="'corrected-field-' + field.id">
+                                        <?= i::__('Válida') ?>
+                                    </label>
+                                    <label class="opportunity-appeal-correction-evaluation__field-option">
+                                        <input type="radio" value="invalid" v-model="formData.data[field.id].evaluation" :disabled="isLocked" :name="'corrected-field-' + field.id">
+                                        <?= i::__('Inválida') ?>
+                                    </label>
+                                </div>
+                            </div>
+                        </div>
+                        <label :for="'corrected-field-obs-' + field.id"><?= i::__('Observações do campo') ?></label>
+                        <textarea
+                            :id="'corrected-field-obs-' + field.id"
+                            :name="'corrected-field-obs-' + field.id"
+                            :disabled="isLocked"
+                            v-model="formData.data[field.id].obs"></textarea>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section v-else-if="isSimple" class="grid-12 section">
+            <h3 class="col-12"><?= i::__('Correção do resultado') ?></h3>
+            <div class="section__content col-12">
+                <div class="card">
+                    <div class="grid-12">
+                        <div class="col-6">
+                            <label><?= i::__('Status original') ?></label>
+                            <p class="semibold">{{ originalStatus() }}</p>
+                        </div>
+                        <div class="col-6">
+                            <label for="corrected-global-status"><?= i::__('Status corrigido') ?></label>
+                            <select
+                                id="corrected-global-status"
+                                name="corrected-global-status"
+                                v-model="formData.data.status"
+                                :disabled="isLocked">
+
+                                <option value="" disabled><?= i::__('Selecione o status') ?></option>
+                                <option v-for="option in statusOptions" :key="option.value" :value="option.value">{{ option.label }}</option>
+                            </select>
+                        </div>
+                        <div class="col-12">
+                            <label for="corrected-global-obs"><?= i::__('Observações') ?></label>
+                            <textarea
+                                id="corrected-global-obs"
+                                name="corrected-global-obs"
+                                :disabled="isLocked"
+                                v-model="formData.data.obs"></textarea>
+                        </div>
+                    </div>
+                    <mc-alert type="helper"><?= i::__('Método de avaliação sem critérios: a correção libera o resultado integral da avaliação.') ?></mc-alert>
                 </div>
             </div>
         </section>

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/template.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/template.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * @var MapasCulturais\App $app
+ * @var MapasCulturais\Themes\BaseV2\Theme $this
+ */
+
+use MapasCulturais\i;
+
+$this->import('
+    mc-alert
+    mc-icon
+    mc-loading
+    mc-modal
+');
+?>
+
+<div class="opportunity-appeal-correction-evaluation">
+    <mc-loading v-if="loading" :condition="loading"><?= i::__('carregando...') ?></mc-loading>
+
+    <mc-alert v-else-if="error" type="danger">{{ error.message }}</mc-alert>
+
+    <template v-else>
+        <section class="grid-12 section">
+            <h3 class="col-12"><?= i::__('Correção de avaliação (recurso)') ?></h3>
+            <div class="section__content col-12">
+                <div class="card">
+                    <div class="grid-12">
+                        <div class="col-6">
+                            <label><?= i::__('Oportunidade') ?></label>
+                            <p class="semibold">{{ environment.opportunityName }}</p>
+                        </div>
+                        <div class="col-3">
+                            <label><?= i::__('Inscrição') ?></label>
+                            <p class="semibold">{{ environment.registrationNumber }}</p>
+                        </div>
+                        <div class="col-3">
+                            <label><?= i::__('Prazo') ?></label>
+                            <p class="semibold">{{ formattedDeadline }}</p>
+                        </div>
+                        <div class="col-6">
+                            <label><?= i::__('Avaliador original') ?></label>
+                            <p class="semibold">{{ environment.targetEvaluatorName }}</p>
+                        </div>
+                        <div class="col-3">
+                            <label><?= i::__('Status') ?></label>
+                            <p><span class="opportunity-appeal-correction-evaluation__badge">{{ statusLabel }}</span></p>
+                        </div>
+                        <div class="col-3">
+                            <label><?= i::__('Tipo de correção') ?></label>
+                            <p><span class="opportunity-appeal-correction-evaluation__badge">{{ correctionTypeLabel }}</span></p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section v-if="environment.committeeOpinion" class="grid-12 section">
+            <h3 class="col-12"><?= i::__('Parecer da Comissão de Recursos') ?></h3>
+            <div class="section__content col-12">
+                <div class="card" v-for="opinion in environment.committeeOpinion.evaluations" :key="opinion.evaluationId">
+                    <p>
+                        <strong>{{ opinion.valuerName }}</strong>
+                        <span v-if="opinion.resultString"> · {{ opinion.resultString }}</span>
+                    </p>
+                    <p v-if="opinion.evaluationData?.obs">{{ opinion.evaluationData.obs }}</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="grid-12 section">
+            <h3 class="col-12"><?= i::__('Critérios liberados para correção') ?></h3>
+            <div class="section__content col-12">
+                <div class="card">
+                    <div class="opportunity-appeal-correction-evaluation__criterion" v-for="criterion in criteriaList" :key="criterion.id">
+                        <label><strong>{{ criterion.title }}</strong></label>
+                        <div class="grid-12">
+                            <div class="col-6">
+                                <label><?= i::__('Nota original') ?></label>
+                                <input disabled min="0" step="0.1" type="number" :value="originalNote(criterion)">
+                            </div>
+                            <div class="col-6">
+                                <label><?= i::__('Nota corrigida') ?></label>
+                                <input :disabled="isLocked" min="0" step="0.1" type="number" v-model.number="formData.data[criterion.id]" @input="handleInput(criterion)">
+                            </div>
+                        </div>
+                        <div class="grid-12">
+                            <small class="col-8"><?= i::__('Nota máxima') ?>: <strong>{{ criterion.max }}</strong></small>
+                            <small class="col-4"><?= i::__('Peso') ?>: <strong>{{ criterion.weight }}</strong></small>
+                        </div>
+                    </div>
+                    <div class="opportunity-appeal-correction-evaluation__results">
+                        <h4><?= i::__('Pontuação total') ?>: <strong>{{ totalScore }}</strong></h4>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <mc-alert v-if="isLocked" type="warning"><?= i::__('Correção enviada, edição bloqueada.') ?></mc-alert>
+
+        <div class="grid-12" v-if="!isLocked">
+            <div class="col-6">
+                <button class="button button--primary-outline" :class="{'btn disabled': savingDraft}" @click="saveDraft()">
+                    <?= i::__('Salvar rascunho') ?>
+                </button>
+            </div>
+            <div class="col-6">
+                <mc-modal title="<?= i::__('Enviar correção') ?>">
+                    <template #default>
+                        <p><?= i::__('Ao confirmar, a correção será aplicada à avaliação e a edição será bloqueada. Esta ação não pode ser desfeita.') ?></p>
+                    </template>
+
+                    <template #actions="modal">
+                        <button class="button button--text" @click="modal.close()"><?= i::__('Cancelar') ?></button>
+                        <button class="button button--primary" :class="{'btn disabled': sending}" @click="sendCorrection(); modal.close()">
+                            <?= i::__('Confirmar envio') ?>
+                        </button>
+                    </template>
+
+                    <template #button="modal">
+                        <button class="button button--primary" @click="modal.open()">
+                            <?= i::__('Enviar definitivamente') ?>
+                        </button>
+                    </template>
+                </mc-modal>
+            </div>
+        </div>
+    </template>
+</div>

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/texts.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/texts.php
@@ -1,0 +1,17 @@
+<?php
+use MapasCulturais\i;
+
+return [
+    'status-designated' => i::__('Designada'),
+    'status-draft' => i::__('Rascunho'),
+    'status-sent' => i::__('Enviada'),
+    'status-reopened' => i::__('Reaberta'),
+    'correction-type-official' => i::__('Correção oficial'),
+    'correction-type-record' => i::__('Somente registro'),
+    'error-forbidden' => i::__('Você não tem permissão para acessar este ambiente de correção.'),
+    'error-not-found' => i::__('Designação não encontrada ou correção de notas desabilitada.'),
+    'error-generic' => i::__('Não foi possível carregar o ambiente de correção.'),
+    'note-higher-configured' => i::__('Nota maior que a configurada para avaliação'),
+    'draft-saved' => i::__('Rascunho salvo com sucesso'),
+    'correction-sent' => i::__('Correção enviada com sucesso'),
+];

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/texts.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-correction-evaluation/texts.php
@@ -14,4 +14,9 @@ return [
     'note-higher-configured' => i::__('Nota maior que a configurada para avaliação'),
     'draft-saved' => i::__('Rascunho salvo com sucesso'),
     'correction-sent' => i::__('Correção enviada com sucesso'),
+
+    // F7 (#51): qualificação documental
+    'field-valid' => i::__('Válida'),
+    'field-invalid' => i::__('Inválida'),
+    'field-not-evaluated' => i::__('Não avaliada'),
 ];

--- a/src/modules/OpportunityAppealPhase/views/appealcorrector/correction.php
+++ b/src/modules/OpportunityAppealPhase/views/appealcorrector/correction.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @var MapasCulturais\App $app
+ * @var MapasCulturais\Themes\BaseV2\Theme $this
+ * @var int $assignmentId
+ * @var OpportunityAppealPhase\Entities\RegistrationAppealReview $assignment
+ */
+
+use MapasCulturais\i;
+
+$this->layout = 'default';
+
+$this->import('
+    mc-breadcrumb
+    opportunity-appeal-correction-evaluation
+');
+
+$breadcrumb = [
+    ['label' => i::__('Início'), 'url' => $app->createUrl('panel', 'opportunities')],
+    ['label' => i::__('Painel de controle'), 'url' => $app->createUrl('panel', 'opportunities')],
+    ['label' => i::__('Correção de avaliação (recurso)')],
+];
+
+$this->breadcrumb = $breadcrumb;
+?>
+
+<div class="main-app">
+    <mc-breadcrumb></mc-breadcrumb>
+    <opportunity-appeal-correction-evaluation :assignment-id="<?= (int) $assignmentId ?>"></opportunity-appeal-correction-evaluation>
+</div>

--- a/src/modules/Spreadsheets/JobTypes/Registrations.php
+++ b/src/modules/Spreadsheets/JobTypes/Registrations.php
@@ -160,6 +160,23 @@ class Registrations extends SpreadsheetJob
                 continue;
             }
 
+            // F4 (#20) — CA-11: colunas computadas de nota por inscrição
+            // (módulo OpportunityAppealPhase); rótulo amigável na planilha.
+            if($property == 'averageOriginalScore') {
+                $header[$property] = i::__('Média original (antes das correções de recurso)');
+                continue;
+            }
+
+            if($property == 'averageCorrectedScore') {
+                $header[$property] = i::__('Média corrigida (vigente)');
+                continue;
+            }
+
+            if($property == 'scoreDifference') {
+                $header[$property] = i::__('Diferença (média corrigida - média original)');
+                continue;
+            }
+
             $header[$property] = $entity_class_name::getPropertyLabel($property) ?: $property;
         }
 

--- a/tests/src/AppealAssignmentApiTest.php
+++ b/tests/src/AppealAssignmentApiTest.php
@@ -1,0 +1,498 @@
+<?php
+
+namespace Tests;
+
+use DateTime;
+use MapasCulturais\App;
+use MapasCulturais\Entities\EvaluationMethodConfiguration;
+use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\Entities\Registration;
+use MapasCulturais\Entities\RegistrationEvaluation;
+use MapasCulturais\Entities\User;
+use OpportunityAppealPhase\Entities\RegistrationAppealReview;
+use Psr\Http\Message\ServerRequestInterface;
+use Tests\Abstract\TestCase;
+use Tests\Builders\PhasePeriods\ConcurrentEndingAfter;
+use Tests\Builders\PhasePeriods\Open;
+use Tests\Enums\EvaluationMethods;
+use Tests\Traits\OpportunityBuilder;
+use Tests\Traits\RegistrationDirector;
+use Tests\Traits\RequestFactory;
+use Tests\Traits\UserDirector;
+
+/**
+ * PR6 (#40): API de designação de corretores por slot.
+ *
+ * Cobertura dos critérios de aceitação:
+ * - AC1: criação via API por gestor com @control gera designação com campos do CA-4;
+ * - AC2 (CA-3): corretor fora de eligibleCorrectors() é rejeitado com erro claro;
+ * - AC3: listagem por inscrição devolve status/prazo/corretor por slot (painel F2);
+ * - AC4: permissões (não-gestor → 403; guest → 401) e feature flag.
+ */
+class AppealAssignmentApiTest extends TestCase
+{
+    use OpportunityBuilder,
+        RegistrationDirector,
+        UserDirector,
+        RequestFactory;
+
+    private function enableFlag(): void
+    {
+        $_ENV['APPEAL_SCORE_CORRECTION'] = 'true';
+    }
+
+    private function disableFlag(): void
+    {
+        unset($_ENV['APPEAL_SCORE_CORRECTION']);
+        putenv('APPEAL_SCORE_CORRECTION');
+    }
+
+    /**
+     * Cenário: fase técnica com 2 slots (avaliadores A e B), fase de recurso com
+     * Comissão de Recursos (committeeUser) e usuários de controle.
+     *
+     * @return array{
+     *   admin: User, slotOwnerA: User, slotOwnerB: User,
+     *   committeeUser: User, outsider: User,
+     *   opportunity: Opportunity, registration: Registration,
+     *   slotA: RegistrationEvaluation, slotB: RegistrationEvaluation,
+     *   appealPhase: Opportunity
+     * }
+     */
+    private function createScenario(): array
+    {
+        $this->enableFlag();
+
+        $admin = $this->userDirector->createUser('admin');
+        $slot_owner_a = $this->userDirector->createUser();
+        $slot_owner_b = $this->userDirector->createUser();
+        $committee_user = $this->userDirector->createUser();
+        $outsider = $this->userDirector->createUser();
+
+        $this->login($admin);
+
+        $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase(EvaluationMethods::technical)
+                ->fillRequiredProperties()
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->save()
+                ->addValuer('Comissão', 'Avaliador A', $slot_owner_a->profile)
+                    ->done()
+                ->addValuer('Comissão', 'Avaliador B', $slot_owner_b->profile)
+                    ->done()
+                ->done()
+            ->save();
+
+        /** @var Opportunity $opportunity */
+        $opportunity = $this->opportunityBuilder->getInstance();
+        $registration = $this->registrationDirector->createSentRegistration($opportunity, data: []);
+
+        $app = App::i();
+        $app->disableAccessControl();
+
+        $slot_a = new RegistrationEvaluation();
+        $slot_a->registration = $registration;
+        $slot_a->user = $slot_owner_a;
+        $slot_a->status = RegistrationEvaluation::STATUS_EVALUATED;
+        $slot_a->save(true);
+
+        $slot_b = new RegistrationEvaluation();
+        $slot_b->registration = $registration;
+        $slot_b->user = $slot_owner_b;
+        $slot_b->status = RegistrationEvaluation::STATUS_EVALUATED;
+        $slot_b->save(true);
+
+        $appeal_phase_class = $opportunity->getSpecializedClassName();
+        /** @var Opportunity $appeal_phase */
+        $appeal_phase = new $appeal_phase_class();
+        $appeal_phase->parent = $opportunity;
+        $appeal_phase->status = Opportunity::STATUS_APPEAL_PHASE;
+        $appeal_phase->name = 'Fase de recurso técnica';
+        $appeal_phase->ownerEntity = $opportunity->ownerEntity;
+        $appeal_phase->owner = $opportunity->owner;
+        $appeal_phase->registrationCategories = $opportunity->registrationCategories;
+        $appeal_phase->registrationRanges = $opportunity->registrationRanges;
+        $appeal_phase->registrationProponentTypes = $opportunity->registrationProponentTypes;
+        $appeal_phase->isDataCollection = true;
+        $appeal_phase->isAppealPhase = true;
+        $appeal_phase->registrationFrom = new DateTime('-1 day');
+        $appeal_phase->registrationTo = new DateTime('+1 day');
+        $appeal_phase->save(true);
+
+        $opportunity->appealPhase = $appeal_phase;
+        $opportunity->save(true);
+
+        $appeal_emc = new EvaluationMethodConfiguration();
+        $appeal_emc->opportunity = $appeal_phase;
+        $appeal_emc->type = 'continuous';
+        $appeal_emc->publishEvaluationDetails = true;
+        $appeal_emc->save(true);
+
+        $appeal_phase->evaluationMethodConfiguration = $appeal_emc;
+        $appeal_phase->save(true);
+
+        $appeal_emc->createAgentRelation($committee_user->profile, 'committee 1', true)->save(true);
+
+        $app->enableAccessControl();
+
+        return [
+            'admin' => $admin,
+            'slotOwnerA' => $slot_owner_a,
+            'slotOwnerB' => $slot_owner_b,
+            'committeeUser' => $committee_user,
+            'outsider' => $outsider,
+            'opportunity' => $opportunity,
+            'registration' => $registration,
+            'slotA' => $slot_a,
+            'slotB' => $slot_b,
+            'appealPhase' => $appeal_phase,
+        ];
+    }
+
+    /**
+     * Executa uma requisição in-process e devolve status + JSON do corpo.
+     *
+     * @return array{status: int, json: mixed}
+     */
+    private function dispatch(ServerRequestInterface $request): array
+    {
+        $app = App::i();
+        $app->reset();
+        $app->run($request, false);
+
+        return [
+            'status' => $app->response->getStatusCode(),
+            'json' => json_decode((string) $app->response->getBody(), true),
+        ];
+    }
+
+    /**
+     * @return array{status: int, json: mixed}
+     */
+    private function postAssignment(array $payload): array
+    {
+        return $this->dispatch(
+            $this->requestFactory->POST('registrationappealreview', 'index', [], $payload)
+        );
+    }
+
+    /**
+     * @return array{status: int, json: mixed}
+     */
+    private function findAssignments(Registration $registration, string $select = 'id,status,correctionType,startsAt,endsAt,sentTimestamp'): array
+    {
+        return $this->dispatch(
+            $this->requestFactory->GET(
+                'api/registrationappealreview',
+                'find',
+                [],
+                [
+                    'registration' => 'EQ(' . $registration->id . ')',
+                    '@select' => $select,
+                ],
+                ajax: true
+            )
+        );
+    }
+
+    private function countActiveReviewsForSlot(RegistrationEvaluation $slot): int
+    {
+        $app = App::i();
+
+        return count($app->repo(RegistrationAppealReview::class)->findBy([
+            'originalEvaluation' => $slot->id,
+            'status' => RegistrationAppealReview::getActiveStatuses(),
+        ]));
+    }
+
+    function testManagerCanDesignateCommitteeMemberWithCa4Fields(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['admin']);
+
+        $response = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+            'correctionType' => RegistrationAppealReview::CORRECTION_TYPE_OFFICIAL,
+            'releasedScope' => json_encode(['criteria' => ['c-1'], 'showAppealOpinion' => true]),
+            'startsAt' => '2026-09-01 09:00',
+            'endsAt' => '2026-09-10 18:00',
+        ]);
+
+        $this->assertEquals(200, $response['status'], 'Gestor com @control deve criar designação: ' . json_encode($response['json']));
+        $this->assertNotEmpty($response['json']['id'], 'Resposta deve devolver o ID da designação criada.');
+
+        /** @var RegistrationAppealReview $review */
+        $review = App::i()->repo(RegistrationAppealReview::class)->find($response['json']['id']);
+        $this->assertNotNull($review, 'Designação deve estar persistida.');
+
+        // Campos do CA-4
+        $this->assertEquals($scenario['slotA']->id, $review->originalEvaluation->id);
+        $this->assertEquals($scenario['committeeUser']->id, $review->correctorUser->id);
+        $this->assertEquals(RegistrationAppealReview::CORRECTION_TYPE_OFFICIAL, $review->correctionType);
+        $this->assertEquals(['criteria' => ['c-1'], 'showAppealOpinion' => true], (array) $review->releasedScope);
+        $this->assertEquals('2026-09-01 09:00:00', $review->startsAt->format('Y-m-d H:i:s'));
+        $this->assertEquals('2026-09-10 18:00:00', $review->endsAt->format('Y-m-d H:i:s'));
+
+        // Campos derivados do slot no servidor
+        $this->assertEquals($scenario['registration']->id, $review->registration->id);
+        $this->assertEquals($scenario['appealPhase']->id, $review->appealPhase->id);
+        $this->assertEquals($scenario['slotOwnerA']->id, $review->slotOwnerUser->id);
+        $this->assertEquals(RegistrationAppealReview::STATUS_DESIGNATED, $review->status);
+        $this->assertNull($review->sentTimestamp, 'Designação recém-criada não tem envio.');
+    }
+
+    function testSlotOwnerIsEligibleCorrector(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['admin']);
+
+        $response = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['slotOwnerA']->id,
+            'correctionType' => RegistrationAppealReview::CORRECTION_TYPE_RECORD,
+        ]);
+
+        $this->assertEquals(200, $response['status'], 'O dono do slot é corretor elegível (CA-3a): ' . json_encode($response['json']));
+        $this->assertEquals(1, $this->countActiveReviewsForSlot($scenario['slotA']));
+    }
+
+    function testEvaluatorFromAnotherSlotIsRejected(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['admin']);
+
+        // R17: avaliador de OUTRO slot da mesma inscrição, fora da Comissão de Recursos.
+        $response = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['slotOwnerB']->id,
+        ]);
+
+        $this->assertEquals(400, $response['status'], 'Avaliador de outro slot deve ser rejeitado (CA-3).');
+        $this->assertTrue($response['json']['error'] ?? false, 'Resposta de erro deve seguir o contrato errorJson.');
+        $this->assertStringContainsStringIgnoringCase('eleg', (string) $response['json']['data'], 'Mensagem deve explicar a inelegibilidade (CA-3).');
+        $this->assertEquals(0, $this->countActiveReviewsForSlot($scenario['slotA']), 'Nenhuma designação deve ser persistida.');
+    }
+
+    function testNonManagerForbidden(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['outsider']);
+
+        $response = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ]);
+
+        $this->assertEquals(403, $response['status'], 'Usuário sem @control na oportunidade recebe 403.');
+        $this->assertEquals(0, $this->countActiveReviewsForSlot($scenario['slotA']), 'Nenhuma designação deve ser persistida.');
+    }
+
+    function testNonAdminManagerWithControlCanDesignate(): void
+    {
+        $scenario = $this->createScenario();
+
+        $manager = $this->userDirector->createUser();
+        $app = App::i();
+        $app->disableAccessControl();
+        $scenario['opportunity']->createAgentRelation($manager->profile, 'group-admin', true)->save(true);
+        $app->enableAccessControl();
+
+        // userHasControl consulta as AgentRelations ao vivo; pcache é filtro de
+        // listagem da API, não usado neste fluxo.
+        $this->login($manager);
+
+        $response = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ]);
+
+        $this->assertEquals(200, $response['status'], 'Gestor não-admin com relação de controle (group-admin) deve designar: ' . json_encode($response['json']));
+    }
+
+    function testGuestUnauthorized(): void
+    {
+        $scenario = $this->createScenario();
+        $this->logout();
+
+        $post = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ]);
+
+        $this->assertEquals(401, $post['status'], 'Guest recebe 401 na criação.');
+
+        $find = $this->findAssignments($scenario['registration']);
+        $this->assertEquals(401, $find['status'], 'Guest recebe 401 na listagem.');
+    }
+
+    function testFlagOffReturns404(): void
+    {
+        $scenario = $this->createScenario();
+        $this->disableFlag();
+        $this->login($scenario['admin']);
+
+        $response = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ]);
+
+        $this->assertEquals(404, $response['status'], 'Feature flag desligada deve retornar 404.');
+    }
+
+    function testDuplicateActiveDesignationRejected(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['admin']);
+
+        $first = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ]);
+
+        $this->assertEquals(200, $first['status']);
+
+        $second = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['slotOwnerA']->id,
+        ]);
+
+        $this->assertEquals(400, $second['status'], 'Segunda designação ativa no mesmo slot deve ser rejeitada com erro claro (índice único).');
+        $this->assertEquals(1, $this->countActiveReviewsForSlot($scenario['slotA']));
+    }
+
+    function testFindListsAssignmentsPerRegistrationForPanel(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['admin']);
+
+        $review_a = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+            'startsAt' => '2026-09-01 09:00',
+            'endsAt' => '2026-09-10 18:00',
+        ]);
+        $this->assertEquals(200, $review_a['status']);
+
+        $review_b = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotB']->id,
+            'correctorUser' => $scenario['slotOwnerB']->id,
+        ]);
+        $this->assertEquals(200, $review_b['status']);
+
+        // Designação de OUTRA inscrição: não pode vazar para o painel desta.
+        $other_registration = $this->registrationDirector->createSentRegistration($scenario['opportunity'], data: []);
+        $app = App::i();
+        $app->disableAccessControl();
+        $slot_c = new RegistrationEvaluation();
+        $slot_c->registration = $other_registration;
+        $slot_c->user = $scenario['slotOwnerA'];
+        $slot_c->status = RegistrationEvaluation::STATUS_EVALUATED;
+        $slot_c->save(true);
+        $app->enableAccessControl();
+
+        $review_c = $this->postAssignment([
+            'originalEvaluation' => $slot_c->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ]);
+        $this->assertEquals(200, $review_c['status']);
+
+        $response = $this->findAssignments($scenario['registration']);
+
+        $this->assertEquals(200, $response['status'], 'Listagem do painel deve funcionar para gestor com @control.');
+        $items = $response['json'];
+        $this->assertIsArray($items);
+        $this->assertCount(2, $items, 'Listagem escopada à inscrição: 2 slots designados, sem vazar a outra inscrição.');
+
+        $by_id = [];
+        foreach ($items as $item) {
+            $by_id[$item['id']] = $item;
+        }
+
+        $this->assertArrayHasKey($review_a['json']['id'], $by_id);
+        $this->assertArrayHasKey($review_b['json']['id'], $by_id);
+
+        $panel_item = $by_id[$review_a['json']['id']];
+        $this->assertEquals(RegistrationAppealReview::STATUS_DESIGNATED, $panel_item['status']);
+        $this->assertArrayHasKey('startsAt', $panel_item, 'Painel (CA-13) exige prazo.');
+        $this->assertArrayHasKey('endsAt', $panel_item);
+        $this->assertArrayHasKey('sentTimestamp', $panel_item, 'Painel (CA-13) exige data de envio.');
+
+        // Corretor por slot: resolvido pela entidade (serialização da relação varia na ApiQuery).
+        /** @var RegistrationAppealReview $persisted_a */
+        $persisted_a = $app->repo(RegistrationAppealReview::class)->find($review_a['json']['id']);
+        $this->assertEquals($scenario['committeeUser']->id, $persisted_a->correctorUser->id);
+        $this->assertEquals($scenario['slotA']->id, $persisted_a->originalEvaluation->id);
+    }
+
+    function testFindForbiddenForNonManager(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['outsider']);
+
+        $response = $this->findAssignments($scenario['registration']);
+
+        $this->assertEquals(403, $response['status'], 'Listagem por inscrição exige @control na oportunidade.');
+    }
+
+    function testPatchSubstitutionEnforcesEligibility(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['admin']);
+
+        $created = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ]);
+        $this->assertEquals(200, $created['status']);
+        $review_id = $created['json']['id'];
+
+        // Substituição por corretor inelegível (avaliador de outro slot) → CA-3.
+        $ineligible = $this->dispatch(
+            $this->requestFactory->PATCH('registrationappealreview', 'single', [$review_id], [
+                'correctorUser' => $scenario['slotOwnerB']->id,
+            ])
+        );
+        $this->assertEquals(400, $ineligible['status'], 'Substituição por corretor inelegível deve ser rejeitada (CA-3).');
+
+        // Substituição por corretor elegível (dono do slot) → OK.
+        $eligible = $this->dispatch(
+            $this->requestFactory->PATCH('registrationappealreview', 'single', [$review_id], [
+                'correctorUser' => $scenario['slotOwnerA']->id,
+            ])
+        );
+        $this->assertEquals(200, $eligible['status'], 'Substituição por corretor elegível deve ser aceita: ' . json_encode($eligible['json']));
+
+        /** @var RegistrationAppealReview $persisted */
+        $persisted = App::i()->repo(RegistrationAppealReview::class)->find($review_id);
+        $this->assertEquals($scenario['slotOwnerA']->id, $persisted->correctorUser->id, 'Substituição deve persistir o novo corretor.');
+    }
+
+    function testDeleteForbiddenForOutsider(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['admin']);
+
+        $created = $this->postAssignment([
+            'originalEvaluation' => $scenario['slotA']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ]);
+        $this->assertEquals(200, $created['status']);
+        $review_id = $created['json']['id'];
+
+        $this->login($scenario['outsider']);
+
+        $deleted = $this->dispatch(
+            $this->requestFactory->DELETE('registrationappealreview', 'single', [$review_id])
+        );
+
+        $this->assertEquals(403, $deleted['status'], 'Exclusão de designação exige @control na oportunidade.');
+        $this->assertNotNull(App::i()->repo(RegistrationAppealReview::class)->find($review_id), 'Designação não pode ser removida por não-gestor.');
+    }
+}

--- a/tests/src/AppealCorrectorCycleTest.php
+++ b/tests/src/AppealCorrectorCycleTest.php
@@ -1,0 +1,377 @@
+<?php
+
+namespace Tests;
+
+use DateTime;
+use MapasCulturais\App;
+use MapasCulturais\Entities\EvaluationMethodConfiguration;
+use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\Entities\Registration;
+use MapasCulturais\Entities\RegistrationEvaluation;
+use MapasCulturais\Entities\RegistrationFieldConfiguration;
+use MapasCulturais\Entities\RegistrationStep;
+use MapasCulturais\Entities\User;
+use OpportunityAppealPhase\Entities\RegistrationAppealReview;
+use Psr\Http\Message\ServerRequestInterface;
+use Tests\Abstract\TestCase;
+use Tests\Builders\PhasePeriods\ConcurrentEndingAfter;
+use Tests\Builders\PhasePeriods\Open;
+use Tests\Enums\EvaluationMethods;
+use Tests\Traits\OpportunityBuilder;
+use Tests\Traits\RegistrationDirector;
+use Tests\Traits\RegistrationFieldBuilder;
+use Tests\Traits\RequestFactory;
+use Tests\Traits\UserDirector;
+
+/**
+ * F7 (#51): ciclo do corretor para métodos não-técnicos (documental/simples).
+ *
+ * Cobertura (por método):
+ * - designação (F6 aberta) → corretor designado ACESSA o slot (canUser via
+ *   hook do módulo + ambiente GET 200, antes PermissionDenied) → rascunho →
+ *   envio → RegistrationEvaluation atualizada in-place + snapshot
+ *   originalValue + designação SENT;
+ * - escopo restrito documental: campo fora do escopo com valor divergente é
+ *   rejeitado (400); campo dentro do escopo é aceito.
+ */
+class AppealCorrectorCycleTest extends TestCase
+{
+    use OpportunityBuilder,
+        RegistrationDirector,
+        RegistrationFieldBuilder,
+        UserDirector,
+        RequestFactory;
+
+    private function enableFlag(): void
+    {
+        $_ENV['APPEAL_SCORE_CORRECTION'] = 'true';
+    }
+
+    /**
+     * @return array{admin: User, slotOwner: User, committeeUser: User,
+     *   opportunity: Opportunity, registration: Registration,
+     *   slot: RegistrationEvaluation, appealPhase: Opportunity,
+     *   fields: array<string, RegistrationFieldConfiguration>}
+     */
+    private function createScenario(EvaluationMethods $method): array
+    {
+        $this->enableFlag();
+
+        $admin = $this->userDirector->createUser('admin');
+        $slot_owner = $this->userDirector->createUser();
+        $committee_user = $this->userDirector->createUser();
+
+        $this->login($admin);
+
+        $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase($method)
+                ->fillRequiredProperties()
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->save()
+                ->addValuer('Comissão', 'Avaliador do Slot', $slot_owner->profile)
+                    ->done()
+                ->done()
+            ->save();
+
+        /** @var Opportunity $opportunity */
+        $opportunity = $this->opportunityBuilder->getInstance();
+
+        $fields = [];
+        if ($method === EvaluationMethods::documentary) {
+            // Campos exigem uma etapa (isFieldVisisble → isStepVisible), no
+            // mesmo padrão da criação de fase de recurso do módulo.
+            $app = App::i();
+            $app->disableAccessControl();
+
+            $step = new RegistrationStep();
+            $step->opportunity = $opportunity;
+            $step->name = '';
+            $step->save(true);
+
+            $app->enableAccessControl();
+
+            foreach (['A' => 'Documento A', 'B' => 'Documento B'] as $key => $title) {
+                $field = $this->registrationFieldBuilder
+                    ->reset($opportunity, 'text', 'doc-field-' . strtolower($key))
+                    ->fillRequiredProperties()
+                    ->setTitle($title)
+                    ->setStep($step)
+                    ->save()
+                    ->getInstance();
+
+                $fields[$title] = $field;
+            }
+
+            $opportunity->registerRegistrationMetadata();
+        }
+
+        $registration = $this->registrationDirector->createSentRegistration($opportunity, data: []);
+
+        $app = App::i();
+        $app->disableAccessControl();
+
+        $slot = new RegistrationEvaluation();
+        $slot->registration = $registration;
+        $slot->user = $slot_owner;
+        $slot->status = RegistrationEvaluation::STATUS_EVALUATED;
+
+        if ($method === EvaluationMethods::documentary) {
+            $data = [];
+            foreach ($fields as $field) {
+                $data[$field->getFieldName()] = ['evaluation' => 'valid', 'obs' => ''];
+            }
+            $slot->setEvaluationData((object) $data);
+        } else {
+            $slot->setEvaluationData((object) ['status' => '3', 'obs' => 'original']);
+        }
+
+        $slot->save(true);
+
+        $appeal_phase_class = $opportunity->getSpecializedClassName();
+        /** @var Opportunity $appeal_phase */
+        $appeal_phase = new $appeal_phase_class();
+        $appeal_phase->parent = $opportunity;
+        $appeal_phase->status = Opportunity::STATUS_APPEAL_PHASE;
+        $appeal_phase->name = 'Fase de recurso ' . $method->name;
+        $appeal_phase->ownerEntity = $opportunity->ownerEntity;
+        $appeal_phase->owner = $opportunity->owner;
+        $appeal_phase->registrationCategories = $opportunity->registrationCategories;
+        $appeal_phase->registrationRanges = $opportunity->registrationRanges;
+        $appeal_phase->registrationProponentTypes = $opportunity->registrationProponentTypes;
+        $appeal_phase->isDataCollection = true;
+        $appeal_phase->isAppealPhase = true;
+        $appeal_phase->registrationFrom = new DateTime('-1 day');
+        $appeal_phase->registrationTo = new DateTime('+1 day');
+        $appeal_phase->save(true);
+
+        $opportunity->appealPhase = $appeal_phase;
+        $opportunity->save(true);
+
+        $appeal_emc = new EvaluationMethodConfiguration();
+        $appeal_emc->opportunity = $appeal_phase;
+        $appeal_emc->type = 'continuous';
+        $appeal_emc->publishEvaluationDetails = true;
+        $appeal_emc->save(true);
+
+        $appeal_phase->evaluationMethodConfiguration = $appeal_emc;
+        $appeal_phase->save(true);
+
+        $appeal_emc->createAgentRelation($committee_user->profile, 'committee 1', true)->save(true);
+
+        $app->enableAccessControl();
+
+        return [
+            'admin' => $admin,
+            'slotOwner' => $slot_owner,
+            'committeeUser' => $committee_user,
+            'opportunity' => $opportunity,
+            'registration' => $registration,
+            'slot' => $slot,
+            'appealPhase' => $appeal_phase,
+            'fields' => $fields,
+        ];
+    }
+
+    /**
+     * @return array{status: int, json: mixed}
+     */
+    private function dispatch(ServerRequestInterface $request): array
+    {
+        $app = App::i();
+        $app->reset();
+        $app->run($request, false);
+
+        return [
+            'status' => $app->response->getStatusCode(),
+            'json' => json_decode((string) $app->response->getBody(), true),
+        ];
+    }
+
+    /**
+     * @return array{status: int, json: mixed}
+     */
+    private function designate(array $scenario, ?array $released_scope = null): array
+    {
+        $this->login($scenario['admin']);
+
+        $payload = [
+            'originalEvaluation' => $scenario['slot']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ];
+
+        if ($released_scope !== null) {
+            $payload['releasedScope'] = json_encode($released_scope);
+        }
+
+        return $this->dispatch(
+            $this->requestFactory->POST('registrationappealreview', 'index', [], $payload)
+        );
+    }
+
+    /**
+     * @return array{status: int, json: mixed}
+     */
+    private function environment(int $assignment_id, User $corrector): array
+    {
+        $this->login($corrector);
+
+        return $this->dispatch(
+            $this->requestFactory->GET('appealCorrector', 'environment', [$assignment_id], ajax: true)
+        );
+    }
+
+    /**
+     * @return array{status: int, json: mixed}
+     */
+    private function applyCorrection(RegistrationEvaluation $slot, array $evaluation_data, bool $draft): array
+    {
+        return $this->dispatch(
+            $this->requestFactory->POST('registrationevaluation', 'applyAppealCorrection', [$slot->id], [
+                'evaluationData' => $evaluation_data,
+                'draft' => $draft,
+            ])
+        );
+    }
+
+    /**
+     * Documental: designar → corretor acessa (hook + ambiente por método) →
+     * rascunho → envio → slot atualizado in-place + snapshot + SENT.
+     */
+    function testDocumentaryCorrectorFullCycle(): void
+    {
+        $scenario = $this->createScenario(EvaluationMethods::documentary);
+        [$field_a, $field_b] = array_values($scenario['fields']);
+        $field_a_name = $field_a->getFieldName();
+        $field_b_name = $field_b->getFieldName();
+
+        $created = $this->designate($scenario);
+        $this->assertEquals(200, $created['status'], 'Designação em documental (F6): ' . json_encode($created['json']));
+        $review_id = (int) $created['json']['id'];
+
+        // Antes do F7: PermissionDenied. Agora: hook concede view/modify ao corretor.
+        $corrector = $scenario['committeeUser'];
+        $this->login($corrector);
+        $this->assertTrue($scenario['slot']->canUser('view', $corrector), 'Corretor designado deve ver o slot documental (hook do módulo, F7).');
+        $this->assertTrue($scenario['slot']->canUser('modify', $corrector), 'Corretor designado deve modificar o slot documental (hook do módulo, F7).');
+
+        // Ambiente por método: method=documentary + campos liberados (sem restrição)
+        $environment = $this->environment($review_id, $corrector);
+        $this->assertEquals(200, $environment['status'], 'Ambiente do corretor em documental: ' . json_encode($environment['json']));
+        $this->assertSame('documentary', $environment['json']['method']);
+        $field_ids = array_map(static fn (array $f): string => $f['id'], $environment['json']['fields'] ?? []);
+        $this->assertContains($field_a_name, $field_ids, 'Ambiente deve expor os campos documentais (fieldName).');
+        $this->assertContains($field_b_name, $field_ids);
+
+        // Rascunho: campo A corrigido para inválido
+        $data = (array) $scenario['slot']->getEvaluationData();
+        $data[$field_a_name] = ['evaluation' => 'invalid', 'obs' => 'ilegível'];
+
+        $draft = $this->applyCorrection($scenario['slot'], $data, draft: true);
+        $this->assertEquals(200, $draft['status'], 'Rascunho em documental: ' . json_encode($draft['json']));
+
+        /** @var RegistrationAppealReview $review */
+        $review = App::i()->repo(RegistrationAppealReview::class)->find($review_id);
+        $this->assertSame(RegistrationAppealReview::STATUS_DRAFT, (int) $review->status);
+        $this->assertEquals('invalid', ((array) $review->correctedValue)[$field_a_name]['evaluation'], 'Rascunho persiste correctedValue por campo.');
+
+        // Envio definitivo: slot atualizado in-place, snapshot original, SENT
+        $sent = $this->applyCorrection($scenario['slot'], $data, draft: false);
+        $this->assertEquals(200, $sent['status'], 'Envio em documental: ' . json_encode($sent['json']));
+
+        $slot = App::i()->repo('RegistrationEvaluation')->find($scenario['slot']->id);
+        $this->assertSame('invalid', ((array) $slot->getEvaluationData())[$field_a_name]['evaluation'], 'Slot documental atualizado in-place.');
+        $this->assertSame('valid', ((array) $slot->getEvaluationData())[$field_b_name]['evaluation'], 'Campo fora da correção permanece.');
+        $this->assertSame((string) RegistrationEvaluation::STATUS_SENT, (string) $slot->status);
+
+        $review = App::i()->repo(RegistrationAppealReview::class)->find($review_id);
+        $this->assertSame(RegistrationAppealReview::STATUS_SENT, (int) $review->status);
+        $this->assertNotNull($review->sentTimestamp);
+        $this->assertEquals('valid', ((array) $review->originalValue)[$field_a_name]['evaluation'], 'Snapshot do valor original preservado.');
+    }
+
+    /**
+     * Simples: mesmo ciclo com resultado global (status + obs), sem seletor.
+     */
+    function testSimpleCorrectorFullCycle(): void
+    {
+        $scenario = $this->createScenario(EvaluationMethods::simple);
+
+        $created = $this->designate($scenario);
+        $this->assertEquals(200, $created['status'], 'Designação em simples (F6): ' . json_encode($created['json']));
+        $review_id = (int) $created['json']['id'];
+
+        $corrector = $scenario['committeeUser'];
+        $this->login($corrector);
+        $this->assertTrue($scenario['slot']->canUser('modify', $corrector), 'Corretor designado deve modificar o slot simples (hook do módulo, F7).');
+
+        $environment = $this->environment($review_id, $corrector);
+        $this->assertEquals(200, $environment['status'], 'Ambiente do corretor em simples: ' . json_encode($environment['json']));
+        $this->assertSame('simple', $environment['json']['method']);
+        $this->assertNotEmpty($environment['json']['statusOptions'], 'Ambiente simples expõe as opções de status global.');
+        $this->assertSame('3', (string) $environment['json']['originalEvaluation']['status']);
+
+        $data = ['status' => '10', 'obs' => 'recurso deferido: selecionada'];
+
+        $draft = $this->applyCorrection($scenario['slot'], $data, draft: true);
+        $this->assertEquals(200, $draft['status'], 'Rascunho em simples: ' . json_encode($draft['json']));
+
+        $sent = $this->applyCorrection($scenario['slot'], $data, draft: false);
+        $this->assertEquals(200, $sent['status'], 'Envio em simples: ' . json_encode($sent['json']));
+
+        $slot = App::i()->repo('RegistrationEvaluation')->find($scenario['slot']->id);
+        $this->assertSame('10', (string) ((array) $slot->getEvaluationData())['status'], 'Slot simples atualizado in-place (status global).');
+        $this->assertSame('recurso deferido: selecionada', ((array) $slot->getEvaluationData())['obs']);
+        $this->assertSame((string) RegistrationEvaluation::STATUS_SENT, (string) $slot->status);
+
+        $review = App::i()->repo(RegistrationAppealReview::class)->find($review_id);
+        $this->assertSame(RegistrationAppealReview::STATUS_SENT, (int) $review->status);
+        $this->assertEquals('3', (string) ((array) $review->originalValue)['status'], 'Snapshot do status original preservado.');
+        $this->assertNotNull(App::i()->repo('Registration')->find($scenario['registration']->id)->refreshed()->consolidatedResult, 'Reconsolidação unitária executada.');
+    }
+
+    /**
+     * Escopo restrito documental: campo fora do escopo com valor divergente é
+     * rejeitado (400); envio somente com o campo liberado é aceito.
+     */
+    function testDocumentaryRestrictedScopeRejectsOutOfScopeField(): void
+    {
+        $scenario = $this->createScenario(EvaluationMethods::documentary);
+        [$field_a, $field_b] = array_values($scenario['fields']);
+        $field_a_name = $field_a->getFieldName();
+        $field_b_name = $field_b->getFieldName();
+
+        $created = $this->designate($scenario, ['criteria' => [$field_a_name]]);
+        $this->assertEquals(200, $created['status']);
+        $review_id = (int) $created['json']['id'];
+
+        $this->login($scenario['committeeUser']);
+
+        // Ambiente: somente o campo liberado é exposto
+        $environment = $this->environment($review_id, $scenario['committeeUser']);
+        $field_ids = array_map(static fn (array $f): string => $f['id'], $environment['json']['fields'] ?? []);
+        $this->assertEquals([$field_a_name], $field_ids, 'Escopo documental filtra os campos do ambiente.');
+
+        // Campo B fora do escopo com valor DIVERGENTE → rejeitado
+        $data = (array) $scenario['slot']->getEvaluationData();
+        $data[$field_a_name] = ['evaluation' => 'invalid', 'obs' => ''];
+        $data[$field_b_name] = ['evaluation' => 'invalid', 'obs' => ''];
+
+        $rejected = $this->applyCorrection($scenario['slot'], $data, draft: false);
+        $this->assertEquals(400, $rejected['status'], 'Campo fora do escopo com valor divergente deve ser rejeitado.');
+        $this->assertTrue($rejected['json']['error'] ?? false);
+
+        // Somente o campo liberado → aceito
+        $data[$field_b_name] = ['evaluation' => 'valid', 'obs' => ''];
+        $accepted = $this->applyCorrection($scenario['slot'], $data, draft: false);
+        $this->assertEquals(200, $accepted['status'], 'Correção dentro do escopo deve ser aplicada: ' . json_encode($accepted['json']));
+
+        $slot = App::i()->repo('RegistrationEvaluation')->find($scenario['slot']->id);
+        $this->assertSame('invalid', ((array) $slot->getEvaluationData())[$field_a_name]['evaluation'], 'Campo liberado corrigido in-place.');
+    }
+}

--- a/tests/src/AppealCorrectorEnvironmentTest.php
+++ b/tests/src/AppealCorrectorEnvironmentTest.php
@@ -300,4 +300,52 @@ class AppealCorrectorEnvironmentTest extends TestCase
         $this->expectException(PermissionDenied::class);
         (new CorrectorEnvironment())->build($scenario['review']);
     }
+
+    function testPayloadExposesCriteriaMetadataAndSlotIdentity(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['corrector']);
+
+        $payload = (new CorrectorEnvironment())->build($scenario['review']);
+
+        $this->assertEquals((int) $scenario['slotA']->id, $payload['evaluationId']);
+        $this->assertEquals((int) $scenario['registration']->id, $payload['registrationId']);
+        $this->assertEquals($scenario['registration']->number, $payload['registrationNumber']);
+        $this->assertNotEmpty($payload['opportunityName']);
+
+        $this->assertIsArray($payload['criteria']);
+        $this->assertCount(1, $payload['criteria']);
+
+        $criteria_ids = array_map(static fn ($criterion) => $criterion['id'], $payload['criteria']);
+        $this->assertEquals(['c-1'], $criteria_ids);
+
+        $criterion = $payload['criteria'][0];
+        $this->assertEquals('Critério 1', $criterion['title']);
+        $this->assertEquals(10, $criterion['max']);
+        $this->assertEquals(1, $criterion['weight']);
+        $this->assertEquals('sec-1', $criterion['sectionId']);
+        $this->assertEquals('Seção 1', $criterion['sectionName']);
+    }
+
+    function testCorrectionPageRendersForCorrector(): void
+    {
+        $scenario = $this->createScenario();
+        $this->login($scenario['corrector']);
+
+        $request = $this->requestFactory->GET(
+            'appealCorrector',
+            'correction',
+            [$scenario['review']->id],
+            ajax: false
+        );
+
+        $app = App::i();
+        $app->reset();
+        $app->run($request, false);
+
+        $this->assertEquals(200, $app->response->getStatusCode());
+        $body = (string) $app->response->getBody();
+        $this->assertStringContainsString('opportunity-appeal-correction-evaluation', $body);
+        $this->assertStringContainsString((string) $scenario['review']->id, $body);
+    }
 }

--- a/tests/src/AppealReleasedScopeTest.php
+++ b/tests/src/AppealReleasedScopeTest.php
@@ -1,0 +1,276 @@
+<?php
+
+namespace Tests;
+
+use DateTime;
+use MapasCulturais\App;
+use MapasCulturais\Entities\EvaluationMethodConfiguration;
+use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\Entities\Registration;
+use MapasCulturais\Entities\RegistrationEvaluation;
+use MapasCulturais\Entities\User;
+use OpportunityAppealPhase\Entities\RegistrationAppealReview;
+use Psr\Http\Message\ServerRequestInterface;
+use Tests\Abstract\TestCase;
+use Tests\Builders\PhasePeriods\ConcurrentEndingAfter;
+use Tests\Builders\PhasePeriods\Open;
+use Tests\Enums\EvaluationMethods;
+use Tests\Traits\OpportunityBuilder;
+use Tests\Traits\RegistrationDirector;
+use Tests\Traits\RequestFactory;
+use Tests\Traits\UserDirector;
+
+/**
+ * F6 (#49): abertura de elegibilidade para todos os métodos + seletor de
+ * escopo de critérios (Variante 3, override registrado na #7 em 2026-09-09).
+ *
+ * Cobertura:
+ * - AC1: método NÃO-técnico (simple) tem designação aceita e
+ *   eligibleCorrectors() devolve dono do slot + Comissão de Recursos;
+ * - AC2: releasedScope com criteria explícito e VAZIO → 400 no POST;
+ * - AC3: POST sem releasedScope persiste null (correção integral) e o PATCH
+ *   com releasedScope null LIMPA restrição existente.
+ */
+class AppealReleasedScopeTest extends TestCase
+{
+    use OpportunityBuilder,
+        RegistrationDirector,
+        UserDirector,
+        RequestFactory;
+
+    private function enableFlag(): void
+    {
+        $_ENV['APPEAL_SCORE_CORRECTION'] = 'true';
+    }
+
+    /**
+     * Cenário análogo ao de AppealAssignmentApiTest, com método parametrizável.
+     *
+     * @return array{admin: User, slotOwner: User, committeeUser: User,
+     *   opportunity: Opportunity, registration: Registration,
+     *   slot: RegistrationEvaluation, appealPhase: Opportunity}
+     */
+    private function createScenario(EvaluationMethods $method = EvaluationMethods::simple): array
+    {
+        $this->enableFlag();
+
+        $admin = $this->userDirector->createUser('admin');
+        $slot_owner = $this->userDirector->createUser();
+        $committee_user = $this->userDirector->createUser();
+
+        $this->login($admin);
+
+        $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase($method)
+                ->fillRequiredProperties()
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->save()
+                ->addValuer('Comissão', 'Avaliador do Slot', $slot_owner->profile)
+                    ->done()
+                ->done()
+            ->save();
+
+        /** @var Opportunity $opportunity */
+        $opportunity = $this->opportunityBuilder->getInstance();
+        $registration = $this->registrationDirector->createSentRegistration($opportunity, data: []);
+
+        $app = App::i();
+        $app->disableAccessControl();
+
+        $slot = new RegistrationEvaluation();
+        $slot->registration = $registration;
+        $slot->user = $slot_owner;
+        $slot->status = RegistrationEvaluation::STATUS_EVALUATED;
+        $slot->save(true);
+
+        $appeal_phase_class = $opportunity->getSpecializedClassName();
+        /** @var Opportunity $appeal_phase */
+        $appeal_phase = new $appeal_phase_class();
+        $appeal_phase->parent = $opportunity;
+        $appeal_phase->status = Opportunity::STATUS_APPEAL_PHASE;
+        $appeal_phase->name = 'Fase de recurso ' . $method->value;
+        $appeal_phase->ownerEntity = $opportunity->ownerEntity;
+        $appeal_phase->owner = $opportunity->owner;
+        $appeal_phase->registrationCategories = $opportunity->registrationCategories;
+        $appeal_phase->registrationRanges = $opportunity->registrationRanges;
+        $appeal_phase->registrationProponentTypes = $opportunity->registrationProponentTypes;
+        $appeal_phase->isDataCollection = true;
+        $appeal_phase->isAppealPhase = true;
+        $appeal_phase->registrationFrom = new DateTime('-1 day');
+        $appeal_phase->registrationTo = new DateTime('+1 day');
+        $appeal_phase->save(true);
+
+        $opportunity->appealPhase = $appeal_phase;
+        $opportunity->save(true);
+
+        $appeal_emc = new EvaluationMethodConfiguration();
+        $appeal_emc->opportunity = $appeal_phase;
+        $appeal_emc->type = 'continuous';
+        $appeal_emc->publishEvaluationDetails = true;
+        $appeal_emc->save(true);
+
+        $appeal_phase->evaluationMethodConfiguration = $appeal_emc;
+        $appeal_phase->save(true);
+
+        $appeal_emc->createAgentRelation($committee_user->profile, 'committee 1', true)->save(true);
+
+        $app->enableAccessControl();
+
+        return [
+            'admin' => $admin,
+            'slotOwner' => $slot_owner,
+            'committeeUser' => $committee_user,
+            'opportunity' => $opportunity,
+            'registration' => $registration,
+            'slot' => $slot,
+            'appealPhase' => $appeal_phase,
+        ];
+    }
+
+    /**
+     * @return array{status: int, json: mixed}
+     */
+    private function dispatch(ServerRequestInterface $request): array
+    {
+        $app = App::i();
+        $app->reset();
+        $app->run($request, false);
+
+        return [
+            'status' => $app->response->getStatusCode(),
+            'json' => json_decode((string) $app->response->getBody(), true),
+        ];
+    }
+
+    /**
+     * @return array{status: int, json: mixed}
+     */
+    private function postAssignment(array $payload): array
+    {
+        return $this->dispatch(
+            $this->requestFactory->POST('registrationappealreview', 'index', [], $payload)
+        );
+    }
+
+    /**
+     * @return array{status: int, json: mixed}
+     */
+    private function patchAssignment(int $id, array $payload): array
+    {
+        return $this->dispatch(
+            $this->requestFactory->PATCH('registrationappealreview', 'single', [$id], $payload)
+        );
+    }
+
+    /**
+     * AC1 (F6): com a fase principal em método SIMPLES (não-técnico), a
+     * designação é aceita — elegibilidade aberta a todos os métodos — e
+     * eligibleCorrectors() devolve dono do slot + Comissão de Recursos.
+     */
+    function testNonTechnicalMethodIsEligibleForDesignation(): void
+    {
+        $scenario = $this->createScenario(EvaluationMethods::simple);
+        $this->login($scenario['admin']);
+
+        // eligibleCorrectors: dono do slot + comissão (sem early-return técnico)
+        $probe = new RegistrationAppealReview();
+        $probe->originalEvaluation = $scenario['slot'];
+        $probe->registration = $scenario['registration'];
+        $probe->appealPhase = $scenario['appealPhase'];
+        $probe->slotOwnerUser = $scenario['slotOwner'];
+        $probe->correctorUser = $scenario['committeeUser'];
+
+        $eligible_ids = array_map(
+            static fn (User $user): int => (int) $user->id,
+            $probe->eligibleCorrectors($scenario['slot'])
+        );
+
+        $this->assertContains($scenario['slotOwner']->id, $eligible_ids, 'Dono do slot deve ser elegível em método não-técnico (F6).');
+        $this->assertContains($scenario['committeeUser']->id, $eligible_ids, 'Comissão de Recursos deve ser elegível em método não-técnico (F6).');
+        $this->assertCount(2, $eligible_ids, 'Elegibilidade em método não-técnico: dono + comissão, sem duplicatas.');
+
+        $response = $this->postAssignment([
+            'originalEvaluation' => $scenario['slot']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ]);
+
+        $this->assertEquals(200, $response['status'], 'Designação em método não-técnico deve ser criada (F6): ' . json_encode($response['json']));
+
+        /** @var RegistrationAppealReview $review */
+        $review = App::i()->repo(RegistrationAppealReview::class)->find($response['json']['id']);
+        $this->assertNull($review->releasedScope, 'Sem seletor (método simples) o escopo persiste null = tudo liberado.');
+    }
+
+    /**
+     * AC2 (F6): releasedScope com criteria vazio é rejeitado com 400 e
+     * mensagem clara — no POST e no PATCH.
+     */
+    function testEmptyCriteriaScopeIsRejected(): void
+    {
+        $scenario = $this->createScenario(EvaluationMethods::technical);
+        $this->login($scenario['admin']);
+
+        $post_response = $this->postAssignment([
+            'originalEvaluation' => $scenario['slot']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+            'releasedScope' => json_encode(['criteria' => []]),
+        ]);
+
+        $this->assertEquals(400, $post_response['status'], 'POST com criteria vazio deve ser rejeitado (F6).');
+        $this->assertTrue($post_response['json']['error'] ?? false);
+        $this->assertStringContainsStringIgnoringCase('escopo', (string) $post_response['json']['data'], 'Mensagem deve explicar a rejeição do escopo vazio.');
+
+        // Cria designação válida para exercitar o PATCH
+        $created = $this->postAssignment([
+            'originalEvaluation' => $scenario['slot']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+        ]);
+        $this->assertEquals(200, $created['status']);
+
+        $patch_response = $this->patchAssignment((int) $created['json']['id'], [
+            'releasedScope' => json_encode(['criteria' => []]),
+        ]);
+
+        $this->assertEquals(400, $patch_response['status'], 'PATCH com criteria vazio deve ser rejeitado (F6).');
+        $this->assertTrue($patch_response['json']['error'] ?? false);
+    }
+
+    /**
+     * AC3 (F6): POST sem releasedScope persiste null (integral) e o PATCH com
+     * releasedScope null LIMPA a restrição previamente gravada.
+     */
+    function testNullScopeMeansUnrestrictedAndClearsRestrictionOnPatch(): void
+    {
+        $scenario = $this->createScenario(EvaluationMethods::technical);
+        $this->login($scenario['admin']);
+
+        // Restrição parcial
+        $created = $this->postAssignment([
+            'originalEvaluation' => $scenario['slot']->id,
+            'correctorUser' => $scenario['committeeUser']->id,
+            'releasedScope' => json_encode(['criteria' => ['c-1', 'c-2']]),
+        ]);
+        $this->assertEquals(200, $created['status']);
+
+        /** @var RegistrationAppealReview $review */
+        $review = App::i()->repo(RegistrationAppealReview::class)->find($created['json']['id']);
+        $this->assertEquals(['criteria' => ['c-1', 'c-2']], (array) $review->releasedScope);
+
+        // "Todos marcados" na substituição → payload null → LIMPA a restrição
+        $patch_response = $this->patchAssignment((int) $created['json']['id'], [
+            'correctorUser' => $scenario['slotOwner']->id,
+            'releasedScope' => null,
+        ]);
+        $this->assertEquals(200, $patch_response['status'], 'PATCH com releasedScope null deve limpar a restrição: ' . json_encode($patch_response['json']));
+
+        $review = App::i()->repo(RegistrationAppealReview::class)->find($created['json']['id']);
+        $this->assertNull($review->releasedScope, 'releasedScope null após PATCH = todos os critérios liberados.');
+        $this->assertEquals($scenario['slotOwner']->id, $review->correctorUser->id);
+    }
+}

--- a/tests/src/AppealScoreColumnsTest.php
+++ b/tests/src/AppealScoreColumnsTest.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace Tests;
+
+use DateTime;
+use MapasCulturais\App;
+use MapasCulturais\ApiQuery;
+use MapasCulturais\Entities\EvaluationMethodConfiguration;
+use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\Entities\Registration;
+use MapasCulturais\Entities\RegistrationEvaluation;
+use MapasCulturais\Entities\User;
+use OpportunityAppealPhase\Entities\RegistrationAppealReview;
+use Psr\Http\Message\ServerRequestInterface;
+use Tests\Abstract\TestCase;
+use Tests\Builders\PhasePeriods\ConcurrentEndingAfter;
+use Tests\Builders\PhasePeriods\Open;
+use Tests\Enums\EvaluationMethods;
+use Tests\Traits\OpportunityBuilder;
+use Tests\Traits\RegistrationDirector;
+use Tests\Traits\RequestFactory;
+use Tests\Traits\UserDirector;
+
+/**
+ * F4 (#20) — CA-11: colunas de nota original/corrigida/diferença.
+ *
+ * Cenário documental com correção APLICADA (slot A: inválida −1 → válida 1;
+ * slot B sem correção: válida 1; inscrição 2 sem nenhuma correção):
+ * - por slot: originalScore/correctedScore/scoreDifference via ApiQuery e API;
+ * - por inscrição: averageOriginalScore/averageCorrectedScore/scoreDifference
+ *   (média corrigida = vigente; média original = recomputada com os snapshots).
+ */
+class AppealScoreColumnsTest extends TestCase
+{
+    use OpportunityBuilder,
+        RegistrationDirector,
+        UserDirector,
+        RequestFactory;
+
+    private function enableFlag(): void
+    {
+        $_ENV['APPEAL_SCORE_CORRECTION'] = 'true';
+    }
+
+    /**
+     * @return array{admin: User, committeeUser: User, opportunity: Opportunity,
+     *   registration1: Registration, registration2: Registration,
+     *   slotA: RegistrationEvaluation, slotB: RegistrationEvaluation}
+     */
+    private function createScenario(): array
+    {
+        $this->enableFlag();
+
+        $admin = $this->userDirector->createUser('admin');
+        $slot_owner_a = $this->userDirector->createUser();
+        $slot_owner_b = $this->userDirector->createUser();
+        $committee_user = $this->userDirector->createUser();
+
+        $this->login($admin);
+
+        $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase(EvaluationMethods::documentary)
+                ->fillRequiredProperties()
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->save()
+                ->addValuer('Comissão', 'Avaliador A', $slot_owner_a->profile)
+                    ->done()
+                ->addValuer('Comissão', 'Avaliador B', $slot_owner_b->profile)
+                    ->done()
+                ->done()
+            ->save();
+
+        /** @var Opportunity $opportunity */
+        $opportunity = $this->opportunityBuilder->getInstance();
+
+        $registration_1 = $this->registrationDirector->createSentRegistration($opportunity, data: []);
+        $registration_2 = $this->registrationDirector->createSentRegistration($opportunity, data: []);
+
+        $app = App::i();
+        $app->disableAccessControl();
+
+        // Slot A: inválida (result −1) — será corrigida para válida (result 1).
+        $slot_a = new RegistrationEvaluation();
+        $slot_a->registration = $registration_1;
+        $slot_a->user = $slot_owner_a;
+        $slot_a->status = RegistrationEvaluation::STATUS_SENT;
+        $slot_a->setEvaluationData((object) ['doc_a' => ['evaluation' => 'invalid', 'obs' => '']]);
+        $slot_a->save(true);
+
+        // Slot B: válida (result 1) — permanece sem correção.
+        $slot_b = new RegistrationEvaluation();
+        $slot_b->registration = $registration_1;
+        $slot_b->user = $slot_owner_b;
+        $slot_b->status = RegistrationEvaluation::STATUS_SENT;
+        $slot_b->setEvaluationData((object) ['doc_b' => ['evaluation' => 'valid', 'obs' => '']]);
+        $slot_b->save(true);
+
+        // Inscrição 2: um slot válido, sem nenhuma correção.
+        $slot_c = new RegistrationEvaluation();
+        $slot_c->registration = $registration_2;
+        $slot_c->user = $slot_owner_b;
+        $slot_c->status = RegistrationEvaluation::STATUS_SENT;
+        $slot_c->setEvaluationData((object) ['doc_b' => ['evaluation' => 'valid', 'obs' => '']]);
+        $slot_c->save(true);
+
+        $appeal_phase_class = $opportunity->getSpecializedClassName();
+        /** @var Opportunity $appeal_phase */
+        $appeal_phase = new $appeal_phase_class();
+        $appeal_phase->parent = $opportunity;
+        $appeal_phase->status = Opportunity::STATUS_APPEAL_PHASE;
+        $appeal_phase->name = 'Fase de recurso documental';
+        $appeal_phase->ownerEntity = $opportunity->ownerEntity;
+        $appeal_phase->owner = $opportunity->owner;
+        $appeal_phase->registrationCategories = $opportunity->registrationCategories;
+        $appeal_phase->registrationRanges = $opportunity->registrationRanges;
+        $appeal_phase->registrationProponentTypes = $opportunity->registrationProponentTypes;
+        $appeal_phase->isDataCollection = true;
+        $appeal_phase->isAppealPhase = true;
+        $appeal_phase->registrationFrom = new DateTime('-1 day');
+        $appeal_phase->registrationTo = new DateTime('+1 day');
+        $appeal_phase->save(true);
+
+        $opportunity->appealPhase = $appeal_phase;
+        $opportunity->save(true);
+
+        $appeal_emc = new EvaluationMethodConfiguration();
+        $appeal_emc->opportunity = $appeal_phase;
+        $appeal_emc->type = 'continuous';
+        $appeal_emc->publishEvaluationDetails = true;
+        $appeal_emc->save(true);
+
+        $appeal_phase->evaluationMethodConfiguration = $appeal_emc;
+        $appeal_phase->save(true);
+
+        $appeal_emc->createAgentRelation($committee_user->profile, 'committee 1', true)->save(true);
+
+        $app->enableAccessControl();
+
+        return [
+            'admin' => $admin,
+            'committeeUser' => $committee_user,
+            'opportunity' => $opportunity,
+            'registration1' => $registration_1,
+            'registration2' => $registration_2,
+            'slotA' => $slot_a,
+            'slotB' => $slot_b,
+        ];
+    }
+
+    /**
+     * @return array{status: int, json: mixed}
+     */
+    private function dispatch(ServerRequestInterface $request): array
+    {
+        $app = App::i();
+        $app->reset();
+        $app->run($request, false);
+
+        return [
+            'status' => $app->response->getStatusCode(),
+            'json' => json_decode((string) $app->response->getBody(), true),
+        ];
+    }
+
+    /**
+     * Designa o comitê para o slot e aplica a correção (inválida → válida).
+     */
+    private function applyRealCorrection(array $scenario): void
+    {
+        $this->login($scenario['admin']);
+
+        $created = $this->dispatch(
+            $this->requestFactory->POST('registrationappealreview', 'index', [], [
+                'originalEvaluation' => $scenario['slotA']->id,
+                'correctorUser' => $scenario['committeeUser']->id,
+            ])
+        );
+        $this->assertEquals(200, $created['status'], 'Designação: ' . json_encode($created['json']));
+
+        $this->login($scenario['committeeUser']);
+
+        $sent = $this->dispatch(
+            $this->requestFactory->POST('registrationevaluation', 'applyAppealCorrection', [$scenario['slotA']->id], [
+                'evaluationData' => ['doc_a' => ['evaluation' => 'valid', 'obs' => 'corrigida']],
+                'draft' => false,
+            ])
+        );
+        $this->assertEquals(200, $sent['status'], 'Correção aplicada: ' . json_encode($sent['json']));
+
+        $this->login($scenario['admin']);
+        // Sem processPCache: o drain da fila com fase de recurso no cenário
+        // esbarra em query pré-existente do OpportunityPhases (EAGER+WITH em
+        // OpportunityMeta#owner) — fora do escopo do F4. As consultas abaixo
+        // rodam como admin (bypass da subquery de permissão).
+    }
+
+    function testSlotColumnsWithAndWithoutCorrection(): void
+    {
+        $scenario = $this->createScenario();
+        $this->applyRealCorrection($scenario);
+
+        $query = new ApiQuery(RegistrationEvaluation::class, [
+            '@select' => 'id,originalScore,correctedScore,scoreDifference',
+            'id' => "IN({$scenario['slotA']->id},{$scenario['slotB']->id})",
+        ]);
+        $rows = [];
+        foreach ($query->find() as $row) {
+            $rows[(int) $row['id']] = $row;
+        }
+
+        // Slot corrigido: −1 → 1 (documental: inválida → válida)
+        $this->assertEquals(-1.0, $rows[$scenario['slotA']->id]['originalScore'], 'originalScore = snapshot da primeira correção aplicada');
+        $this->assertEquals(1.0, $rows[$scenario['slotA']->id]['correctedScore'], 'correctedScore = nota vigente (result pós correção in-place)');
+        $this->assertEquals(2.0, $rows[$scenario['slotA']->id]['scoreDifference'], 'scoreDifference = corrigida − original');
+
+        // Slot sem correção: original = vigente, diferença 0
+        $this->assertEquals(1.0, $rows[$scenario['slotB']->id]['originalScore'], 'sem correção: originalScore = nota atual');
+        $this->assertEquals(1.0, $rows[$scenario['slotB']->id]['correctedScore']);
+        $this->assertEquals(0.0, $rows[$scenario['slotB']->id]['scoreDifference']);
+    }
+
+    function testRegistrationAveragesAndDifference(): void
+    {
+        $scenario = $this->createScenario();
+        $this->applyRealCorrection($scenario);
+
+        $query = new ApiQuery(Registration::class, [
+            '@select' => 'id,averageOriginalScore,averageCorrectedScore,scoreDifference',
+            'id' => "IN({$scenario['registration1']->id},{$scenario['registration2']->id})",
+        ]);
+        $rows = [];
+        foreach ($query->find() as $row) {
+            $rows[(int) $row['id']] = $row;
+        }
+
+        // Inscrição 1: slots (−1→1) e (1) → média original 0, corrigida 1, diferença 1
+        $reg1 = $rows[$scenario['registration1']->id];
+        $this->assertEquals(0.0, $reg1['averageOriginalScore'], 'média original = (−1 + 1) / 2');
+        $this->assertEquals(1.0, $reg1['averageCorrectedScore'], 'média corrigida = (1 + 1) / 2');
+        $this->assertEquals(1.0, $reg1['scoreDifference']);
+
+        // Inscrição 2: sem nenhuma correção → médias iguais, diferença 0
+        $reg2 = $rows[$scenario['registration2']->id];
+        $this->assertEquals(1.0, $reg2['averageOriginalScore']);
+        $this->assertEquals(1.0, $reg2['averageCorrectedScore']);
+        $this->assertEquals(0.0, $reg2['scoreDifference'], 'sem correção: diferença 0');
+    }
+
+    /**
+     * Query API real (proof): @select das propriedades computadas retorna
+     * valores no cenário com correção (documental −1 → 1).
+     */
+    function testApiSelectReturnsComputedScoreColumns(): void
+    {
+        $scenario = $this->createScenario();
+        $this->applyRealCorrection($scenario);
+
+        $evaluation_response = $this->dispatch(
+            $this->requestFactory->GET('api/registrationevaluation', 'find', [], [
+                '@select' => 'id,originalScore,correctedScore,scoreDifference',
+                'id' => "EQ({$scenario['slotA']->id})",
+            ], ajax: true)
+        );
+
+        $this->assertEquals(200, $evaluation_response['status'], 'API find de avaliações: ' . json_encode($evaluation_response['json']));
+        $slot = $evaluation_response['json'][0] ?? null;
+        $this->assertNotNull($slot);
+        $this->assertEquals(-1.0, $slot['originalScore'], 'API: originalScore do slot corrigido');
+        $this->assertEquals(1.0, $slot['correctedScore'], 'API: correctedScore do slot corrigido');
+        $this->assertEquals(2.0, $slot['scoreDifference'], 'API: scoreDifference do slot corrigido');
+
+        $registration_response = $this->dispatch(
+            $this->requestFactory->GET('api/registration', 'find', [], [
+                '@select' => 'id,averageOriginalScore,averageCorrectedScore,scoreDifference',
+                'id' => "EQ({$scenario['registration1']->id})",
+            ], ajax: true)
+        );
+
+        $this->assertEquals(200, $registration_response['status'], 'API find de inscrições: ' . json_encode($registration_response['json']));
+        $registration = $registration_response['json'][0] ?? null;
+        $this->assertNotNull($registration);
+        $this->assertEquals(0.0, $registration['averageOriginalScore'], 'API: média original da inscrição');
+        $this->assertEquals(1.0, $registration['averageCorrectedScore'], 'API: média corrigida da inscrição');
+        $this->assertEquals(1.0, $registration['scoreDifference'], 'API: diferença da inscrição');
+    }
+}


### PR DESCRIPTION
Entrega completa da épica #7 (variante Condensed): designação de correção por slot de avaliação, em todos os métodos.

## O que entra
- **Backend**: entidade `RegistrationAppealReview` por slot (PR1), permissões por slot + `eligibleCorrectors()` (PR2), publicação preliminar/final do recurso (PR3), serviço de correção in-place + reconsolidação unitária (PR4), endpoint read-only do corretor (PR4.5), API de designação criar/listar/substituir/cancelar (PR6).
- **Gestor**: coluna + botão na lista da fase de recurso (F1), modal de designação por slot com seletor de escopo de critérios (F2 + F6), substituição/cancelamento pela tela (F5), colunas nota original/corrigida/diferença nas listas e exportações (F4).
- **Corretor**: ambiente de correção por slot (F3) + ciclo completo para todos os métodos — técnica, documental, simples (F7).
- **Proponente**: linha do tempo preliminar → recurso → reavaliação → final, com gates de publicação (F8).
- **Notificações/e-mails** (PR5).

## Verificação
- Testes novos verdes: `AppealAssignmentApiTest` (12/51) · `AppealReleasedScopeTest` (3/16) · `AppealCorrectorCycleTest` (3/37) · `AppealScoreColumnsTest` (3/28) — suites vizinhas sem regressão (falhas da base pré-existentes por deprecations PHP 8.4, provadas via stash).
- E2E manual no ambiente dev, ponta a ponta, por método (técnico/documental/simples), incluindo escopo restrito, privacidade de publicação (critério 5 da F8) e os ciclos de designar/substituir/cancelar.

## Desvios declarados (registro da rodada — docs/rounds/R01-2026-08-correcao-notas-recurso/deviations.md)
1. F1: mecanismo de exposição da coluna (hook `visibleColumns` da tabela de resultados → mecanismo nativo da lista de inscritos).
2. F4: filtragem pelas colunas virtuais não suportada pela ApiQuery (fora dos critérios de aceitação; exibição completa).
3. Reabertura pós-envio (CA-13 parcial) fica para follow-up (registrado na #45).

## Antes do merge
A revisão final da rodada (#44) é o gate de fechamento da rodada (documentação × código, desvios, retro). Registro completo da rodada em `docs/rounds/R01-2026-08-correcao-notas-recurso/`.