### PR TITLE
Fix: layout do bloco de comissões na configuração da resposta do recurso (#56)

### DIFF
--- a/src/themes/BaseV2/assets-src/sass/2.components/_opportunity-appeal-phase-config.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_opportunity-appeal-phase-config.scss
@@ -34,13 +34,14 @@
                 display: flex;
                 flex-direction: column;
                 gap: size(32);
-                // #56 — a comissão do recurso segue o padrão do mc-accordion do
-                // tema (fundo branco + padding lateral); o cinza e o padding 0
-                // lateral degradavam a seção de comissões.
-                padding: size(16);
-                background-color: var(--mc-white);
+                padding: size(16) 0;
+                background-color: var(--mc-gray-100);
                 max-width: 100%;
                 border-top: var(--mc-border-hairline) var(--mc-gray-300);
+
+                .mc-card {
+                    background-color: var(--mc-gray-100);
+                }
             }
 
             &__title {
@@ -171,6 +172,13 @@
     &__add-evaluation-committee {
         border-bottom: var(--mc-border-hairline) var(--mc-gray-300);
         padding-bottom: size(42);
+
+        // #56 — respiro lateral da seção de comissões: o __content do
+        // accordion do recurso não tem padding lateral (shell cinza contínuo
+        // por design), então o espaçamento é dado apenas neste wrapper —
+        // sem tocar no shell do accordion.
+        padding-left: size(16);
+        padding-right: size(16);
     }
 
     &__delete {

--- a/src/themes/BaseV2/assets-src/sass/2.components/_opportunity-appeal-phase-config.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_opportunity-appeal-phase-config.scss
@@ -34,14 +34,13 @@
                 display: flex;
                 flex-direction: column;
                 gap: size(32);
-                padding: size(16) 0;
-                background-color: var(--mc-gray-100);
+                // #56 — a comissão do recurso segue o padrão do mc-accordion do
+                // tema (fundo branco + padding lateral); o cinza e o padding 0
+                // lateral degradavam a seção de comissões.
+                padding: size(16);
+                background-color: var(--mc-white);
                 max-width: 100%;
                 border-top: var(--mc-border-hairline) var(--mc-gray-300);
-
-                .mc-card {
-                    background-color: var(--mc-gray-100);
-                }
             }
 
             &__title {

--- a/src/themes/BaseV2/assets-src/sass/2.components/_opportunity-appeal-phase-config.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_opportunity-appeal-phase-config.scss
@@ -16,7 +16,10 @@
             padding: size(16) size(20) size(30);
 
             &__header {
-                padding: 0;
+                // #56 — shell cinza com respiro: título não cola nas bordas
+                // (era padding 0); padding-bottom do estado ativo coincide
+                // com o padding base (mesmo valor, sem duplicação).
+                padding: size(16);
                 background-color: var(--mc-gray-100);
                 max-width: size(1047);
                 grid-template-columns: 1fr size(124);
@@ -34,7 +37,10 @@
                 display: flex;
                 flex-direction: column;
                 gap: size(32);
-                padding: size(16) 0;
+                // #56 — padding em todos os lados (era size(16) 0): conteúdo
+                // não fica colado nas bordas; fundo cinza mantido (shell
+                // contínuo header+content).
+                padding: size(16);
                 background-color: var(--mc-gray-100);
                 max-width: 100%;
                 border-top: var(--mc-border-hairline) var(--mc-gray-300);
@@ -172,13 +178,8 @@
     &__add-evaluation-committee {
         border-bottom: var(--mc-border-hairline) var(--mc-gray-300);
         padding-bottom: size(42);
-
-        // #56 — respiro lateral da seção de comissões: o __content do
-        // accordion do recurso não tem padding lateral (shell cinza contínuo
-        // por design), então o espaçamento é dado apenas neste wrapper —
-        // sem tocar no shell do accordion.
-        padding-left: size(16);
-        padding-right: size(16);
+        // #56 — o respiro lateral vem do padding do __content (size(16) em
+        // todos os lados); padding lateral aqui duplicaria (16+16).
     }
 
     &__delete {


### PR DESCRIPTION
A seção "Comissões de avaliação" da configuração da "Resposta do recurso" (gestão da oportunidade → Configuração de fases → fase de avaliação → Etapa suplementar) renderizava com fundo cinza e sem padding, colada nas bordas.

- **Causa**: `_opportunity-appeal-phase-config.scss` — o `&__content` dentro de `.opportunity-appeal-phase-config__appeals .mc-accordion` aplicava fundo `--mc-gray-100` (o `mc-accordion` padrão do tema é branco), `padding: size(16) 0` (lateral zero) e um override `.mc-card` cinza.
- **Fix (CSS-only, escopo cirúrgico)**: `__content` → fundo branco + `padding: size(16)` em todos os lados; override `.mc-card` cinza removido. Vivo apenas no seletor da config de recurso — a fase avaliativa normal (outro partial) segue intocada. Defeito pré-existente do módulo (fora da rodada R01 — verificado por `git log`).

**Verificação:** diff revisado; SCSS balanceado; verificação visual no ambiente a seguir.